### PR TITLE
Feature/repeat pages

### DIFF
--- a/.circleci/circle_trigger.sh
+++ b/.circleci/circle_trigger.sh
@@ -58,7 +58,7 @@ PACKAGES=$(ls ${ROOT} -l | grep ^d | awk '{print $9}')
 echo "Searching for changes since commit [${LAST_COMPLETED_BUILD_SHA:0:7}] ..."
 
 ## The CircleCI API parameters object
-PARAMETERS='"trigger":false, "designer":true, "runner":true'
+PARAMETERS='"trigger":false, "designer":true, "runner":true, "engine":true'
 COUNT=2
 
 ## Get the list of workflows in current branch for which the CI is currently in failed state

--- a/engine/components/radiosfield.js
+++ b/engine/components/radiosfield.js
@@ -44,20 +44,20 @@ class RadiosField extends ConditionalFormComponent {
             condition: item.condition
           }
 
-        if (options.bold) {
-          itemModel.label = {
-            classes: 'govuk-label--s'
+          if (options.bold) {
+            itemModel.label = {
+              classes: 'govuk-label--s'
+            }
           }
-        }
 
-        if (item.description) {
-          itemModel.hint = {
-            html: this.localisedString(item.description)
+          if (item.description) {
+            itemModel.hint = {
+              html: this.localisedString(item.description)
+            }
           }
-        }
 
-        return super.addConditionalComponents(item, itemModel, formData, errors)
-      })
+          return super.addConditionalComponents(item, itemModel, formData, errors)
+        })
     })
 
     return viewModel

--- a/engine/package.json
+++ b/engine/package.json
@@ -11,7 +11,7 @@
     "build": "babel src -d lib --source-maps inline",
     "build:watch": "babel src -d lib --source-maps inline --watch",
     "test-lab": "lab -T node_modules/@xgovformbuilder/lab-babel -S -v -P 'test' test/cases -r console -o stdout -r html -o unit-test.html -I version",
-    "test": "npm run-script lint && npm run-script test-lab"
+    "test": "yarn lint && yarn test-lab"
   },
   "repository": {
     "type": "git",
@@ -42,13 +42,17 @@
     "@hapi/code": "^8.0.1",
     "@hapi/lab": "^22.0.4",
     "@xgovformbuilder/lab-babel": "2.0.0",
+    "babel-eslint": "11.0.0-beta.2",
+    "eslint-plugin-babel": "^5.3.1",
     "standard": "14.3.3"
   },
   "peerDependencies": {
     "joi": "^14"
   },
   "standard": {
-    "ignore": ["lib"],
+    "ignore": [
+      "lib"
+    ],
     "parser": "babel-eslint"
   }
 }

--- a/engine/package.json
+++ b/engine/package.json
@@ -43,7 +43,6 @@
     "@hapi/lab": "^22.0.4",
     "@xgovformbuilder/lab-babel": "2.0.0",
     "babel-eslint": "11.0.0-beta.2",
-    "eslint-plugin-babel": "^5.3.1",
     "standard": "14.3.3"
   },
   "peerDependencies": {

--- a/engine/src/index.js
+++ b/engine/src/index.js
@@ -2,6 +2,9 @@ const Boom = require('boom')
 const pkg = require('../package.json')
 const Model = require('./model')
 
+// 5mb
+const UPLOAD_LIMIT = 5 * 1024 * 1024
+
 function normalisePath (path) {
   return path
     .replace(/^\//, '')
@@ -65,7 +68,7 @@ module.exports = {
 
       server.route({
         method: 'get',
-        path: '/',
+        path: `/`,
         handler: (request, h) => {
           const keys = Object.keys(forms)
           let id = ''
@@ -82,7 +85,7 @@ module.exports = {
 
       server.route({
         method: 'get',
-        path: '/{id}',
+        path: `/{id}`,
         handler: (request, h) => {
           const { id } = request.params
           const model = forms[id]
@@ -95,7 +98,7 @@ module.exports = {
 
       server.route({
         method: 'get',
-        path: '/{id}/{path*}',
+        path: `/{id}/{path*}`,
         handler: (request, h) => {
           const { path, id } = request.params
           const model = forms[id]
@@ -132,7 +135,7 @@ module.exports = {
 
       server.route({
         method: 'post',
-        path: '/{id}/{path*}',
+        path: `/{id}/{path*}`,
         options: {
           plugins: {
             'hapi-rate-limit': {

--- a/engine/src/index.js
+++ b/engine/src/index.js
@@ -2,9 +2,6 @@ const Boom = require('boom')
 const pkg = require('../package.json')
 const Model = require('./model')
 
-// 5mb
-const UPLOAD_LIMIT = 5 * 1024 * 1024
-
 function normalisePath (path) {
   return path
     .replace(/^\//, '')
@@ -68,7 +65,7 @@ module.exports = {
 
       server.route({
         method: 'get',
-        path: `/`,
+        path: '/',
         handler: (request, h) => {
           const keys = Object.keys(forms)
           let id = ''
@@ -85,7 +82,7 @@ module.exports = {
 
       server.route({
         method: 'get',
-        path: `/{id}`,
+        path: '/{id}',
         handler: (request, h) => {
           const { id } = request.params
           const model = forms[id]
@@ -98,7 +95,7 @@ module.exports = {
 
       server.route({
         method: 'get',
-        path: `/{id}/{path*}`,
+        path: '/{id}/{path*}',
         handler: (request, h) => {
           const { path, id } = request.params
           const model = forms[id]
@@ -135,7 +132,7 @@ module.exports = {
 
       server.route({
         method: 'post',
-        path: `/{id}/{path*}`,
+        path: '/{id}/{path*}',
         options: {
           plugins: {
             'hapi-rate-limit': {

--- a/engine/src/lib.js
+++ b/engine/src/lib.js
@@ -1,9 +1,9 @@
 import findByPostcode from './address-service'
-import ComponentTypes from './component-types'
-import ConditionalComponentTypes from './conditional-component-types'
+import * as ComponentTypes from './component-types'
+import * as ConditionalComponentTypes from './conditional-component-types'
 import * as Helpers from './helpers'
 import Model from './model'
-import Page from './page'
+import Page  from './page'
 import Schema from './schema'
 import { plugin } from './index'
 

--- a/engine/src/lib.js
+++ b/engine/src/lib.js
@@ -3,7 +3,7 @@ import * as ComponentTypes from './component-types'
 import * as ConditionalComponentTypes from './conditional-component-types'
 import * as Helpers from './helpers'
 import Model from './model'
-import Page  from './page'
+import Page from './page'
 import Schema from './schema'
 import { plugin } from './index'
 

--- a/engine/src/model.js
+++ b/engine/src/model.js
@@ -8,6 +8,7 @@ class Model {
   constructor (def, options) {
     const result = schema.validate(def, { abortEarly: false })
 
+    //TODO:- throw/catch this properly 🤦🏻‍
     if (result.error) {
       throw result.error
     }
@@ -78,11 +79,15 @@ class Model {
 
       if (sectionPages.length > 0) {
         if (section) {
+          const isRepeatable = sectionPages.find(page => page.pageDef.repeatField)
+
           let sectionSchema = joi.object().required()
           sectionPages.forEach(sectionPage => {
             sectionSchema = sectionSchema.concat(sectionPage.stateSchema)
           })
-
+          if (isRepeatable) {
+            sectionSchema = joi.array().items(sectionSchema)
+          }
           schema = schema.append({
             [section.name]: sectionSchema
           })

--- a/engine/src/model.js
+++ b/engine/src/model.js
@@ -8,7 +8,7 @@ class Model {
   constructor (def, options) {
     const result = schema.validate(def, { abortEarly: false })
 
-    //TODO:- throw/catch this properly 🤦🏻‍
+    // TODO:- throw/catch this properly 🤦🏻‍
     if (result.error) {
       throw result.error
     }

--- a/engine/src/page.js
+++ b/engine/src/page.js
@@ -1,8 +1,8 @@
+import { merge, reach } from '@hapi/hoek'
+import * as querystring from 'querystring'
 const joi = require('joi')
 const { proceed } = require('./helpers')
 const { ComponentCollection } = require('../components')
-import { merge, reach } from '@hapi/hoek'
-import * as querystring from 'querystring'
 
 const FORM_SCHEMA = Symbol('FORM_SCHEMA')
 const STATE_SCHEMA = Symbol('STATE_SCHEMA')
@@ -97,9 +97,9 @@ class Page {
       const requiredCount = reach(state, this.repeatField)
       const otherRepeatPagesInSection = this.model.pages.filter(page => page.section === this.section && page.repeatField)
       const sectionState = state[this.section.name] || {}
-      if (Object.keys(sectionState[sectionState.length -1]).length === otherRepeatPagesInSection.length) { //iterated all pages at least once
+      if (Object.keys(sectionState[sectionState.length - 1]).length === otherRepeatPagesInSection.length) { // iterated all pages at least once
         const lastIteration = sectionState[sectionState.length - 1]
-        if (otherRepeatPagesInSection.length === this.#objLength(lastIteration)) { //this iteration is 'complete'
+        if (otherRepeatPagesInSection.length === this.#objLength(lastIteration)) { // this iteration is 'complete'
           if (sectionState.length < requiredCount) {
             return this.findPageByPath(Object.keys(lastIteration)[0])
           }
@@ -122,17 +122,17 @@ class Page {
 
   getNext (state) {
     const nextPage = this.getNextPage(state)
-    let query = { num: 0 }
+    const query = { num: 0 }
     let queryString = ''
-    if(nextPage.repeatField) {
+    if (nextPage.repeatField) {
       const requiredCount = reach(state, nextPage.repeatField)
       const otherRepeatPagesInSection = this.model.pages.filter(page => page.section === this.section && page.repeatField)
       const sectionState = state[nextPage.section.name]
-      const lastInSection = sectionState?.[sectionState.length -1] ?? {}
-      const isLastComplete =  Object.keys(lastInSection).length === otherRepeatPagesInSection.length
-      query.num = sectionState ? isLastComplete ? this.#objLength(sectionState) + 1 : this.#objLength(sectionState): 1
+      const lastInSection = sectionState?.[sectionState.length - 1] ?? {}
+      const isLastComplete = Object.keys(lastInSection).length === otherRepeatPagesInSection.length
+      query.num = sectionState ? isLastComplete ? this.#objLength(sectionState) + 1 : this.#objLength(sectionState) : 1
 
-      if(query.num <= requiredCount) {
+      if (query.num <= requiredCount) {
         queryString = `?${querystring.encode(query)}`
       }
     }
@@ -146,9 +146,9 @@ class Page {
   getFormDataFromState (state, atIndex) {
     const pageState = this.section ? state[this.section.name] : state
     if (this.repeatField) {
-      let repeatedPageState = pageState?.[atIndex ?? (pageState.length - 1 || 0)] ?? {}
-      let values = Object.values(repeatedPageState)
-      return this.components.getFormDataFromState(values.length ? values.reduce((acc, page) => ({...acc, ...page})) : {})
+      const repeatedPageState = pageState?.[atIndex ?? (pageState.length - 1 || 0)] ?? {}
+      const values = Object.values(repeatedPageState)
+      return this.components.getFormDataFromState(values.length ? values.reduce((acc, page) => ({ ...acc, ...page })) : {})
     }
 
     return this.components.getFormDataFromState(pageState || {})
@@ -199,226 +199,223 @@ class Page {
     }
     return request.yar.get('lang')
   }
-
-  #objLength (object) {
-    return Object.keys(object).length ?? 0
-  }
-
-  makeGetRouteHandler () {
-    return async (request, h) => {
-      const { cacheService } = request.services([])
-      const lang = this.langFromRequest(request)
-      const state = await cacheService.getState(request)
-      const progress = state.progress || []
-      const { num } = request.query
-      const currentPath = `/${this.model.basePath}${this.path}${num ? '?num=' + num : ''}`
-      const startPage = this.model.def.startPage
-      const formData =  this.getFormDataFromState(state, num - 1)
-
-      if (!this.model.options.previewMode && progress.length === 0 && this.path !== `${startPage}`) {
-        return startPage.startsWith('http') ? h.redirect(startPage) : h.redirect(`/${this.model.basePath}${startPage}`)
-      }
-
-      formData.lang = lang
-      const { originalFilenames } = state
-      if (originalFilenames) {
-        Object.entries(formData).forEach(([key, value]) => {
-          if (value && value === (originalFilenames[key] || {}).location) {
-            formData[key] = originalFilenames[key].originalFilename
-          }
-        })
-      }
-
-      const viewModel = this.getViewModel(formData, num)
-      viewModel.startPage = startPage.startsWith('http') ? h.redirect(startPage) : h.redirect(`/${this.model.basePath}${startPage}`)
-      viewModel.currentPath = `${currentPath}${request.query.returnUrl ? '?returnUrl=' + request.query.returnUrl : ''}`
-      viewModel.components = viewModel.components.filter(component => {
-        if ((component.model.content || component.type === 'Details') && component.model.condition) {
-          const condition = this.model.conditions[component.model.condition]
-          return condition.fn(state)
-        }
-        return true
-      })
-      viewModel.components = viewModel.components.map(component => {
-        const evaluatedComponent = component
-        const content = evaluatedComponent.model.content
-        if (content instanceof Array) {
-          evaluatedComponent.model.content = content.filter(item => item.condition ? this.model.conditions[item.condition].fn(state) : true)
-        }
-        // apply condition to items for radios, checkboxes etc
-        const items = evaluatedComponent.model.items
-        if (items instanceof Array) {
-          evaluatedComponent.model.items = items.filter(item => item.condition ? this.model.conditions[item.condition].fn(state) : true)
-        }
-        return evaluatedComponent
-      })
-
-      const lastVisited = progress[progress.length - 1]
-      if (!lastVisited || !lastVisited.startsWith(currentPath)) {
-        if (progress[progress.length - 2] === currentPath) {
-          progress.pop()
-        } else {
-          progress.push(currentPath)
-        }
-      }
-
-      await cacheService.mergeState(request, { progress })
-      viewModel.backLink = progress[progress.length - 2]
-      return h.view(this.viewName, viewModel)
+    #objLength (object) {  /* eslint-disable-line */
+      return Object.keys(object).length ?? 0
     }
-  }
 
-  makePostRouteHandler () {
-    return async (request, h) => {
-      const { cacheService } = request.services([])
-      const hasFilesizeError = request.payload === null
-      const preHandlerErrors = request.pre.errors
-      const payload = request.payload || {}
-      const formResult = this.validateForm(payload)
-      const state = await cacheService.getState(request)
-      const originalFilenames = (state || {}).originalFilenames || {}
-      const fileFields = this.getViewModel(formResult).components.filter(component => component.type === 'FileUploadField').map(component => component.model)
-      const progress = state.progress || []
-      const { num } = request.query
+    makeGetRouteHandler () {
+      return async (request, h) => {
+        const { cacheService } = request.services([])
+        const lang = this.langFromRequest(request)
+        const state = await cacheService.getState(request)
+        const progress = state.progress || []
+        const { num } = request.query
+        const currentPath = `/${this.model.basePath}${this.path}${num ? '?num=' + num : ''}`
+        const startPage = this.model.def.startPage
+        const formData = this.getFormDataFromState(state, num - 1)
 
-      // TODO:- Refactor this into a validation method
-      if (hasFilesizeError) {
-        const reformattedErrors = fileFields.map(field => {
-          return {
-            path: field.name, href: `#${field.name}`, name: field.name, text: 'The file you uploaded was too big'
+        if (!this.model.options.previewMode && progress.length === 0 && this.path !== `${startPage}`) {
+          return startPage.startsWith('http') ? h.redirect(startPage) : h.redirect(`/${this.model.basePath}${startPage}`)
+        }
+
+        formData.lang = lang
+        const { originalFilenames } = state
+        if (originalFilenames) {
+          Object.entries(formData).forEach(([key, value]) => {
+            if (value && value === (originalFilenames[key] || {}).location) {
+              formData[key] = originalFilenames[key].originalFilename
+            }
+          })
+        }
+
+        const viewModel = this.getViewModel(formData, num)
+        viewModel.startPage = startPage.startsWith('http') ? h.redirect(startPage) : h.redirect(`/${this.model.basePath}${startPage}`)
+        viewModel.currentPath = `${currentPath}${request.query.returnUrl ? '?returnUrl=' + request.query.returnUrl : ''}`
+        viewModel.components = viewModel.components.filter(component => {
+          if ((component.model.content || component.type === 'Details') && component.model.condition) {
+            const condition = this.model.conditions[component.model.condition]
+            return condition.fn(state)
           }
+          return true
+        })
+        viewModel.components = viewModel.components.map(component => {
+          const evaluatedComponent = component
+          const content = evaluatedComponent.model.content
+          if (content instanceof Array) {
+            evaluatedComponent.model.content = content.filter(item => item.condition ? this.model.conditions[item.condition].fn(state) : true)
+          }
+          // apply condition to items for radios, checkboxes etc
+          const items = evaluatedComponent.model.items
+          if (items instanceof Array) {
+            evaluatedComponent.model.items = items.filter(item => item.condition ? this.model.conditions[item.condition].fn(state) : true)
+          }
+          return evaluatedComponent
         })
 
-        formResult.errors = Object.is(formResult.errors, null) ? { titleText: 'Fix the following errors' } : formResult.errors
-        formResult.errors.errorList = reformattedErrors
-      }
+        const lastVisited = progress[progress.length - 1]
+        if (!lastVisited || !lastVisited.startsWith(currentPath)) {
+          if (progress[progress.length - 2] === currentPath) {
+            progress.pop()
+          } else {
+            progress.push(currentPath)
+          }
+        }
 
-      /**
-       * @code other file related errors.. assuming file fields will be on their own page. This will replace all other errors from the page if not..
-       */
-      if (preHandlerErrors) {
-        const reformattedErrors = []
-        preHandlerErrors.forEach(error => {
-          const reformatted = error
-          const fieldMeta = fileFields.find(field => field.id === error.name)
-          if (typeof reformatted.text === 'string') {
+        await cacheService.mergeState(request, { progress })
+        viewModel.backLink = progress[progress.length - 2]
+        return h.view(this.viewName, viewModel)
+      }
+    }
+
+    makePostRouteHandler () {
+      return async (request, h) => {
+        const { cacheService } = request.services([])
+        const hasFilesizeError = request.payload === null
+        const preHandlerErrors = request.pre.errors
+        const payload = request.payload || {}
+        const formResult = this.validateForm(payload)
+        const state = await cacheService.getState(request)
+        const originalFilenames = (state || {}).originalFilenames || {}
+        const fileFields = this.getViewModel(formResult).components.filter(component => component.type === 'FileUploadField').map(component => component.model)
+        const progress = state.progress || []
+        const { num } = request.query
+
+        // TODO:- Refactor this into a validation method
+        if (hasFilesizeError) {
+          const reformattedErrors = fileFields.map(field => {
+            return {
+              path: field.name, href: `#${field.name}`, name: field.name, text: 'The file you uploaded was too big'
+            }
+          })
+
+          formResult.errors = Object.is(formResult.errors, null) ? { titleText: 'Fix the following errors' } : formResult.errors
+          formResult.errors.errorList = reformattedErrors
+        }
+
+        /**
+         * @code other file related errors.. assuming file fields will be on their own page. This will replace all other errors from the page if not..
+         */
+        if (preHandlerErrors) {
+          const reformattedErrors = []
+          preHandlerErrors.forEach(error => {
+            const reformatted = error
+            const fieldMeta = fileFields.find(field => field.id === error.name)
+            if (typeof reformatted.text === 'string') {
             /**
              * @code if it's not a string it's probably going to be a stack trace.. don't want to show that to the user. A problem for another day.
              */
-            reformatted.text = reformatted.text.replace(/%s/, fieldMeta ? fieldMeta.label.text.trim() : 'the file')
-            reformattedErrors.push(reformatted)
+              reformatted.text = reformatted.text.replace(/%s/, fieldMeta ? fieldMeta.label.text.trim() : 'the file')
+              reformattedErrors.push(reformatted)
+            }
+          })
+
+          formResult.errors = Object.is(formResult.errors, null) ? { titleText: 'Fix the following errors' } : formResult.errors
+          formResult.errors.errorList = reformattedErrors
+        }
+
+        Object.entries(payload).forEach(([key, value]) => {
+          if (value && value === (originalFilenames[key] || {}).location) {
+            payload[key] = originalFilenames[key].originalFilename
           }
         })
 
-        formResult.errors = Object.is(formResult.errors, null) ? { titleText: 'Fix the following errors' } : formResult.errors
-        formResult.errors.errorList = reformattedErrors
-      }
-
-      Object.entries(payload).forEach(([key, value]) => {
-        if (value && value === (originalFilenames[key] || {}).location) {
-          payload[key] = originalFilenames[key].originalFilename
+        if (formResult.errors) {
+          const viewModel = this.getViewModel(payload, num, formResult.errors)
+          viewModel.backLink = progress[progress.length - 2]
+          return h.view(this.viewName, viewModel)
         }
-      })
 
-      if (formResult.errors) {
-        const viewModel = this.getViewModel(payload, num, formResult.errors)
-        viewModel.backLink = progress[progress.length - 2]
-        return h.view(this.viewName, viewModel)
-      }
+        const newState = this.getStateFromValidForm(formResult.value)
+        const stateResult = this.validateState(newState)
 
-      const newState = this.getStateFromValidForm(formResult.value)
-      const stateResult = this.validateState(newState)
-
-      if (stateResult.errors) {
-        const viewModel = this.getViewModel(payload, num, stateResult.errors)
-        viewModel.backLink = progress[progress.length - 2]
-        return h.view(this.viewName, viewModel)
-      }
-
-
-      let update = this.getPartialMergeState(stateResult.value)
-      if (this.repeatField) {
-        let updateValue = {[this.path]: update[this.section.name]}
-        let sectionState = state[this.section.name]
-        if (!sectionState) {
-          update = { [this.section.name]: [updateValue] }
-        } else if(!sectionState[num-1]) {
-          sectionState.push(updateValue)
-          update = { [this.section.name]: sectionState }
-
-        } else {
-          sectionState[num-1] = merge(sectionState[num-1] ?? {}, updateValue)
-          update = { [this.section.name]: sectionState }
+        if (stateResult.errors) {
+          const viewModel = this.getViewModel(payload, num, stateResult.errors)
+          viewModel.backLink = progress[progress.length - 2]
+          return h.view(this.viewName, viewModel)
         }
+
+        let update = this.getPartialMergeState(stateResult.value)
+        if (this.repeatField) {
+          const updateValue = { [this.path]: update[this.section.name] }
+          const sectionState = state[this.section.name]
+          if (!sectionState) {
+            update = { [this.section.name]: [updateValue] }
+          } else if (!sectionState[num - 1]) {
+            sectionState.push(updateValue)
+            update = { [this.section.name]: sectionState }
+          } else {
+            sectionState[num - 1] = merge(sectionState[num - 1] ?? {}, updateValue)
+            update = { [this.section.name]: sectionState }
+          }
+        }
+        const savedState = await cacheService.mergeState(request, update, !!this.repeatField)
+        return this.proceed(request, h, savedState)
       }
-      const savedState = await cacheService.mergeState(request, update, !!this.repeatField)
-      return this.proceed(request, h, savedState)
     }
-  }
 
-  makeGetRoute (getState) {
-    return {
-      method: 'get',
-      path: this.path,
-      options: this.getRouteOptions,
-      handler: this.makeGetRouteHandler(getState)
+    makeGetRoute (getState) {
+      return {
+        method: 'get',
+        path: this.path,
+        options: this.getRouteOptions,
+        handler: this.makeGetRouteHandler(getState)
+      }
     }
-  }
 
-  makePostRoute (mergeState) {
-    return {
-      method: 'post',
-      path: this.path,
-      options: this.postRouteOptions,
-      handler: this.makePostRouteHandler(mergeState)
+    makePostRoute (mergeState) {
+      return {
+        method: 'post',
+        path: this.path,
+        options: this.postRouteOptions,
+        handler: this.makePostRouteHandler(mergeState)
+      }
     }
-  }
 
-  findPageByPath (path) {
-    return this.model.pages.find(page => page.path === path)
-  }
-
-  proceed (request, h, state) {
-    return proceed(request, h, this.getNext(state))
-  }
-
-  getPartialMergeState (value) {
-    return this.section ? { [this.section.name]: value } : value
-  }
-
-  localisedString (description, lang) {
-    let string
-    if (typeof description === 'string') {
-      string = description
-    } else {
-      string = description[lang]
-        ? description[lang]
-        : description.en
+    findPageByPath (path) {
+      return this.model.pages.find(page => page.path === path)
     }
-    return string
-  }
 
-  get viewName () { return 'index' }
+    proceed (request, h, state) {
+      return proceed(request, h, this.getNext(state))
+    }
 
-  get defaultNextPath () { return `${this.model.basePath || ''}/summary` }
+    getPartialMergeState (value) {
+      return this.section ? { [this.section.name]: value } : value
+    }
 
-  get validationOptions () { return { abortEarly: false } }
+    localisedString (description, lang) {
+      let string
+      if (typeof description === 'string') {
+        string = description
+      } else {
+        string = description[lang]
+          ? description[lang]
+          : description.en
+      }
+      return string
+    }
 
-  get conditionOptions () { return this.model.conditionOptions }
+    get viewName () { return 'index' }
 
-  get errorSummaryTitle () { return 'Fix the following errors' }
+    get defaultNextPath () { return `${this.model.basePath || ''}/summary` }
 
-  get getRouteOptions () { return {} }
+    get validationOptions () { return { abortEarly: false } }
 
-  get postRouteOptions () { return {} }
+    get conditionOptions () { return this.model.conditionOptions }
 
-  get formSchema () { return this[FORM_SCHEMA] }
+    get errorSummaryTitle () { return 'Fix the following errors' }
 
-  set formSchema (value) { this[FORM_SCHEMA] = value }
+    get getRouteOptions () { return {} }
 
-  get stateSchema () { return this[STATE_SCHEMA] }
+    get postRouteOptions () { return {} }
 
-  set stateSchema (value) { this[STATE_SCHEMA] = value }
+    get formSchema () { return this[FORM_SCHEMA] }
+
+    set formSchema (value) { this[FORM_SCHEMA] = value }
+
+    get stateSchema () { return this[STATE_SCHEMA] }
+
+    set stateSchema (value) { this[STATE_SCHEMA] = value }
 }
 
 module.exports = Page

--- a/engine/yarn.lock
+++ b/engine/yarn.lock
@@ -167,6 +167,13 @@
   dependencies:
     "@babel/types" "^7.10.1"
 
+"@babel/helper-module-imports@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz#4c5c54be04bd31670a7382797d75b9fa2e5b5620"
+  integrity sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==
+  dependencies:
+    "@babel/types" "^7.10.4"
+
 "@babel/helper-module-transforms@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.10.1.tgz#24e2f08ee6832c60b157bb0936c86bef7210c622"
@@ -191,6 +198,11 @@
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz#ec5a5cf0eec925b66c60580328b122c01230a127"
   integrity sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==
+
+"@babel/helper-plugin-utils@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
+  integrity sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
 
 "@babel/helper-regex@^7.10.1":
   version "7.10.1"
@@ -239,6 +251,11 @@
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz#5770b0c1a826c4f53f5ede5e153163e0318e94b5"
   integrity sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==
+
+"@babel/helper-validator-identifier@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
+  integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
 
 "@babel/helper-wrap-function@^7.10.1":
   version "7.10.1"
@@ -655,6 +672,16 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
 
+"@babel/plugin-transform-runtime@^7.10.1":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.10.4.tgz#594fb53453ea1b6f0779cceb48ce0718a447feb7"
+  integrity sha512-8ULlGv8p+Vuxu+kz2Y1dk6MYS2b/Dki+NO6/0ZlfSj5tMalfDL7jI/o/2a+rrWLqSXvnadEqc2WguB4gdQIxZw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.10.4"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.1.tgz#e8b54f238a1ccbae482c4dce946180ae7b3143f3"
@@ -825,6 +852,15 @@
   integrity sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.1"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.4.tgz#369517188352e18219981efd156bfdb199fff1ee"
+  integrity sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
@@ -1153,6 +1189,15 @@ babel-eslint@10.x.x:
     "@babel/types" "^7.7.0"
     eslint-visitor-keys "^1.0.0"
     resolve "^1.12.0"
+
+babel-eslint@11.0.0-beta.2:
+  version "11.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-11.0.0-beta.2.tgz#de1f06795aa0d8cedcf6ac943e63056f5b4a7048"
+  integrity sha512-D2tunrOu04XloEdU2XVUminUu25FILlGruZmffqH5OSnLDhCheKNvUoM1ihrexdUvhizlix8bjqRnsss4V/UIQ==
+  dependencies:
+    eslint-scope "5.0.0"
+    eslint-visitor-keys "^1.1.0"
+    semver "^6.3.0"
 
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
@@ -1704,6 +1749,14 @@ eslint-plugin-standard@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz#ff0519f7ffaff114f76d1bd7c3996eef0f6e20b4"
   integrity sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==
+
+eslint-scope@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
+  integrity sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
 
 eslint-scope@^5.0.0:
   version "5.1.0"
@@ -3239,7 +3292,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.3.2:
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.3.2, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -3310,7 +3363,7 @@ seedrandom@3.x.x:
   resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-3.0.5.tgz#54edc85c95222525b0c7a6f6b3543d8e0b3aa0a7"
   integrity sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -3320,7 +3373,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^6.1.0, semver@^6.1.2:
+semver@^6.1.0, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==

--- a/runner/package.json
+++ b/runner/package.json
@@ -1,22 +1,22 @@
 {
   "name": "digital-form-builder",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Digital forms runner",
   "main": "src/index.js",
   "scripts": {
     "start": "NODE_ENV=development node dist/index.js",
     "dev": "yarn babel-build:dev & NODE_ENV=development node dist/index.js",
     "build:css": "bin/build-css",
-    "build": "npm run build:css && npm run babel-build",
+    "build": "yarn build:css && yarn babel-build",
     "lint": "standard",
     "unit-test": "lab -T node_modules/@xgovformbuilder/lab-babel -v -P 'test' test/cases -r console -o stdout -r html -o unit-test.html -I version -l",
     "unit-test:dev": "lab -v -P 'test' --inspect-brk",
-    "test": "NODE_ENV=test npm run lint && npm run unit-test",
-    "postinstall": "npm run build",
+    "test": "NODE_ENV=test yarn run lint && yarn run unit-test",
+    "postinstall": "yarn build",
     "a11y": "node test/audit/components && node lighthouse",
     "symlink-env": "./bin/symlink-config",
-    "babel-build": "babel src -d dist --copy-files --minified",
-    "babel-build:dev": "babel src -d dist --copy-files --watch"
+    "babel-build": "babel src -d dist --copy-files --minified -s inline",
+    "babel-build:dev": "babel src -d dist --copy-files --watch -s inline"
   },
   "repository": {
     "type": "git",

--- a/runner/src/server/lib/cacheService.js
+++ b/runner/src/server/lib/cacheService.js
@@ -6,25 +6,18 @@ const Redis = require('ioredis')
 
 const partition = 'cache'
 
-const Key = (id) => {
-  return {
-    segment: partition,
-    id
-  }
-}
-
 class CacheService {
   constructor (server, options) {
     this.cache = server.cache({ segment: 'cache' })
   }
 
   async getState (request) {
-    const cached = await this.cache.get(Key(request.yar.id))
+    const cached = await this.cache.get(this.Key(request.yar.id))
     return cached || {}
   }
 
   async mergeState (request, value, nullOverride = true, arrayMerge = false) {
-    const key = Key(request.yar.id)
+    const key = this.Key(request.yar.id)
     const state = await this.getState(request)
     hoek.merge(state, value, nullOverride, arrayMerge)
     await this.cache.set(key, state, sessionTimeout)
@@ -33,7 +26,14 @@ class CacheService {
 
   async clearState (request) {
     if (request.yar && request.yar.id) {
-      this.cache.drop(Key(request.yar.id))
+      this.cache.drop(this.Key(request.yar.id))
+    }
+  }
+
+  Key (id) {
+    return {
+      segment: partition,
+      id
     }
   }
 }

--- a/runner/src/server/lib/documentUpload.js
+++ b/runner/src/server/lib/documentUpload.js
@@ -140,6 +140,10 @@ class UploadService {
           if (e.data && e.data.res) {
             const { error } = this.parsedDocumentUploadResponse(e.data.res)
             request.pre.errors = [...h.request.pre.errors || [], parsedError(key, error)]
+          } else if (e.code === 'EPIPE') {
+            // ignore this error, it happens when the request is responded to by the doc upload service before the
+            // body has finished being sent. A valid response is still received.
+            request.server.log(['info', 'documentupload'], `Ignoring EPIPE response: ${e.message}`)
           } else {
             request.server.log(['error', 'documentupload'], `Error uploading document: ${e.message}`)
             request.pre.errors = [...h.request.pre.errors || [], parsedError(key, e)]

--- a/runner/src/server/plugins/builder/pages/summary.js
+++ b/runner/src/server/plugins/builder/pages/summary.js
@@ -375,6 +375,7 @@ class SummaryViewModel {
       url: `/${model.basePath}${page.path}?${queryString || querystring.encode(query)}`,
       pageId: `/${model.basePath}${page.path}`,
       type: component.type,
+      title: component.title,
       dataType: component.dataType
     }
   }

--- a/runner/src/server/plugins/views.js
+++ b/runner/src/server/plugins/views.js
@@ -23,10 +23,12 @@ module.exports = {
           }
         },
         prepare: (options, next) => {
-          options.compileOptions.environment = nunjucks.configure(options.path, {
+          const environment = nunjucks.configure(options.path, {
             autoescape: true,
             watch: false
           })
+          environment.addFilter('isArray', x => Array.isArray(x))
+          options.compileOptions.environment = environment
 
           return next()
         }

--- a/runner/test/cases/dynamic.json
+++ b/runner/test/cases/dynamic.json
@@ -1,0 +1,221 @@
+{
+  "conditions": [
+    {
+      "name": "hasUKPassport",
+      "value": "checkBeforeYouStart.ukPassport==true"
+    },
+    {
+      "name": "doesntHaveUKPassport",
+      "value": "checkBeforeYouStart.ukPassport==false"
+    }
+  ],
+  "startPage": "/uk-passport",
+  "pages": [
+    {
+      "path": "/uk-passport",
+      "components": [
+        {
+          "type": "YesNoField",
+          "name": "ukPassport",
+          "title": "Do you have a UK passport?"
+        }
+      ],
+      "section": "checkBeforeYouStart",
+      "next": [
+        {
+          "path": "/how-many-people"
+        },
+        {
+          "path": "/no-uk-passport",
+          "condition": "doesntHaveUKPassport"
+        }
+      ],
+      "title": "Do you have a UK passport?"
+    },
+    {
+      "path": "/no-uk-passport",
+      "title": "You're not eligible for this service",
+      "components": [
+        {
+          "type": "Para",
+          "content": "If you still think you're eligible please contact the Foreign and Commonwealth Office."
+        }
+      ],
+      "next": []
+    },
+    {
+      "path": "/how-many-people",
+      "section": "applicantDetails",
+      "components": [
+        {
+          "options": {
+            "list": "numberOfApplicants",
+            "classes": "govuk-input--width-10"
+          },
+          "type": "SelectField",
+          "name": "numberOfApplicants",
+          "title": "How many applicants are there?"
+        }
+      ],
+      "next": [
+        {
+          "path": "/applicant-repeatable"
+        }
+      ],
+      "title": "How many applicants are there?"
+    },
+    {
+      "path": "/applicant-repeatable",
+      "title": "Applicant",
+      "section": "applicant",
+      "repeatField": "applicantDetails.numberOfApplicants",
+      "components": [
+        {
+          "type": "Para",
+          "content": "Provide the details as they appear on your passport."
+        },
+        {
+          "type": "TextField",
+          "name": "firstName",
+          "title": "First name"
+        },
+        {
+          "options": {
+            "required": false,
+            "optionalText": false
+          },
+          "type": "TextField",
+          "name": "middleName",
+          "title": "Middle name",
+          "hint": "If you have a middle name on your passport you must include it here"
+        },
+        {
+          "type": "TextField",
+          "name": "lastName",
+          "title": "Surname"
+        }
+      ],
+      "next": [
+        {
+          "path": "/contact-details"
+        }
+      ]
+    },
+    {
+      "path": "/contact-details",
+      "section": "applicant",
+      "repeatField": "applicantDetails.numberOfApplicants",
+      "components": [
+        {
+          "type": "TelephoneNumberField",
+          "name": "phoneNumber",
+          "title": "Phone number",
+          "hint": "If you haven't got a UK phone number, include country code"
+        },
+        {
+          "type": "EmailAddressField",
+          "name": "emailAddress",
+          "title": "Your email address"
+        }
+      ],
+      "next": [
+        {
+          "path": "/summary"
+        }
+      ],
+      "title": "Applicant contact details"
+    },
+    {
+      "path": "/summary",
+      "controller": "./pages/summary.js",
+      "title": "Summary",
+      "components": [],
+      "next": []
+    }
+  ],
+  "sections": [
+    {
+      "name": "checkBeforeYouStart",
+      "title": "Check before you start"
+    },
+    {
+      "name": "applicantDetails",
+      "title": "How many"
+    },
+    {
+      "name": "applicant",
+      "title": "Applicant"
+    }
+  ],
+  "lists": [
+    {
+      "name": "numberOfApplicants",
+      "title": "Number of people",
+      "type": "number",
+      "items": [
+        {
+          "text": "1",
+          "value": "1",
+          "description": "",
+          "condition": ""
+        },
+        {
+          "text": "2",
+          "value": "2",
+          "description": "",
+          "condition": ""
+        },
+        {
+          "text": "3",
+          "value": "3",
+          "description": "",
+          "condition": ""
+        },
+        {
+          "text": "4",
+          "value": "4",
+          "description": "",
+          "condition": ""
+        }
+      ]
+    }
+  ],
+  "fees": [
+    {
+      "description": "Application fee",
+      "amount": 5000,
+      "condition": "hasUKPassport",
+      "multiplier": "applicantDetails.numberOfApplicants"
+    },
+    {
+      "description": "Postage",
+      "amount": 1000,
+      "condition": "hasUKPassport"
+    }
+  ],
+  "payApiKey": "<GOV.UK Pay API key>",
+  "outputs": [
+    {
+      "name": "formsapi",
+      "type": "webhook",
+      "outputConfiguration": {
+        "url": "http://forms-api:9000/v1/forms"
+      }
+    },
+    {
+      "name": "confirmationemail",
+      "type": "notify",
+      "outputConfiguration": {
+        "templateId": "<GOV.UK Notify template ID>",
+        "personalisation": [
+          "applicantOneDetails.firstName",
+          "applicantOneDetails.lastName"
+        ],
+        "emailField": "applicantDetails.emailAddress",
+        "apiKey": "<GOV.UK Notify API key>"
+      }
+    }
+  ],
+  "skipSummary": false,
+  "declaration": "<p class=\"govuk-body\">All the answers you have provided are true to the best of your knowledge.</p>"
+}

--- a/runner/test/cases/dynamic.test.js
+++ b/runner/test/cases/dynamic.test.js
@@ -1,0 +1,183 @@
+import { CacheService } from '../../src/server/lib/cacheService'
+const Lab = require('@hapi/lab')
+const { expect } = require('@hapi/code')
+const cheerio = require('cheerio')
+const FormData = require('form-data')
+const createServer = require('../../src/server/index')
+const { before, afterEach, test, suite, after } = exports.lab = Lab.script()
+const { stub, restore } = require('sinon')
+
+const state = {
+  progress: [
+    '/test/start',
+    '/dynamic/uk-passport',
+    '/dynamic/how-many-people',
+    '/dynamic/applicant-repeatable?num=1',
+    '/dynamic/contact-details?num=1',
+    '/dynamic/applicant-repeatable?num=2',
+    '/dynamic/contact-details?num=2'
+  ],
+  checkBeforeYouStart: {
+    ukPassport: true
+  },
+  applicantDetails: {
+    numberOfApplicants: 2
+  },
+  applicant: [
+    {
+      '/applicant-repeatable': {
+        firstName: 'a',
+        middleName: 'b',
+        lastName: 'c'
+      },
+      '/contact-details': {
+        phoneNumber: '123',
+        emailAddress: 'test@one'
+      }
+    },
+    {
+      '/applicant-repeatable': {
+        firstName: 'c',
+        middleName: 'd',
+        lastName: 'e'
+      },
+      '/contact-details': {
+        phoneNumber: '456',
+        emailAddress: 'test@two'
+      }
+    }
+  ]
+}
+
+const postOptions = (path, form) => {
+  const formData = new FormData()
+
+  Object.entries(form).forEach(([key, value]) => {
+    formData.append(key, value)
+  })
+
+  return {
+    method: 'POST',
+    url: path,
+    headers: formData.getHeaders(),
+    payload: formData.getBuffer()
+  }
+}
+
+const FORMS = {
+  passport: { ukPassport: 'true' },
+  howManyPeople: { numberOfApplicants: 2 },
+  name: {
+    firstName: 'a',
+    middleName: 'b',
+    lastName: 'c'
+  },
+  contact: {
+    phoneNumber: '123',
+    emailAddress: 'test@test'
+  }
+}
+
+suite('Dynamic pages', () => {
+  let server
+
+  // Create server before each test
+  before(async () => {
+    server = await createServer({ data: 'dynamic.json', customPath: __dirname })
+    await server.start()
+  })
+
+  after(async () => {
+    server.stop()
+  })
+
+  afterEach(async () => {
+    restore()
+    const { cacheService } = server.services()
+    await cacheService.clearState({ yar: { id: 'TEST_ID' } })
+    stub(CacheService.prototype, 'Key').callsFake(() => ({
+      segment: 'segment',
+      id: 'TEST_ID'
+    }))
+  })
+
+  test('Start of repeatable section appends num parameter', async () => {
+    const response = await server.inject(postOptions('/dynamic/how-many-people', { numberOfApplicants: 2 }))
+    expect(response.headers.location).to.equal('/dynamic/applicant-repeatable?num=1')
+  })
+
+  test('Asks questions in section correct number of times', async () => {
+    let nextPath = '/dynamic/uk-passport'
+    let response
+
+    const reassignNextPath = () => { nextPath = response.headers.location }
+
+    response = await server.inject(postOptions(nextPath, FORMS.passport))
+    reassignNextPath()
+    response = await server.inject(postOptions(nextPath, FORMS.howManyPeople))
+    reassignNextPath()
+    response = await server.inject(postOptions(nextPath, FORMS.name))
+    reassignNextPath()
+
+    response = await server.inject(postOptions(nextPath, FORMS.contact))
+    expect(response.headers.location).to.equal('/dynamic/applicant-repeatable?num=2')
+    reassignNextPath()
+
+    response = await server.inject(postOptions(nextPath, FORMS.name))
+    reassignNextPath()
+
+    response = await server.inject(postOptions(nextPath, FORMS.contact))
+    expect(response.headers.location).to.equal('/dynamic/summary')
+
+    reassignNextPath()
+  })
+
+  test('Change url redirects to question page with correct answers', async () => {
+    stub(CacheService.prototype, 'getState').callsFake(() => {
+      return state
+    })
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/dynamic/summary'
+    })
+    expect(response.statusCode).to.equal(200)
+    expect(response.headers['content-type']).to.include('text/html')
+
+    let $ = cheerio.load(response.payload)
+
+    const changeEmailLink = $('span:contains("Your email address")')[0].parent.attribs.href
+    const changeEmailPage = await server.inject({
+      method: 'GET',
+      url: changeEmailLink
+    })
+    $ = cheerio.load(changeEmailPage.payload)
+    expect($('#emailAddress')[0].attribs.value).to.equal(state.applicant[0]['/contact-details'].emailAddress)
+  })
+
+  test('Summary page displays correct number of repeatable sections', async () => {
+    const { cacheService } = server.services()
+    await cacheService.mergeState({ yar: { id: 'TEST_ID' } }, state)
+    const response = await server.inject({
+      method: 'GET',
+      url: '/dynamic/summary'
+    })
+    expect(response.statusCode).to.equal(200)
+    expect(response.headers['content-type']).to.include('text/html')
+
+    let $ = cheerio.load(response.payload)
+    const applicantHeadings = $('h2:contains("Applicant")')
+    expect(applicantHeadings).to.be.length(2)
+
+    await server.inject(postOptions('/dynamic/how-many-people', { numberOfApplicants: 1 }))
+
+    const responseAfterNumberChange = await server.inject({
+      method: 'GET',
+      url: '/dynamic/summary'
+    })
+
+    $ = cheerio.load(responseAfterNumberChange.payload)
+
+    expect($('h2:contains("Applicant")')).to.be.length(1)
+  })
+})

--- a/runner/views/partials/summary-detail.html
+++ b/runner/views/partials/summary-detail.html
@@ -1,29 +1,21 @@
+{% from "./summary-row.html" import summaryRow %}
+
 {% macro summaryDetail(data) %}
-  <h2 class="govuk-heading-m">{{data.title}}</h2>
+    {%  set isRepeatableSection = (data.items[0] | isArray) %}
+    {% if not isRepeatableSection %}
+        <h2 class="govuk-heading-m">{{data.title}}</h2>
+    {% endif %}
   <dl class="govuk-summary-list">
     {% for item in data.items %}
-      {% if not hide %}
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            {{item.label}}
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {% if item.value %}
-              {% if item.type == 'FileUploadField' %}
-                Uploaded
-              {% else %}
-                {{item.value}}
-              {% endif %}
-            {% else %}
-              Not supplied
-            {% endif %}
-          </dd>
-          <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="{{item.url}}">
-              Change<span class="govuk-visually-hidden"> {{item.label}}</span>
-            </a>
-          </dd>
-        </div>
+        {% if not hide %}
+        {%- if item | isArray %}
+            <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-0">{{data.title}} {{ loop.index }}</h2>
+            {% for repeated in item %}
+                {{ summaryRow(repeated) }}
+            {% endfor %}
+        {% else %}
+          {{ summaryRow(item) }}
+        {% endif %}
       {% endif %}
     {% endfor %}
   </dl>

--- a/runner/views/partials/summary-row.html
+++ b/runner/views/partials/summary-row.html
@@ -1,0 +1,23 @@
+{% macro summaryRow(item) %}
+<div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+        {{item.label}}
+    </dt>
+    <dd class="govuk-summary-list__value">
+        {% if item.value %}
+            {% if item.type == 'FileUploadField' %}
+                Uploaded
+            {% else %}
+                {{item.value}}
+            {% endif %}
+        {% else %}
+            Not supplied
+        {% endif %}
+    </dd>
+    <dd class="govuk-summary-list__actions">
+        <a class="govuk-link" href="{{item.url}}">
+            Change<span class="govuk-visually-hidden"> {{item.label}}</span>
+        </a>
+    </dd>
+</div>
+{% endmacro %}

--- a/runner/views/summary.html
+++ b/runner/views/summary.html
@@ -9,7 +9,6 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
-
         {% for detail in details %}
           {{ summaryDetail(detail) }}
         {% endfor %}


### PR DESCRIPTION
# Description

Repeatable pages support! This is currently a developer only feature (so no support in designer for it right now.)

- Repeatable pages can be flagged with "repeatableField" property which the field storing '_n_'. 
- These values are stored as an array of objects inside section. The objects key the values by page path `sectionName: [{/page-1: {...}, /page-2: {...}}]` to keep track of which pages have been "completed". Each array item is 1 "iteration" of the repeatable section.
- Support for summary
  - summary-detail has been split out into summary-row
  - Added isArray filter to detect if the section...is an array (repeated) 
- [x] waiting on a patch from @superafroman also 
- change circleci to trigger engine build + test


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)



# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Use dynamic.json inside `runner/test/cases` if you would like to "play" a repeatable form. 

- [x] Unit tested


# Checklist:

- [x] My code follows the [javascript standard style](https://standardjs.com/)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto master and there are no code conflicts




