### PR TITLE
Display placeholder message when users cannot define a condition

### DIFF
--- a/designer/client/conditions-edit.js
+++ b/designer/client/conditions-edit.js
@@ -50,7 +50,12 @@ class ConditionsEdit extends React.Component {
                 ))}
                 <li>
                   <hr />
-                  <a href='#' onClick={e => this.onClickAddCondition(e)}>Add condition</a>
+                  { data.allInputs().length > 0
+                    ? <a href='#' onClick={e => this.onClickAddCondition(e)}>Add condition</a>
+                    : <div className='govuk-body'>
+                      You cannot add any conditions as there are no available fields
+                    </div>
+                  }
                 </li>
               </ul>
             )}

--- a/designer/client/conditions/inline-conditions.js
+++ b/designer/client/conditions/inline-conditions.js
@@ -128,24 +128,27 @@ class InlineConditions extends React.Component {
                   {conditions.toPresentationString()}
                 </div>
                 {!editView &&
-                  <div>
-                    <a href='#' id='edit-conditions-link' className='govuk-link' onClick={this.toggleEdit}>
-                      Not what you meant?
-                    </a>
-                  </div>
+                <div>
+                  <a href='#' id='edit-conditions-link' className='govuk-link' onClick={this.toggleEdit}>
+                    Not what you meant?
+                  </a>
+                </div>
                 }
               </div>
             }
           </div>
-          { !editView && definingCondition &&
+          {!editView && definingCondition &&
             <div>
-              <InlineConditionsDefinition expectsCoordinator={hasConditions} fields={this.state.fields} saveCallback={this.saveCondition} />
+              <InlineConditionsDefinition expectsCoordinator={hasConditions} fields={this.state.fields}
+                saveCallback={this.saveCondition} />
               <div className='govuk-form-group'>
-                <a href='#' id='cancel-inline-conditions-link' className='govuk-link' onClick={this.onClickCancel}>Cancel</a>
+                <a href='#' id='cancel-inline-conditions-link' className='govuk-link'
+                  onClick={this.onClickCancel}>Cancel</a>
               </div>
             </div>
           }
-          {editView && <InlineConditionsEdit conditions={conditions} fields={this.state.fields} saveCallback={this.editCallback} exitCallback={this.toggleEdit} />}
+          {editView && <InlineConditionsEdit conditions={conditions} fields={this.state.fields}
+            saveCallback={this.editCallback} exitCallback={this.toggleEdit} />}
         </div>
     )
   }

--- a/designer/client/conditions/select-conditions.js
+++ b/designer/client/conditions/select-conditions.js
@@ -71,35 +71,45 @@ class SelectConditions extends React.Component {
     const { selectedCondition, inline } = this.state
 
     return (
-      this.state.fields && Object.keys(this.state.fields).length > 0 &&
-        <div className='conditions'>
-          <div className='govuk-form-group' id='conditions-header-group'>
-            <label className='govuk-label govuk-label--s' htmlFor='page-conditions'>Conditions (optional)</label>
-          </div>
-          {!inline &&
-            <div id='select-condition'>
-              <div className='govuk-form-group' id='cond-selection-group'>
-                <label className='govuk-label' htmlFor='cond-select'>
-                  Select a condition
-                </label>
-                <select className='govuk-select' id='cond-select' name='cond-select' value={selectedCondition??''}
-                  onChange={this.onChangeConditionSelection}>
-                  <option />
-                  {
-                    this.props.data.conditions.map((it, index) =>
-                      <option key={`select-condition-${index}`} value={it.name}>{it.displayName}</option>)
-                  }
-                </select>
-              </div>
-              <div className='govuk-form-group'>
-                <a href='#' id='inline-conditions-link' className='govuk-link' onClick={this.onClickDefineCondition}>Define a new condition</a>
-              </div>
-            </div>
-          }
-          {inline &&
-            <InlineConditions data={this.props.data} path={this.props.path} conditionsChange={this.props.conditionsChange} cancelCallback={this.onCancelInlineCondition} hideAddLink={this.props.data.hasConditions} />
-          }
+      <div className='conditions'>
+        <div className='govuk-form-group' id='conditions-header-group'>
+          <label className='govuk-label govuk-label--s' htmlFor='page-conditions'>Conditions (optional)</label>
         </div>
+        {this.state.fields && Object.keys(this.state.fields).length > 0
+          ? <div>
+            {!inline
+              ? <div id='select-condition'>
+                <div className='govuk-form-group' id='cond-selection-group'>
+                  <label className='govuk-label' htmlFor='cond-select'>
+                          Select a condition
+                  </label>
+                  <select className='govuk-select' id='cond-select' name='cond-select'
+                    value={selectedCondition ?? ''}
+                    onChange={this.onChangeConditionSelection}>
+                    <option />
+                    {
+                      this.props.data.conditions.map((it, index) =>
+                        <option key={`select-condition-${index}`} value={it.name}>{it.displayName}</option>)
+                    }
+                  </select>
+                </div>
+                <div className='govuk-form-group'>
+                  <a href='#' id='inline-conditions-link' className='govuk-link'
+                    onClick={this.onClickDefineCondition}>Define
+                          a new condition</a>
+                </div>
+              </div>
+              : <InlineConditions data={this.props.data} path={this.props.path}
+                conditionsChange={this.props.conditionsChange}
+                cancelCallback={this.onCancelInlineCondition}
+                hideAddLink={this.props.data.hasConditions} />
+            }
+          </div>
+          : <div className='govuk-body'>
+                You cannot add any conditions as there are no available fields
+          </div>
+        }
+      </div>
     )
   }
 }

--- a/designer/test/select-conditions.test.js
+++ b/designer/test/select-conditions.test.js
@@ -11,6 +11,13 @@ const lab = Lab.script()
 exports.lab = lab
 const { before, beforeEach, describe, suite, test } = lab
 
+function assertNoFieldsText (wrapper) {
+  expect(wrapper.exists('.conditions')).to.equal(true)
+  expect(wrapper.find('.conditions').find('.govuk-body').text().trim()).to.equal('You cannot add any conditions as there are no available fields')
+  expect(wrapper.exists('InlineConditions')).to.equal(false)
+  expect(wrapper.exists('#select-condition')).to.equal(false)
+}
+
 suite('Select conditions', () => {
   const data = {
     inputsAccessibleAt: sinon.stub(),
@@ -36,10 +43,10 @@ suite('Select conditions', () => {
       data.conditions = conditions
     })
 
-    test('render returns nothing when there is an empty fields list', () => {
+    test('render returns placeholder message when there is an empty fields list', () => {
       data.inputsAccessibleAt.withArgs(path).returns([])
       data.listFor.returns(undefined)
-      expect(shallow(<SelectConditions data={data} path={path} conditionsChange={conditionsChange} />).exists('.conditions')).to.equal(false)
+      assertNoFieldsText(shallow(<SelectConditions data={data} path={path} conditionsChange={conditionsChange} />))
       expect(conditionsChange.called).to.equal(false)
     })
 
@@ -117,11 +124,10 @@ suite('Select conditions', () => {
       data.conditions = []
     })
 
-    test('render returns nothing when there is an empty fields list', () => {
+    test('render returns placeholder message is an empty fields list', () => {
       data.inputsAccessibleAt.withArgs(path).returns([])
       data.listFor.returns(undefined)
-      expect(shallow(<SelectConditions data={data} path={path}
-        conditionsChange={conditionsChange} />).exists('.conditions')).to.equal(false)
+      assertNoFieldsText(shallow(<SelectConditions data={data} path={path} conditionsChange={conditionsChange} />))
       expect(conditionsChange.called).to.equal(false)
     })
 
@@ -160,14 +166,14 @@ suite('Select conditions', () => {
         assertInlineConditionsComponent(wrapper, data, path, conditionsChange, false)
       })
 
-      test('if the path property changes to a route without fields then the condition section disappears', () => {
+      test('if the path property changes to a route without fields then the condition section is replaced by no fields text', () => {
         let path2 = '/2'
         data.inputsAccessibleAt.withArgs(path2).returns([])
         data.listFor.returns(undefined)
         const wrapper = shallow(<SelectConditions data={data} path={path} conditionsChange={conditionsChange} />)
-        expect(wrapper.exists('.conditions')).to.equal(true)
+        expect(wrapper.find('InlineConditions').exists()).to.equal(true)
         wrapper.setProps({ path: path2 })
-        expect(wrapper.exists('.conditions')).to.equal(false)
+        assertNoFieldsText(wrapper)
       })
 
       test('if the path property changes from a route with fields then the condition section appears', () => {
@@ -175,9 +181,9 @@ suite('Select conditions', () => {
         data.inputsAccessibleAt.withArgs(path2).returns([])
         data.listFor.returns(undefined)
         const wrapper = shallow(<SelectConditions data={data} path={path2} conditionsChange={conditionsChange} />)
-        expect(wrapper.exists('.conditions')).to.equal(false)
+        expect(wrapper.exists('InlineConditions')).to.equal(false)
         wrapper.setProps({ path: path })
-        expect(wrapper.exists('.conditions')).to.equal(true)
+        expect(wrapper.exists('InlineConditions')).to.equal(true)
       })
     })
   })


### PR DESCRIPTION
# Description
Display placeholder message when users cannot define a condition

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Unit tests
- [X] Click testing

# Checklist:

- [X] My code follows the [javascript standard style](https://standardjs.com/)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts




