### PR TITLE
Fixing page path issues

### DIFF
--- a/designer/client/helpers.js
+++ b/designer/client/helpers.js
@@ -52,6 +52,10 @@ export function getFormData (form) {
   return data
 }
 
+export function toUrl (title) {
+  return '/'.concat(title.replace(/[^a-zA-Z ]/g, '').trim().replace(/ +/g, '-')).toLowerCase()
+}
+
 export function clone (obj) {
   if (obj) {
     if (typeof obj.clone === 'function') {

--- a/designer/client/page-create.js
+++ b/designer/client/page-create.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import SelectConditions from './conditions/select-conditions'
 import InlineConditionHelpers from './conditions/inline-condition-helpers'
+import { toUrl } from './helpers'
 
 class PageCreate extends React.Component {
   state = {}
@@ -47,10 +48,7 @@ class PageCreate extends React.Component {
   }
 
   generatePath (title, data) {
-    let path = '/' + title
-      .replace(/[^a-zA-Z ]/g, '')
-      .replace(/\s/g, '-')
-      .toLowerCase()
+    let path = toUrl(title)
 
     let count = 1
     while (data.findPage(path)) {

--- a/designer/client/page-edit.js
+++ b/designer/client/page-edit.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { clone } from './helpers'
+import { clone, toUrl } from './helpers'
 
 class PageEdit extends React.Component {
   state = {}
@@ -9,7 +9,7 @@ class PageEdit extends React.Component {
     const form = e.target
     const formData = new window.FormData(form)
     const title = formData.get('title').trim()
-    const newPath = '/'.concat(title.replace(/[^a-zA-Z ]/g, '').replace(' ', '-')).toLowerCase()
+    const newPath = toUrl(title)
     const section = formData.get('section').trim()
     const pageType = formData.get('page-type').trim()
     const { data, page } = this.props

--- a/designer/test/page-create.test.js
+++ b/designer/test/page-create.test.js
@@ -293,5 +293,39 @@ suite('Page create', () => {
       expect(clonedData.addPage.calledOnce).to.equal(true)
       expect(clonedData.addPage.firstCall.args[0]).to.equal(expectedPage)
     })
+
+    test('translated title to path automatically if no path provided', async flags => {
+      const expectedPage = {
+        path: '/my-new-page',
+        title: 'My New    Page 23?!¢#',
+        controller: './pages/start.js',
+        next: [],
+        components: []
+      }
+      const onCreate = data => {
+        expect(data.value).to.equal(expectedPage)
+      }
+      const clonedData = {
+        addPage: sinon.stub(),
+        addLink: sinon.stub()
+      }
+      data.save = sinon.stub()
+      data.save.resolves(clonedData)
+      const wrappedOnCreate = flags.mustCall(onCreate, 1)
+
+      const wrapper = shallow(<PageCreate data={data} onCreate={wrappedOnCreate} />)
+      const preventDefault = sinon.spy()
+      wrapper.find('#page-type').simulate('change', { target: { value: './pages/start.js' } })
+      wrapper.find('#page-title').simulate('blur', { target: { value: 'My New    Page 23?!¢#' } })
+
+      data.clone = sinon.stub()
+      data.clone.returns(clonedData)
+      clonedData.addLink.returns(clonedData)
+      clonedData.addPage.returns(clonedData)
+
+      await wrapper.instance().onSubmit({ preventDefault: preventDefault })
+      expect(clonedData.addPage.calledOnce).to.equal(true)
+      expect(clonedData.addPage.firstCall.args[0]).to.equal(expectedPage)
+    })
   })
 })


### PR DESCRIPTION
# Description

Fixing the automatic generate of page paths

- Trim string before replacing spaces with hyphens
- Replace all whitespace chars / multiple successive whitespace chars with a single '-'
- Extract common utility method to ensure consistency

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [X] Unit tests
- [X] Click test

# Checklist:

- [X] My code follows the [javascript standard style](https://standardjs.com/)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts




