### PR TITLE
Wire condition builder into link-edit

### DIFF
--- a/designer/client/conditions/select-conditions.js
+++ b/designer/client/conditions/select-conditions.js
@@ -8,7 +8,8 @@ class SelectConditions extends React.Component {
 
     this.state = {
       fields: this.fieldsForPath(props.path),
-      inline: !props.data.hasConditions
+      inline: !props.data.hasConditions,
+      selectedCondition: props.selectedCondition
     }
   }
 
@@ -63,7 +64,7 @@ class SelectConditions extends React.Component {
   onCancelInlineCondition = () => {
     this.setState({
       inline: !this.props.data.hasConditions,
-      selectedCondition: null
+      selectedCondition: this.props.selectedCondition
     })
   }
 

--- a/designer/client/link-edit.js
+++ b/designer/client/link-edit.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import { clone } from './helpers'
+import SelectConditions from './conditions/select-conditions'
+import InlineConditionHelpers from './conditions/inline-condition-helpers'
 
 class LinkEdit extends React.Component {
   constructor (props) {
@@ -17,25 +19,16 @@ class LinkEdit extends React.Component {
     }
   }
 
-  onSubmit = e => {
+  onSubmit = async e => {
     e.preventDefault()
-    const form = e.target
-    const formData = new window.FormData(form)
-    const condition = formData.get('condition')
+    const { link, page, selectedCondition, conditions } = this.state
     const { data } = this.props
-    const { link, page } = this.state
 
     const copy = clone(data)
-    const copyPage = copy.findPage(page.path)
-    const copyLink = copyPage.next.find(n => n.path === link.path)
+    const conditionResult = await InlineConditionHelpers.storeConditionIfNecessary(copy, selectedCondition, conditions)
+    const updatedData = conditionResult.data.updateLink(page.path, link.path, conditionResult.condition)
 
-    if (condition) {
-      copyLink.condition = condition
-    } else {
-      delete copyLink.condition
-    }
-
-    data.save(copy)
+    data.save(updatedData)
       .then(data => {
         this.props.onEdit({ data })
       })
@@ -70,14 +63,14 @@ class LinkEdit extends React.Component {
 
   render () {
     const { data, edge } = this.props
-    const { pages, conditions } = data
+    const { pages } = data
     const { link } = this.state
 
     return (
       <form onSubmit={e => this.onSubmit(e)} autoComplete='off'>
         <div className='govuk-form-group'>
           <label className='govuk-label govuk-label--s' htmlFor='link-source'>From</label>
-          <select defaultValue={edge.source} className='govuk-select' id='link-source' disabled>
+          <select value={edge.source} className='govuk-select' id='link-source' disabled>
             <option />
             {pages.map(page => (<option key={page.path} value={page.path}>{page.title}</option>))}
           </select>
@@ -85,27 +78,25 @@ class LinkEdit extends React.Component {
 
         <div className='govuk-form-group'>
           <label className='govuk-label govuk-label--s' htmlFor='link-target'>To</label>
-          <select defaultValue={edge.target} className='govuk-select' id='link-target' disabled>
+          <select value={edge.target} className='govuk-select' id='link-target' disabled>
             <option />
             {pages.map(page => (<option key={page.path} value={page.path}>{page.title}</option>))}
           </select>
         </div>
 
-        <div className='govuk-form-group'>
-          <label className='govuk-label govuk-label--s' htmlFor='link-condition'>Condition (optional)</label>
-          <span id='link-condition-hint' className='govuk-hint'>
-            The link will only be used if the expression evaluates to true.
-          </span>
-          <select className='govuk-select' id='link-condition' name='condition' defaultValue={link.condition} aria-describedby='link-condition-hint'>
-            <option value='' />
-            {conditions.map(condition => (<option key={condition.name} value={condition.name}>{condition.displayName}</option>))}
-          </select>
-        </div>
+        <SelectConditions data={data} path={edge.source} selectedCondition={link.condition} conditionsChange={this.saveConditions} />
 
         <button className='govuk-button' type='submit'>Save</button>&nbsp;
         <button className='govuk-button' type='button' onClick={this.onClickDelete}>Delete</button>
       </form>
     )
+  }
+
+  saveConditions = (conditions, selectedCondition) => {
+    this.setState({
+      conditions: conditions,
+      selectedCondition: selectedCondition
+    })
   }
 }
 

--- a/designer/client/model/data-model.js
+++ b/designer/client/model/data-model.js
@@ -74,6 +74,22 @@ export class Data {
     return this
   }
 
+  updateLink (from, to, condition) {
+    const fromPage = this.findPage(from)
+    const toPage = this.pages.find(p => p.path === to)
+    if (fromPage && toPage) {
+      const existingLink = fromPage.next?.find(it => it.path === to)
+      if (existingLink) {
+        if (condition) {
+          existingLink.condition = condition
+        } else {
+          delete existingLink.condition
+        }
+      }
+    }
+    return this
+  }
+
   addPage (page) {
     this.pages = this.pages || []
     this.pages.push(page)

--- a/designer/test/data-model.test.js
+++ b/designer/test/data-model.test.js
@@ -633,6 +633,171 @@ suite('data model', () => {
     })
   })
 
+  describe('update link', () => {
+    test('should remove a condition from a link to the next page', () => {
+      const data = new Data({
+        pages: [
+          {
+            name: 'page1',
+            section: 'section1',
+            path: '/1',
+            next: [{ path: '/2', condition: 'badgers' }],
+            components: [{ name: 'name1' }, { name: 'name2' }]
+          },
+          {
+            name: 'page2',
+            section: 'section1',
+            path: '/2',
+            components: [{ name: 'name3' }, { name: 'name4' }]
+          }
+        ]
+      })
+      const returned = data.updateLink('/1', '/2')
+      expect(returned.findPage(('/1'))).to.equal({
+        name: 'page1',
+        section: 'section1',
+        path: '/1',
+        next: [{ path: '/2' }],
+        components: [{ name: 'name1' }, { name: 'name2' }]
+      })
+      expect(returned.findPage(('/2'))).to.equal({
+        name: 'page2',
+        section: 'section1',
+        path: '/2',
+        components: [{ name: 'name3' }, { name: 'name4' }]
+      })
+    })
+
+    test('should add a condition to a link to the next page', () => {
+      const data = new Data({
+        pages: [
+          {
+            name: 'page1',
+            section: 'section1',
+            path: '/1',
+            next: [{ path: '/2' }],
+            components: [{ name: 'name1' }, { name: 'name2' }]
+          },
+          {
+            name: 'page2',
+            section: 'section1',
+            path: '/2',
+            components: [{ name: 'name3' }, { name: 'name4' }]
+          }
+        ],
+        conditions: [
+          { name: 'condition1' }
+        ]
+      })
+
+      const returned = data.updateLink('/1', '/2', 'condition1')
+
+      expect(returned.findPage(('/1'))).to.equal({
+        name: 'page1',
+        section: 'section1',
+        path: '/1',
+        next: [{ path: '/2', condition: 'condition1' }],
+        components: [{ name: 'name1' }, { name: 'name2' }]
+      })
+      expect(returned.findPage(('/2'))).to.equal({
+        name: 'page2',
+        section: 'section1',
+        path: '/2',
+        components: [{ name: 'name3' }, { name: 'name4' }]
+      })
+    })
+
+    test('should replace a condition on a link', () => {
+      const data = new Data({
+        pages: [
+          {
+            name: 'page1',
+            section: 'section1',
+            path: '/1',
+            next: [{ path: '/2', condition: 'badgers' }],
+            components: [{ name: 'name1' }, { name: 'name2' }]
+          },
+          {
+            name: 'page2',
+            section: 'section1',
+            path: '/2',
+            components: [{ name: 'name3' }, { name: 'name4' }]
+          }
+        ],
+        conditions: [
+          { name: 'condition1' }
+        ]
+      })
+
+      const returned = data.updateLink('/1', '/2', 'condition1')
+
+      expect(returned.findPage(('/1'))).to.equal({
+        name: 'page1',
+        section: 'section1',
+        path: '/1',
+        next: [{ path: '/2', condition: 'condition1' }],
+        components: [{ name: 'name1' }, { name: 'name2' }]
+      })
+      expect(returned.findPage(('/2'))).to.equal({
+        name: 'page2',
+        section: 'section1',
+        path: '/2',
+        components: [{ name: 'name3' }, { name: 'name4' }]
+      })
+    })
+
+    test('should do nothing if the specified link does not exist', () => {
+      const data = new Data({
+        pages: [
+          {
+            name: 'page1',
+            section: 'section1',
+            path: '/1',
+            next: [{ path: '/2' }],
+            components: [{ name: 'name1' }, { name: 'name2' }]
+          },
+          {
+            name: 'page2',
+            section: 'section1',
+            path: '/2',
+            components: [{ name: 'name3' }, { name: 'name4' }]
+          },
+          {
+            name: 'page3',
+            section: 'section1',
+            path: '/3',
+            components: [{ name: 'name5' }, { name: 'name6' }]
+          }
+        ],
+        conditions: [
+          { name: 'condition1' }
+        ]
+      })
+
+      const returned = data.updateLink('/1', '/3', 'condition1')
+
+      expect(returned.findPage(('/1'))).to.equal({
+        name: 'page1',
+        section: 'section1',
+        path: '/1',
+        next: [{ path: '/2' }],
+        components: [{ name: 'name1' }, { name: 'name2' }]
+      })
+      expect(returned.findPage(('/2'))).to.equal({
+        name: 'page2',
+        section: 'section1',
+        path: '/2',
+        components: [{ name: 'name3' }, { name: 'name4' }]
+      })
+      expect(returned.findPage(('/3'))).to.equal({
+        name: 'page3',
+        section: 'section1',
+        path: '/3',
+        components: [{ name: 'name5' }, { name: 'name6' }]
+      })
+    })
+  })
+
   describe('find page', () => {
     test('should return the page with the requested path if it exists', () => {
       const data = new Data({

--- a/designer/test/link-edit.test.js
+++ b/designer/test/link-edit.test.js
@@ -1,0 +1,177 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import * as Code from '@hapi/code'
+import * as Lab from '@hapi/lab'
+import { Data } from '../client/model/data-model'
+import sinon from 'sinon'
+import { assertSelectInput } from './helpers/element-assertions'
+import InlineConditionHelpers from '../client/conditions/inline-condition-helpers'
+import LinkEdit from '../client/link-edit'
+
+const { expect } = Code
+const lab = Lab.script()
+exports.lab = lab
+const { suite, test, describe, beforeEach, afterEach } = lab
+
+suite('Link edit', () => {
+  describe('Editing a link which does not have a condition', () => {
+    const data = new Data({
+      pages: [
+        { path: '/1', title: 'Page 1', next: [ { path: '/2' } ] },
+        { path: '/2', title: 'Page 2' }
+      ],
+      conditions: [
+        { name: 'someCondition', displayName: 'My condition' },
+        { name: 'anotherCondition', displayName: 'Another condition' }
+      ]
+    })
+    const edge = {
+      source: '/1',
+      target: '/2'
+    }
+
+    test('Renders a form with expected inputs', () => {
+      const wrapper = shallow(<LinkEdit data={data} edge={edge} />)
+      const form = wrapper.find('form')
+
+      const fromInput = form.find('#link-source')
+      assertSelectInput(fromInput, 'link-source', [
+        { text: '' },
+        { value: '/1', text: 'Page 1' },
+        { value: '/2', text: 'Page 2' }
+      ], '/1')
+      expect(fromInput.prop('disabled')).to.equal(true)
+
+      const toInput = form.find('#link-target')
+      assertSelectInput(toInput, 'link-target', [
+        { text: '' },
+        { value: '/1', text: 'Page 1' },
+        { value: '/2', text: 'Page 2' }
+      ], '/2')
+      expect(toInput.prop('disabled')).to.equal(true)
+
+      const selectConditions = wrapper.find('SelectConditions')
+      expect(selectConditions.exists()).to.equal(true)
+      expect(selectConditions.prop('data')).to.equal(data)
+      expect(selectConditions.prop('path')).to.equal('/1')
+      expect(selectConditions.prop('selectedCondition')).to.equal(undefined)
+      expect(selectConditions.prop('conditionsChange')).to.equal(wrapper.instance().saveConditions)
+    })
+  })
+
+  describe('Editing a link which has a condition', () => {
+    const data = new Data({
+      pages: [
+        { path: '/1', title: 'Page 1', next: [ { path: '/2', condition: 'anotherCondition' } ] },
+        { path: '/2', title: 'Page 2' }
+      ],
+      conditions: [
+        { name: 'someCondition', displayName: 'My condition' },
+        { name: 'anotherCondition', displayName: 'Another condition' }
+      ]
+    })
+    const edge = {
+      source: '/1',
+      target: '/2'
+    }
+
+    test('Renders a form with expected inputs', () => {
+      const wrapper = shallow(<LinkEdit data={data} edge={edge} />)
+      const form = wrapper.find('form')
+
+      const fromInput = form.find('#link-source')
+      assertSelectInput(fromInput, 'link-source', [
+        { text: '' },
+        { value: '/1', text: 'Page 1' },
+        { value: '/2', text: 'Page 2' }
+      ], '/1')
+      expect(fromInput.prop('disabled')).to.equal(true)
+
+      const toInput = form.find('#link-target')
+      assertSelectInput(toInput, 'link-target', [
+        { text: '' },
+        { value: '/1', text: 'Page 1' },
+        { value: '/2', text: 'Page 2' }
+      ], '/2')
+      expect(toInput.prop('disabled')).to.equal(true)
+
+      const selectConditions = wrapper.find('SelectConditions')
+      expect(selectConditions.exists()).to.equal(true)
+      expect(selectConditions.prop('data')).to.equal(data)
+      expect(selectConditions.prop('path')).to.equal('/1')
+      expect(selectConditions.prop('selectedCondition')).to.equal('anotherCondition')
+      expect(selectConditions.prop('conditionsChange')).to.equal(wrapper.instance().saveConditions)
+    })
+  })
+
+  describe('submitting the form', () => {
+    const data = new Data({
+      pages: [
+        { path: '/1', title: 'Page 1', next: [ { path: '/2' } ] },
+        { path: '/2', title: 'Page 2' }
+      ],
+      conditions: [
+        { name: 'someCondition', displayName: 'My condition' },
+        { name: 'anotherCondition', displayName: 'Another condition' }
+      ]
+    })
+    const edge = {
+      source: '/1',
+      target: '/2'
+    }
+    let storeConditionStub
+
+    beforeEach(function () {
+      storeConditionStub = sinon.stub(InlineConditionHelpers, 'storeConditionIfNecessary')
+    })
+
+    afterEach(function () {
+      storeConditionStub.restore()
+    })
+
+    test('with a condition updates the link and calls back', async flags => {
+      const clonedData = {}
+      const withCondition = {
+        updateLink: sinon.stub()
+      }
+      const updatedData = sinon.spy()
+      const savedData = sinon.spy()
+      const onEdit = data => {
+        expect(data.data).to.equal(savedData)
+      }
+      const save = data => {
+        expect(data).to.equal(updatedData)
+        return Promise.resolve(savedData)
+      }
+      // const wrappedOnEdit = flags.mustCall(onEdit, 1)
+
+      const wrapper = shallow(<LinkEdit data={data} edge={edge} onEdit={onEdit} />)
+      const conditions = {}
+      const selectedCondition = {}
+      wrapper.instance().saveConditions(conditions, selectedCondition)
+
+      storeConditionStub.resolves({ data: withCondition, condition: 'aCondition' })
+
+      withCondition.updateLink.returns(updatedData)
+
+      const preventDefault = sinon.spy()
+
+      data.clone = sinon.stub()
+      data.clone.returns(clonedData)
+      data.save = flags.mustCall(save, 1)
+
+      await wrapper.simulate('submit', { preventDefault: preventDefault })
+
+      expect(preventDefault.calledOnce).to.equal(true)
+      expect(storeConditionStub.calledOnce).to.equal(true)
+      expect(storeConditionStub.firstCall.args[0]).to.equal(clonedData)
+      expect(storeConditionStub.firstCall.args[1]).to.equal(selectedCondition)
+      expect(storeConditionStub.firstCall.args[2]).to.equal(conditions)
+
+      expect(withCondition.updateLink.calledOnce).to.equal(true)
+      expect(withCondition.updateLink.firstCall.args[0]).to.equal('/1')
+      expect(withCondition.updateLink.firstCall.args[1]).to.equal('/2')
+      expect(withCondition.updateLink.firstCall.args[2]).to.equal('aCondition')
+    })
+  })
+})

--- a/designer/test/select-conditions.test.js
+++ b/designer/test/select-conditions.test.js
@@ -80,6 +80,23 @@ suite('Select conditions', () => {
         assertLink(selectConditions.find('#inline-conditions-link'), 'inline-conditions-link', 'Define a new condition')
       })
 
+      test('should default the selected condition when one is provided', () => {
+        const wrapper = shallow(<SelectConditions data={data} path={path} selectedCondition={conditions[1].name} conditionsChange={conditionsChange} />)
+        let conditionsSection = wrapper.find('.conditions')
+        expect(conditionsSection.exists()).to.equal(true)
+        let conditionHeaderGroup = conditionsSection.find('#conditions-header-group')
+        expect(conditionHeaderGroup.find('label').text()).to.equal('Conditions (optional)')
+        expect(conditionsSection.find('InlineConditions').exists()).to.equal(false)
+        let selectConditions = conditionsSection.find('#select-condition')
+        expect(selectConditions.exists()).to.equal(true)
+        expect(selectConditions.find('label').text()).to.equal('Select a condition')
+        const expectedFieldOptions = conditions.map(condition => ({ text: condition.displayName, value: condition.name }))
+        expectedFieldOptions.unshift({ text: '' })
+        assertSelectInput(selectConditions.find('select'), 'cond-select',
+          expectedFieldOptions, conditions[1].name)
+        assertLink(selectConditions.find('#inline-conditions-link'), 'inline-conditions-link', 'Define a new condition')
+      })
+
       test('Clicking the define condition link should trigger the inline view to define a condition', () => {
         const wrapper = shallow(<SelectConditions data={data} path={path} conditionsChange={conditionsChange} />)
         expect(wrapper.find('#select-condition').exists()).to.equal(true)
@@ -90,13 +107,27 @@ suite('Select conditions', () => {
         assertInlineConditionsComponent(wrapper, data, path, conditionsChange, true)
       })
 
-      test('cancel inline condition should re-display the select conditions section', () => {
+      test('cancel inline condition should re-display the select conditions section with blank condition', () => {
         const wrapper = shallow(<SelectConditions data={data} path={path} conditionsChange={conditionsChange} />)
         wrapper.find('#inline-conditions-link').simulate('click')
         assertInlineConditionsComponent(wrapper, data, path, conditionsChange, true)
         wrapper.instance().onCancelInlineCondition()
 
-        expect(wrapper.find('#select-condition').exists()).to.equal(true)
+        const expectedFieldOptions = conditions.map(condition => ({ text: condition.displayName, value: condition.name }))
+        expectedFieldOptions.unshift({ text: '' })
+        assertSelectInput(wrapper.find('select'), 'cond-select', expectedFieldOptions, '')
+        expect(wrapper.find('InlineConditions').exists()).to.equal(false)
+      })
+
+      test('cancel inline condition should re-display the select conditions section with specified condition selected', () => {
+        const wrapper = shallow(<SelectConditions data={data} path={path} selectedCondition={conditions[1].name} conditionsChange={conditionsChange} />)
+        wrapper.find('#inline-conditions-link').simulate('click')
+        assertInlineConditionsComponent(wrapper, data, path, conditionsChange, true)
+        wrapper.instance().onCancelInlineCondition()
+
+        const expectedFieldOptions = conditions.map(condition => ({ text: condition.displayName, value: condition.name }))
+        expectedFieldOptions.unshift({ text: '' })
+        assertSelectInput(wrapper.find('select'), 'cond-select', expectedFieldOptions, conditions[1].name)
         expect(wrapper.find('InlineConditions').exists()).to.equal(false)
       })
 


### PR DESCRIPTION
Description
Make link-edit consistent with the inline condition builder approach.

Wire condition builder into link-edit
SelectConditions component now supports a default selected condition
Data class now supports updating a link
Type of change
Please delete options that are not relevant.

 Bug fix (non-breaking change which fixes an issue)
How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

 Unit tests
 Click testing
Checklist:
 My code follows the javascript standard style
 I have performed a self-review of my own code
 I have commented my code, particularly in hard-to-understand areas
 I have made corresponding changes to the documentation and versioning
 My changes generate no new warnings
 I have added tests that prove my fix is effective or that my feature works
 New and existing unit tests pass locally with my changes
 I have rebased onto master and there are no code conflicts