### PR TITLE
Hide title for inputs

### DIFF
--- a/designer/client/component-type-edit.js
+++ b/designer/client/component-type-edit.js
@@ -16,6 +16,7 @@ function Classes (props) {
     </div>
   )
 }
+
 class FieldEdit extends React.Component {
   constructor (props) {
     super(props)
@@ -59,6 +60,18 @@ class FieldEdit extends React.Component {
           <textarea className='govuk-textarea' id='field-hint' name='hint'
             defaultValue={component.hint} rows='2' />
         </div>
+
+        <div className='govuk-checkboxes govuk-form-group'>
+          <div className='govuk-checkboxes__item'>
+            <input className='govuk-checkboxes__input' id='field-options.hideTitle'
+              name='options.hideTitle' type='checkbox' value defaultChecked={options.hideTitle}
+            />
+            <label className='govuk-label govuk-checkboxes__label'
+              htmlFor='field-options.hideTitle'>Hide title</label>
+            <span className='govuk-hint'>Hide the title of the component</span>
+          </div>
+        </div>
+
         <div className='govuk-checkboxes govuk-form-group'>
           <div className='govuk-checkboxes__item'>
             <input className={`govuk-checkboxes__input ${isFileUploadField ? 'disabled' : ''}`} id='field-options.required'
@@ -73,7 +86,6 @@ class FieldEdit extends React.Component {
             {!isFileUploadField && (
               <span className='govuk-hint'>The hint can include HTML</span>
             )}
-
           </div>
         </div>
 

--- a/designer/client/component-type-edit.js
+++ b/designer/client/component-type-edit.js
@@ -75,16 +75,13 @@ class FieldEdit extends React.Component {
         <div className='govuk-checkboxes govuk-form-group'>
           <div className='govuk-checkboxes__item'>
             <input className={`govuk-checkboxes__input ${isFileUploadField ? 'disabled' : ''}`} id='field-options.required'
-              name='options.required' type='checkbox' defaultChecked={isFileUploadField}
+              name='options.required' type='checkbox' defaultChecked={isFileUploadField || options.required === false}
               onChange={(e) => this.checkOptionalBox(e)}
             />
             <label className='govuk-label govuk-checkboxes__label'
               htmlFor='field-options.required'>Optional</label>
             {isFileUploadField && (
               <span className='govuk-hint govuk-checkboxes__label'>All file upload fields are optional to mitigate possible upload errors</span>
-            )}
-            {!isFileUploadField && (
-              <span className='govuk-hint'>The hint can include HTML</span>
             )}
           </div>
         </div>

--- a/designer/client/component-type-edit.js
+++ b/designer/client/component-type-edit.js
@@ -39,59 +39,61 @@ class FieldEdit extends React.Component {
 
     return (
       <div>
-        <div className='govuk-form-group'>
-          <label className='govuk-label govuk-label--s' htmlFor='field-name'>Name</label>
-          <span className='govuk-hint'>This is used as the key in the JSON output. Use `camelCasing` e.g. dateOfBirth or
-            fullName.</span>
-          <input className='govuk-input govuk-input--width-20' id='field-name'
-            name='name' type='text' defaultValue={component.name} required pattern='^\S+' />
-        </div>
-
-        <div className='govuk-form-group'>
-          <label className='govuk-label govuk-label--s' htmlFor='field-title'>Title</label>
-          <span className='govuk-hint'>This is the title text displayed on the page</span>
-          <input className='govuk-input' id='field-title' name='title' type='text'
-            defaultValue={component.title} required />
-        </div>
-
-        <div className='govuk-form-group'>
-          <label className='govuk-label govuk-label--s' htmlFor='field-hint'>Hint (optional)</label>
-          <span className='govuk-hint'>The hint can include HTML</span>
-          <textarea className='govuk-textarea' id='field-hint' name='hint'
-            defaultValue={component.hint} rows='2' />
-        </div>
-
-        <div className='govuk-checkboxes govuk-form-group'>
-          <div className='govuk-checkboxes__item'>
-            <input className='govuk-checkboxes__input' id='field-options.hideTitle'
-              name='options.hideTitle' type='checkbox' value defaultChecked={options.hideTitle}
-            />
-            <label className='govuk-label govuk-checkboxes__label'
-              htmlFor='field-options.hideTitle'>Hide title</label>
-            <span className='govuk-hint'>Hide the title of the component</span>
+        <div data-test-id='standard-inputs'>
+          <div className='govuk-form-group'>
+            <label className='govuk-label govuk-label--s' htmlFor='field-name'>Name</label>
+            <span className='govuk-hint'>This is used as the key in the JSON output. Use `camelCasing` e.g. dateOfBirth or
+              fullName.</span>
+            <input className='govuk-input govuk-input--width-20' id='field-name'
+              name='name' type='text' defaultValue={component.name} required pattern='^\S+' />
           </div>
-        </div>
 
-        <div className='govuk-checkboxes govuk-form-group'>
-          <div className='govuk-checkboxes__item'>
-            <input className={`govuk-checkboxes__input ${isFileUploadField ? 'disabled' : ''}`} id='field-options.required'
-              name='options.required' type='checkbox' defaultChecked={isFileUploadField || options.required === false}
-              onChange={(e) => this.checkOptionalBox(e)}
-            />
-            <label className='govuk-label govuk-checkboxes__label'
-              htmlFor='field-options.required'>Optional</label>
-            {isFileUploadField && (
-              <span className='govuk-hint govuk-checkboxes__label'>All file upload fields are optional to mitigate possible upload errors</span>
-            )}
+          <div className='govuk-form-group'>
+            <label className='govuk-label govuk-label--s' htmlFor='field-title'>Title</label>
+            <span className='govuk-hint'>This is the title text displayed on the page</span>
+            <input className='govuk-input' id='field-title' name='title' type='text'
+              defaultValue={component.title} required />
           </div>
-        </div>
 
-        <div className={`govuk-checkboxes govuk-form-group`} hidden={this.state.hidden}>
-          <div className='govuk-checkboxes__item'>
-            <input className='govuk-checkboxes__input' id='field-options.optionalText'
-              name='options.optionalText' type='checkbox' defaultChecked={options.optionalText === false} />
-            <label className='govuk-label govuk-checkboxes__label'
-              htmlFor='field-options.optionalText'>Hide '(Optional)' text</label>
+          <div className='govuk-form-group'>
+            <label className='govuk-label govuk-label--s' htmlFor='field-hint'>Hint (optional)</label>
+            <span className='govuk-hint'>The hint can include HTML</span>
+            <textarea className='govuk-textarea' id='field-hint' name='hint'
+              defaultValue={component.hint} rows='2' />
+          </div>
+
+          <div className='govuk-checkboxes govuk-form-group'>
+            <div className='govuk-checkboxes__item'>
+              <input className='govuk-checkboxes__input' id='field-options.hideTitle'
+                name='options.hideTitle' type='checkbox' value defaultChecked={options.hideTitle}
+              />
+              <label className='govuk-label govuk-checkboxes__label'
+                htmlFor='field-options.hideTitle'>Hide title</label>
+              <span className='govuk-hint'>Hide the title of the component</span>
+            </div>
+          </div>
+
+          <div className='govuk-checkboxes govuk-form-group'>
+            <div className='govuk-checkboxes__item'>
+              <input className={`govuk-checkboxes__input ${isFileUploadField ? 'disabled' : ''}`} id='field-options.required'
+                name='options.required' type='checkbox' checked={isFileUploadField || options.required === false}
+                onChange={(e) => this.checkOptionalBox(e)}
+              />
+              <label className='govuk-label govuk-checkboxes__label'
+                htmlFor='field-options.required'>Optional</label>
+              {isFileUploadField && (
+                <span className='govuk-hint govuk-checkboxes__label'>All file upload fields are optional to mitigate possible upload errors</span>
+              )}
+            </div>
+          </div>
+
+          <div className={`govuk-checkboxes govuk-form-group`} data-test-id='field-options.optionalText-wrapper' hidden={this.state.hidden}>
+            <div className='govuk-checkboxes__item'>
+              <input className='govuk-checkboxes__input' id='field-options.optionalText'
+                name='options.optionalText' type='checkbox' defaultChecked={options.optionalText === false} />
+              <label className='govuk-label govuk-checkboxes__label'
+                htmlFor='field-options.optionalText'>Hide '(Optional)' text</label>
+            </div>
           </div>
         </div>
 

--- a/designer/client/helpers.js
+++ b/designer/client/helpers.js
@@ -18,7 +18,9 @@ export function getFormData (form) {
     } else if (cast === 'boolean') {
       return val === 'on'
     }
-
+    if (val === 'true' || val === 'false') {
+      return Boolean(val)
+    }
     return val
   }
 

--- a/designer/test/component-type-edit.test.js
+++ b/designer/test/component-type-edit.test.js
@@ -1,0 +1,152 @@
+import React from 'react'
+import { render } from 'enzyme'
+import * as Code from '@hapi/code'
+import * as Lab from '@hapi/lab'
+import ComponentTypes from 'digital-form-builder-engine/src/component-types'
+import ComponentTypeEdit from '../client/component-type-edit'
+import { Data } from '../client/model/data-model'
+import sinon from 'sinon'
+import { assertCheckboxInput, assertRequiredTextInput, assertTextArea } from './helpers/element-assertions'
+
+const { expect } = Code
+const lab = Lab.script()
+exports.lab = lab
+const { suite, test, describe } = lab
+
+suite('Component type edit', () => {
+  const data = new Data({ lists: [] })
+  const nextId = 'abcdef'
+  data.getId = sinon.stub()
+  data.getId.resolves(nextId)
+
+  describe('FileUploadField type gets the standard inputs but is always optional', () => {
+    const cases = [
+      { case: 'with all options provided', options: { hideTitle: true, optionalText: false }, hint: 'a hint' },
+      { case: 'with title hidden', options: { hideTitle: true } },
+      { case: 'with title explicitly not hidden', options: { hideTitle: false } },
+      { case: 'with optional text hidden', options: { optionalText: false } },
+      { case: 'with optional text explicitly not hidden', options: { optionalText: true } },
+      { case: 'with no options' }
+    ]
+
+    cases.forEach(testCase => {
+      test(`${testCase.case}`, () => {
+        const wrapper = render(<ComponentTypeEdit data={data} component={{ type: 'FileUploadField', name: 'myComponent', title: 'My component', hint: testCase.hint, options: testCase.options }} />)
+        const standardInputs = wrapper.find('[data-test-id="standard-inputs"]')
+        expect(standardInputs.length).to.equal(1)
+        const inputs = standardInputs.find('input')
+        expect(inputs.length).to.equal(5)
+
+        assertRequiredTextInput(inputs.get(0), 'field-name', 'myComponent', { name: 'name', pattern: '^\\S+' })
+        assertRequiredTextInput(inputs.get(1), 'field-title', 'My component', { name: 'title' })
+        assertCheckboxInput(inputs.get(2), 'field-options.hideTitle', 'true', testCase.options?.hideTitle || '', { name: 'options.hideTitle' })
+        assertCheckboxInput(inputs.get(3), 'field-options.required', undefined, true, { name: 'options.required' })
+        assertCheckboxInput(inputs.get(4), 'field-options.optionalText', undefined, testCase.options?.optionalText === false || '', { name: 'options.optionalText' })
+        assertOptionalTextWrapper(inputs.get(4), true)
+
+        const textAreas = standardInputs.find('textarea')
+        expect(textAreas.length).to.equal(1)
+        assertTextArea(textAreas.get(0), 'field-hint', testCase.hint || '', { name: 'hint', rows: '2' })
+
+        const selects = standardInputs.find('select')
+        expect(selects.length).to.equal(0)
+      })
+    })
+  })
+
+  const inputsExcludingFileUpload = ComponentTypes.filter(type => type.subType === 'field').filter(type => type.name !== 'FileUploadField')
+  inputsExcludingFileUpload.forEach(componentType => {
+    test(`${componentType.name} type gets the standard inputs and is required by default`, () => {
+      const wrapper = render(<ComponentTypeEdit data={data} component={{ type: componentType.name, name: 'myComponent', title: 'My component' }} />)
+      const standardInputs = wrapper.find('[data-test-id="standard-inputs"]')
+      expect(standardInputs.length).to.equal(1)
+      const inputs = standardInputs.find('input')
+      expect(inputs.length).to.equal(5)
+
+      assertRequiredTextInput(inputs.get(0), 'field-name', 'myComponent', { name: 'name', pattern: '^\\S+' })
+      assertRequiredTextInput(inputs.get(1), 'field-title', 'My component', { name: 'title' })
+      assertCheckboxInput(inputs.get(2), 'field-options.hideTitle', 'true', '', { name: 'options.hideTitle' })
+      assertCheckboxInput(inputs.get(3), 'field-options.required', undefined, '', { name: 'options.required' })
+      assertCheckboxInput(inputs.get(4), 'field-options.optionalText', undefined, '', { name: 'options.optionalText' })
+      assertOptionalTextWrapper(inputs.get(4), true)
+
+      const textAreas = standardInputs.find('textarea')
+      expect(textAreas.length).to.equal(1)
+      assertTextArea(textAreas.get(0), 'field-hint', '', { name: 'hint', rows: '2' })
+
+      const selects = standardInputs.find('select')
+      expect(selects.length).to.equal(0)
+    })
+
+    describe(`${componentType.name} type has correctly pre-populated inputs `, () => {
+      const optionalCases = [
+        { case: 'with all options provided', options: { hideTitle: true, required: false, optionalText: false }, hint: 'a hint' },
+        { case: 'with optional text unspecified', options: { required: false } },
+        { case: 'with optional text hidden', options: { required: false, optionalText: false } },
+        { case: 'with optional text explicitly not hidden', options: { required: false, optionalText: true } }
+      ]
+
+      optionalCases.forEach(testCase => {
+        test(`when specified as optional ${testCase.case}`, () => {
+          const wrapper = render(<ComponentTypeEdit data={data} component={{ type: componentType.name, name: 'myComponent', title: 'My component', hint: testCase.hint, options: testCase.options }} />)
+          const standardInputs = wrapper.find('[data-test-id="standard-inputs"]')
+          expect(standardInputs.length).to.equal(1)
+          const inputs = standardInputs.find('input')
+
+          expect(inputs.length).to.equal(5)
+
+          assertRequiredTextInput(inputs.get(0), 'field-name', 'myComponent', { name: 'name', pattern: '^\\S+' })
+          assertRequiredTextInput(inputs.get(1), 'field-title', 'My component', { name: 'title' })
+          assertCheckboxInput(inputs.get(2), 'field-options.hideTitle', 'true', testCase.options?.hideTitle || '', { name: 'options.hideTitle' })
+          assertCheckboxInput(inputs.get(3), 'field-options.required', undefined, true, { name: 'options.required' })
+          assertCheckboxInput(inputs.get(4), 'field-options.optionalText', undefined, testCase.options?.optionalText === false || '', { name: 'options.optionalText' })
+          assertOptionalTextWrapper(inputs.get(4))
+
+          const textAreas = standardInputs.find('textarea')
+          expect(textAreas.length).to.equal(1)
+          assertTextArea(textAreas.get(0), 'field-hint', testCase.hint || '', { name: 'hint', rows: '2' })
+
+          const selects = standardInputs.find('select')
+          expect(selects.length).to.equal(0)
+        })
+      })
+
+      const nonOptionalCases = [
+        { case: 'with no options' },
+        { case: 'with title hidden', options: { hideTitle: true } },
+        { case: 'with title explicitly not hidden', options: { hideTitle: false } },
+        { case: 'with required explicitly true', options: { required: true } }
+      ]
+
+      nonOptionalCases.forEach(testCase => {
+        test(`when not specified as optional ${testCase.case}`, () => {
+          const wrapper = render(<ComponentTypeEdit data={data} component={{ type: componentType.name, name: 'myComponent', title: 'My component', hint: testCase.hint, options: testCase.options }} />)
+          const standardInputs = wrapper.find('[data-test-id="standard-inputs"]')
+          expect(standardInputs.length).to.equal(1)
+          const inputs = standardInputs.find('input')
+
+          expect(inputs.length).to.equal(5)
+
+          assertRequiredTextInput(inputs.get(0), 'field-name', 'myComponent', { name: 'name', pattern: '^\\S+' })
+          assertRequiredTextInput(inputs.get(1), 'field-title', 'My component', { name: 'title' })
+          assertCheckboxInput(inputs.get(2), 'field-options.hideTitle', 'true', testCase.options?.hideTitle || '', { name: 'options.hideTitle' })
+          assertCheckboxInput(inputs.get(3), 'field-options.required', undefined, '', { name: 'options.required' })
+          assertCheckboxInput(inputs.get(4), 'field-options.optionalText', undefined, '', { name: 'options.optionalText' })
+          assertOptionalTextWrapper(inputs.get(4), true)
+
+          const textAreas = standardInputs.find('textarea')
+          expect(textAreas.length).to.equal(1)
+          assertTextArea(textAreas.get(0), 'field-hint', testCase.hint || '', { name: 'hint', rows: '2' })
+
+          const selects = standardInputs.find('select')
+          expect(selects.length).to.equal(0)
+        })
+      })
+    })
+  })
+})
+
+function assertOptionalTextWrapper (input, hidden) {
+  const wrappingDiv = input.parent.parent
+  expect(wrappingDiv.attribs['hidden']).to.equal(hidden ? '' : undefined)
+}

--- a/designer/test/helpers/element-assertions.js
+++ b/designer/test/helpers/element-assertions.js
@@ -1,4 +1,5 @@
 import * as Code from '@hapi/code'
+
 const { expect } = Code
 
 export function assertDiv (wrapper, classes) {
@@ -12,7 +13,7 @@ export function assertText (wrapper, text) {
 export function assertClasses (wrapper, classes) {
   const certainClasses = classes??[]
   certainClasses.forEach(className => {
-    expect(wrapper.hasClass(className), `${wrapper.name()} ${wrapper.prop('id') || ''} to have class ${className}`).to.equal(true)
+    expect(wrapper.hasClass(className), `${getTagName(wrapper)} ${getProperty(wrapper, 'id') || ''} to have class ${className}`).to.equal(true)
   })
 }
 
@@ -26,50 +27,94 @@ export function assertLabel (wrapper, text) {
 }
 
 export function assertLink (wrapper, id, expectedText) {
-  expect(wrapper.name()).to.equal('a')
-  expect(wrapper.prop('id')).to.equal(id)
+  expect(getTagName(wrapper)).to.equal('a')
+  expect(getProperty(wrapper, 'id')).to.equal(id)
   expect(wrapper.text()).to.equal(expectedText)
-  expect(wrapper.prop('href')).to.equal('#')
+  expect(getProperty(wrapper, 'href')).to.equal('#')
 }
 
-export function assertRequiredTextInput (wrapper, id, expectedValue) {
+export function assertRequiredTextInput (wrapper, id, expectedValue, attrs) {
   assertTextInput(wrapper, id, expectedValue)
-  expect(Object.keys(wrapper.props()).includes('required')).to.equal(true)
+  expect(getPropertyNames(wrapper).includes('required')).to.equal(true)
 }
 
-export function assertTextInput (wrapper, id, expectedValue) {
-  expect(wrapper.name()).to.equal('input')
-  expect(wrapper.prop('id')).to.equal(id)
-  expect(wrapper.prop('type')).to.equal('text')
-  expect(wrapper.prop('defaultValue')).to.equal(expectedValue)
+export function assertTextInput (wrapper, id, expectedValue, attrs) {
+  expect(getTagName(wrapper)).to.equal('input')
+  expect(getProperty(wrapper, 'id')).to.equal(id)
+  expect(getProperty(wrapper, 'type')).to.equal('text')
+  expect(getProperty(wrapper, 'defaultValue')).to.equal(expectedValue)
+  assertAdditionalAttributes(attrs, wrapper)
+}
+
+export function assertTextArea (wrapper, id, expectedValue, attrs) {
+  expect(getTagName(wrapper)).to.equal('textarea')
+  expect(getProperty(wrapper, 'id')).to.equal(id)
+  expect(getText(wrapper)).to.equal(expectedValue)
+  assertAdditionalAttributes(attrs, wrapper)
 }
 
 export function assertSelectInput (wrapper, id, expectedFieldOptions, expectedValue) {
-  expect(wrapper.name()).to.equal('select')
-  expect(wrapper.prop('id')).to.equal(id)
+  expect(getTagName(wrapper)).to.equal('select')
+  expect(getProperty(wrapper, 'id')).to.equal(id)
   const options = wrapper.children()
   expect(options.length).to.equal(expectedFieldOptions.length)
   expectedFieldOptions.forEach((expectedOption, index) => {
     assertOption(options.at(index), expectedOption.value, expectedOption.text)
   })
-  expect(wrapper.prop('value')).to.equal(expectedValue)
+  expect(getProperty(wrapper, 'value')).to.equal(expectedValue)
 }
 
-export function assertCheckboxInput (wrapper, id, value, checked) {
-  expect(wrapper.name()).to.equal('input')
-  expect(wrapper.prop('type')).to.equal('checkbox')
-  expect(wrapper.prop('id')).to.equal(id)
-  expect(wrapper.prop('value')).to.equal(value)
-  expect(wrapper.prop('checked'), `checkbox ${id} to be ${checked ? 'checked' : 'not checked'}`).to.equal(checked || '')
+export function assertCheckboxInput (wrapper, id, value, checked, attrs) {
+  expect(getTagName(wrapper)).to.equal('input')
+  expect(getProperty(wrapper, 'type')).to.equal('checkbox')
+  expect(getProperty(wrapper, 'id')).to.equal(id)
+  expect(getProperty(wrapper, 'value')).to.equal(value)
+  expect(getProperty(wrapper, 'checked'), `checkbox ${id} to be ${checked ? 'checked' : 'not checked'}`).to.equal(checked)
+  assertAdditionalAttributes(attrs, wrapper)
 }
 
 export function assertOption (wrapper, expectedValue, expectedText) {
-  expect(wrapper.name()).to.equal('option')
-  expect(wrapper.prop('value')).to.equal(expectedValue)
+  expect(getTagName(wrapper)).to.equal('option')
+  expect(getProperty(wrapper, 'value')).to.equal(expectedValue)
   expect(wrapper.text()).to.equal(expectedText)
 }
 
 function assertElement (wrapper, elementName, classes) {
-  expect(wrapper.name()).to.equal(elementName)
+  expect(getTagName(wrapper)).to.equal(elementName)
   assertClasses(wrapper, classes)
+}
+
+function assertAdditionalAttributes (attrs, wrapper) {
+  Object.keys(attrs || {}).forEach(key => {
+    expect(getProperty(wrapper, key)).to.equal(attrs[key])
+  })
+}
+
+/** ****** Adapters for handling standard Enzyme (shallow) vs Cheerio (render) wrappers. Eugh! ***********/
+function getTagName (wrapper) {
+  if (typeof wrapper.name === 'function') {
+    return wrapper.name()
+  }
+  return wrapper.name
+}
+
+function getProperty (wrapper, name) {
+  if (typeof wrapper.prop === 'function') {
+    return wrapper.prop(name)
+  }
+  const propertyMapping = propertyMappings[name]
+  return propertyMapping ? propertyMapping(wrapper.attribs) : wrapper.attribs[name]
+}
+
+function getPropertyNames (wrapper) {
+  return typeof wrapper.props === 'function' ? Object.keys(wrapper.props()) : Object.keys(wrapper.attribs)
+}
+
+function getText (wrapper) {
+  return typeof wrapper.text === 'function' ? wrapper.text() : wrapper.children?.[0]?.data??''
+}
+
+const propertyMappings = {
+  defaultValue: attribs => attribs['value'],
+  checked: attribs => Object.keys(attribs).includes('checked') || ''
 }

--- a/designer/test/inline-conditions-edit.test.js
+++ b/designer/test/inline-conditions-edit.test.js
@@ -309,7 +309,7 @@ function assertEditPanel (wrapper, conditions, editingError) {
     const checkboxDiv = checkboxesDiv.children().at(index)
     assertDiv(checkboxDiv, ['govuk-checkboxes__item'])
     expect(checkboxDiv.children().length).to.equal(3)
-    assertCheckboxInput(checkboxDiv.children().at(0), `condition-${index}`, index, condition.selected)
+    assertCheckboxInput(checkboxDiv.children().at(0), `condition-${index}`, index, condition.selected || '')
     assertLabel(checkboxDiv.children().at(1), condition.condition)
     let actions = checkboxDiv.children().at(2)
     assertSpan(actions)

--- a/engine/components/index.js
+++ b/engine/components/index.js
@@ -130,9 +130,10 @@ class FormComponent extends Component {
     const isOptional = options.required === false
     const optionalPostfix = isOptional && options.optionalText !== false ? optionalText : ''
     this.lang = formData.lang
-    const label = `${this.localisedString(this.title)}${optionalPostfix}`
+    const label = options.hideTitle ? '' : `${this.localisedString(this.title)}${optionalPostfix}`
 
     const name = this.name
+
     const model = {
       label: {
         text: label,


### PR DESCRIPTION
# Description

- Allow users to hide title on inputs
- Optional checkbox pre-populated on component edit
- Optional checkbox no longer has a hint relating to the 'hint' input

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [X] Unit testing
- [X] Click testing

# Checklist:

- [X] My code follows the [javascript standard style](https://standardjs.com/)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts




