### PR TITLE
Bug/style-flash

### DIFF
--- a/runner/bin/build-css
+++ b/runner/bin/build-css
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-node-sass --output-style=expanded \
+node-sass --output-style=compressed \
   --output=public/build/stylesheets \
   client/sass

--- a/runner/src/server/index.js
+++ b/runner/src/server/index.js
@@ -106,11 +106,13 @@ async function createServer (routeConfig) {
     if (request.response && request.response.header) {
       request.response.header('X-Robots-Tag', 'noindex, nofollow')
 
-      const WEBFONT_EXTENSIONS = /\.(?:eot|ttf|woff|svg)$/i
+      const WEBFONT_EXTENSIONS = /\.(?:eot|ttf|woff|svg|woff2)$/i
       if (!WEBFONT_EXTENSIONS.test(request.url)) {
         request.response.header('cache-control', 'private, no-cache, no-store, must-revalidate, max-age=0')
         request.response.header('pragma', 'no-cache')
         request.response.header('expires', '0')
+      } else {
+        request.response.header('cache-control', 'public, max-age=604800, immutable')
       }
     }
     return h.continue

--- a/runner/src/server/index.js
+++ b/runner/src/server/index.js
@@ -102,11 +102,16 @@ async function createServer (routeConfig) {
     if (request.response.isBoom) {
       return h.continue
     }
+
     if (request.response && request.response.header) {
       request.response.header('X-Robots-Tag', 'noindex, nofollow')
-      request.response.header('cache-control', 'private, no-cache, no-store, must-revalidate, max-age=0')
-      request.response.header('pragma', 'no-cache')
-      request.response.header('expires', '0')
+
+      const WEBFONT_EXTENSIONS = /\.(?:eot|ttf|woff|svg)$/i
+      if (!WEBFONT_EXTENSIONS.test(request.url)) {
+        request.response.header('cache-control', 'private, no-cache, no-store, must-revalidate, max-age=0')
+        request.response.header('pragma', 'no-cache')
+        request.response.header('expires', '0')
+      }
     }
     return h.continue
   })

--- a/runner/views/layout.html
+++ b/runner/views/layout.html
@@ -7,7 +7,12 @@
 
 {% block head %}
   <!--[if !IE 8]><!-->
+    <link rel="preload" as="font" href="{{ assetPath }}/fonts/bold-b542beb274-v2.woff2" type="font/woff2" crossorigin="anonymous">
+    <link rel="preload" as="font" href="{{ assetPath }}/fonts/bold-b542beb274-v2.woff2" type="font/woff2" crossorigin="anonymous">
+    <link rel="preload" as="font" href="{{ assetPath }}/fonts/bold-affa96571d-v2.woff" type="font/woff" crossorigin="anonymous">
+    <link rel="preload" as="font" href="{{ assetPath }}/fonts/light-f591b13f7d-v2.woff" type="font/woff" crossorigin="anonymous">
     <link href="{{ assetPath }}/stylesheets/application.css" rel="stylesheet" />
+
   <!--<![endif]-->
 
   {# For Internet Explorer 8, you need to compile specific stylesheet #}


### PR DESCRIPTION
# Description
Closes: #53 
- Added font preloading 
  - I'm not sure why the font files have a hash on them. presumably if design system changes we will have to change it here too.
- Added explicit caching for font files
- building css in compressed mode  


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] click testing with throttled network (slow 3G is most obvious, chrome devTool thing)
- [x] checked response headers for cache control 
![Screenshot 2020-07-15 at 12 50 11](https://user-images.githubusercontent.com/22080510/87541772-ba881d80-c699-11ea-85f2-74470c18a074.png)


# Checklist:

- [x] My code follows the [javascript standard style](https://standardjs.com/)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto master and there are no code conflicts




