### PR TITLE
Path override

### DIFF
--- a/designer/client/helpers.js
+++ b/designer/client/helpers.js
@@ -55,5 +55,5 @@ export function getFormData (form) {
 }
 
 export function toUrl (title) {
-  return '/'.concat(title.replace(/[^a-zA-Z ]/g, '').trim().replace(/ +/g, '-')).toLowerCase()
+  return '/'.concat(title.replace(/[^a-zA-Z0-9- ]/g, '').trim().replace(/ +/g, '-')).toLowerCase()
 }

--- a/designer/client/helpers.js
+++ b/designer/client/helpers.js
@@ -55,5 +55,5 @@ export function getFormData (form) {
 }
 
 export function toUrl (title) {
-  return '/'.concat((title?.replace(/[^a-zA-Z0-9- ]/g, '')??'').trim().replace(/ +/g, '-')).toLowerCase()
+  return `/${(title?.replace(/[^a-zA-Z0-9- ]/g, '')??'').trim().replace(/ +/g, '-').toLowerCase()}`
 }

--- a/designer/client/helpers.js
+++ b/designer/client/helpers.js
@@ -55,5 +55,5 @@ export function getFormData (form) {
 }
 
 export function toUrl (title) {
-  return '/'.concat(title.replace(/[^a-zA-Z0-9- ]/g, '').trim().replace(/ +/g, '-')).toLowerCase()
+  return '/'.concat((title?.replace(/[^a-zA-Z0-9- ]/g, '')??'').trim().replace(/ +/g, '-')).toLowerCase()
 }

--- a/designer/client/page-create.js
+++ b/designer/client/page-create.js
@@ -14,7 +14,7 @@ class PageCreate extends React.Component {
     const section = this.state.section?.trim()
     const pageType = this.state.pageType?.trim()
     const selectedCondition = this.state.selectedCondition?.trim()
-    const path = this.generatePath(title, data)
+    const path = this.state.path || this.state.generatedPath
 
     const value = {
       path,
@@ -61,7 +61,7 @@ class PageCreate extends React.Component {
   render () {
     const { data } = this.props
     const { sections, pages } = data
-    const { pageType, linkFrom, title, section } = this.state
+    const { pageType, linkFrom, title, section, path, generatedPath } = this.state
 
     return (
       <form onSubmit={e => this.onSubmit(e)} autoComplete='off'>
@@ -87,8 +87,16 @@ class PageCreate extends React.Component {
         <div className='govuk-form-group'>
           <label className='govuk-label govuk-label--s' htmlFor='page-title'>Title</label>
           <input className='govuk-input' id='page-title' name='title'
-            type='text' aria-describedby='page-title-hint' required onBlur={this.onBlurTitle}
-            defaultValue={title} />
+            type='text' aria-describedby='page-title-hint' required onChange={this.onChangeTitle}
+            value={title || ''} />
+        </div>
+
+        <div className='govuk-form-group'>
+          <label className='govuk-label govuk-label--s' htmlFor='page-path'>Path</label>
+          <span className='govuk-hint'>The path of this page e.g. '/personal-details'.</span>
+          <input className='govuk-input' id='page-path' name='path'
+            type='text' aria-describedby='page-path-hint' required
+            value={path || generatedPath || ''} onChange={this.onChangePath} />
         </div>
 
         <div className='govuk-form-group'>
@@ -118,10 +126,22 @@ class PageCreate extends React.Component {
     })
   }
 
-  onBlurTitle = e => {
+  onChangeTitle = e => {
+    const { data } = this.props
     const input = e.target
+    const title = input.value
     this.setState({
-      title: input.value
+      title: title,
+      generatedPath: this.generatePath(title, data)
+    })
+  }
+
+  onChangePath = e => {
+    const input = e.target
+    const path = input.value.startsWith('/') ? input.value : `/${input.value}`
+    const sanitizedPath = path.replace(/\s/g, '-')
+    this.setState({
+      path: sanitizedPath
     })
   }
 

--- a/designer/client/page-create.js
+++ b/designer/client/page-create.js
@@ -139,9 +139,9 @@ class PageCreate extends React.Component {
   onChangePath = e => {
     const input = e.target
     const path = input.value.startsWith('/') ? input.value : `/${input.value}`
-    const sanitizedPath = path.replace(/\s/g, '-')
+    const sanitisedPath = path.replace(/\s/g, '-')
     this.setState({
-      path: sanitizedPath
+      path: sanitisedPath
     })
   }
 

--- a/designer/client/page-edit.js
+++ b/designer/client/page-edit.js
@@ -3,7 +3,10 @@ import { toUrl } from './helpers'
 import { clone } from 'digital-form-builder-model/lib/helpers'
 
 class PageEdit extends React.Component {
-  state = {}
+  constructor (props) {
+    super(props)
+    this.state = props.page.path !== this.generatePath(props.page.title) ? { path: props.page.path } : {}
+  }
 
   onSubmit = e => {
     e.preventDefault()

--- a/designer/client/page-edit.js
+++ b/designer/client/page-edit.js
@@ -10,7 +10,7 @@ class PageEdit extends React.Component {
     const form = e.target
     const formData = new window.FormData(form)
     const title = formData.get('title').trim()
-    const newPath = toUrl(title)
+    const newPath = formData.get('path').trim()
     const section = formData.get('section').trim()
     const pageType = formData.get('page-type').trim()
     const { data, page } = this.props
@@ -119,9 +119,43 @@ class PageEdit extends React.Component {
       })
   }
 
+  onChangeTitle = e => {
+    const input = e.target
+    const title = input.value
+    this.setState({
+      title: title,
+      generatedPath: this.generatePath(title)
+    })
+  }
+
+  onChangePath = e => {
+    const input = e.target
+    const path = input.value.startsWith('/') ? input.value : `/${input.value}`
+    const sanitizedPath = path.replace(/\s/g, '-')
+    this.setState({
+      path: sanitizedPath
+    })
+  }
+
+  generatePath (title) {
+    let path = toUrl(title)
+    const { data, page } = this.props
+
+    let count = 1
+    while (data.findPage(path) && page.title !== title) {
+      if (count > 1) {
+        path = path.substr(0, path.length - 2)
+      }
+      path = `${path}-${count}`
+      count++
+    }
+    return path
+  }
+
   render () {
     const { data, page } = this.props
     const { sections } = data
+    const { title, path, generatedPath } = this.state
 
     return (
       <form onSubmit={this.onSubmit} autoComplete='off'>
@@ -136,8 +170,16 @@ class PageEdit extends React.Component {
 
         <div className='govuk-form-group'>
           <label className='govuk-label govuk-label--s' htmlFor='page-title'>Title</label>
-          <input className='govuk-input' id='page-title' name='title' type='text' defaultValue={page.title}
-            aria-describedby='page-title-hint' required />
+          <input className='govuk-input' id='page-title' name='title' type='text' value={title || page.title}
+            aria-describedby='page-title-hint' required onChange={this.onChangeTitle} />
+        </div>
+
+        <div className='govuk-form-group'>
+          <label className='govuk-label govuk-label--s' htmlFor='page-path'>Path</label>
+          <span className='govuk-hint'>The path of this page e.g. '/personal-details'.</span>
+          <input className='govuk-input' id='page-path' name='path'
+            type='text' aria-describedby='page-path-hint' required
+            value={path || generatedPath || page.path} onChange={this.onChangePath} />
         </div>
 
         <div className='govuk-form-group'>

--- a/designer/client/page-edit.js
+++ b/designer/client/page-edit.js
@@ -31,6 +31,8 @@ class PageEdit extends React.Component {
         return
       }
 
+      data.updateLinksTo(page.path, newPath)
+
       copyPage.path = newPath
 
       if (pageIndex === 0) {

--- a/designer/client/page-edit.js
+++ b/designer/client/page-edit.js
@@ -162,11 +162,16 @@ class PageEdit extends React.Component {
     const { sections } = data
     const { title, path, generatedPath, controller, section } = this.state
 
+    const configuredController = controller || page.controller || ''
+    const configuredPath = path || generatedPath || page.path
+    const configuredTitle = title || page.title
+    const configuredSection = section || page.section || ''
+
     return (
       <form onSubmit={this.onSubmit} autoComplete='off'>
         <div className='govuk-form-group'>
           <label className='govuk-label govuk-label--s' htmlFor='page-type'>Page Type</label>
-          <select className='govuk-select' id='page-type' name='page-type' value={controller || page.controller || ''}
+          <select className='govuk-select' id='page-type' name='page-type' value={configuredController}
             onChange={e => this.setState({ controller: e.target.value })}>
             <option value=''>Question Page</option>
             <option value='./pages/start.js'>Start Page</option>
@@ -176,7 +181,7 @@ class PageEdit extends React.Component {
 
         <div className='govuk-form-group'>
           <label className='govuk-label govuk-label--s' htmlFor='page-title'>Title</label>
-          <input className='govuk-input' id='page-title' name='title' type='text' value={title || page.title}
+          <input className='govuk-input' id='page-title' name='title' type='text' value={configuredTitle}
             aria-describedby='page-title-hint' required onChange={this.onChangeTitle} />
         </div>
 
@@ -185,12 +190,12 @@ class PageEdit extends React.Component {
           <span className='govuk-hint'>The path of this page e.g. '/personal-details'.</span>
           <input className='govuk-input' id='page-path' name='path'
             type='text' aria-describedby='page-path-hint' required
-            value={path || generatedPath || page.path} onChange={this.onChangePath} />
+            value={configuredPath} onChange={this.onChangePath} />
         </div>
 
         <div className='govuk-form-group'>
           <label className='govuk-label govuk-label--s' htmlFor='page-section'>Section (optional)</label>
-          <select className='govuk-select' id='page-section' name='section' value={section || page.section || ''}
+          <select className='govuk-select' id='page-section' name='section' value={configuredSection}
             onChange={e => this.setState({ section: e.target.value })}>
             <option />
             {sections.map(section => (<option key={section.name} value={section.name}>{section.title}</option>))}

--- a/designer/client/page-edit.js
+++ b/designer/client/page-edit.js
@@ -160,13 +160,14 @@ class PageEdit extends React.Component {
   render () {
     const { data, page } = this.props
     const { sections } = data
-    const { title, path, generatedPath } = this.state
+    const { title, path, generatedPath, controller, section } = this.state
 
     return (
       <form onSubmit={this.onSubmit} autoComplete='off'>
         <div className='govuk-form-group'>
           <label className='govuk-label govuk-label--s' htmlFor='page-type'>Page Type</label>
-          <select className='govuk-select' id='page-type' name='page-type' defaultValue={page.controller || ''}>
+          <select className='govuk-select' id='page-type' name='page-type' value={controller || page.controller || ''}
+            onChange={e => this.setState({ controller: e.target.value })}>
             <option value=''>Question Page</option>
             <option value='./pages/start.js'>Start Page</option>
             <option value='./pages/summary.js'>Summary Page</option>
@@ -189,7 +190,8 @@ class PageEdit extends React.Component {
 
         <div className='govuk-form-group'>
           <label className='govuk-label govuk-label--s' htmlFor='page-section'>Section (optional)</label>
-          <select className='govuk-select' id='page-section' name='section' defaultValue={page.section}>
+          <select className='govuk-select' id='page-section' name='section' value={section || page.section || ''}
+            onChange={e => this.setState({ section: e.target.value })}>
             <option />
             {sections.map(section => (<option key={section.name} value={section.name}>{section.title}</option>))}
           </select>

--- a/designer/test/page-create.test.js
+++ b/designer/test/page-create.test.js
@@ -39,6 +39,7 @@ suite('Page create', () => {
       { value: './pages/summary.js', text: 'Summary Page' }
     ])
     assertTextInput(wrapper.find('#page-title'), 'page-title')
+    assertTextInput(wrapper.find('#page-path'), 'page-path')
     assertSelectInput(wrapper.find('#link-from'), 'link-from', [
       { text: '' },
       { value: '/1', text: '/1' },

--- a/designer/test/page-create.test.js
+++ b/designer/test/page-create.test.js
@@ -55,11 +55,11 @@ suite('Page create', () => {
   test('Inputs remain populated when amending other fields', () => {
     const wrapper = shallow(<PageCreate data={data} />)
     wrapper.find('#page-type').simulate('change', { target: { value: './pages/start.js' } })
-    wrapper.find('#page-title').simulate('blur', { target: { value: 'New Page' } })
+    wrapper.find('#page-title').simulate('change', { target: { value: 'New Page' } })
     wrapper.find('#link-from').simulate('change', { target: { value: '/2' } })
     wrapper.find('#page-section').simulate('change', { target: { value: 'personalDetails' } })
 
-    assertTextInput(wrapper.find('#page-title'), 'page-title', 'New Page')
+    assertTextInput(wrapper.find('#page-title'), 'page-title', undefined, { value: 'New Page' })
     assertSelectInput(wrapper.find('#link-from'), 'link-from', [
       { text: '' },
       { value: '/1', text: '/1' },
@@ -113,7 +113,7 @@ suite('Page create', () => {
       const wrapper = shallow(<PageCreate data={data} onCreate={wrappedOnCreate} />)
       const preventDefault = sinon.spy()
       wrapper.find('#page-type').simulate('change', { target: { value: './pages/start.js' } })
-      wrapper.find('#page-title').simulate('blur', { target: { value: 'New Page' } })
+      wrapper.find('#page-title').simulate('change', { target: { value: 'New Page' } })
       wrapper.find('#link-from').simulate('change', { target: { value: '/2' } })
       wrapper.find('#page-section').simulate('change', { target: { value: 'personalDetails' } })
 
@@ -161,7 +161,7 @@ suite('Page create', () => {
       const wrapper = shallow(<PageCreate data={data} onCreate={wrappedOnCreate} />)
       const preventDefault = sinon.spy()
       wrapper.find('#page-type').simulate('change', { target: { value: './pages/start.js' } })
-      wrapper.find('#page-title').simulate('blur', { target: { value: 'New Page' } })
+      wrapper.find('#page-title').simulate('change', { target: { value: 'New Page' } })
       wrapper.find('#link-from').simulate('change', { target: { value: '/2' } })
       wrapper.find('#page-section').simulate('change', { target: { value: 'personalDetails' } })
 
@@ -204,7 +204,7 @@ suite('Page create', () => {
       const wrapper = shallow(<PageCreate data={data} onCreate={wrappedOnCreate} />)
       const preventDefault = sinon.spy()
       wrapper.find('#page-type').simulate('change', { target: { value: './pages/start.js' } })
-      wrapper.find('#page-title').simulate('blur', { target: { value: 'New Page' } })
+      wrapper.find('#page-title').simulate('change', { target: { value: 'New Page' } })
 
       data.clone = sinon.stub()
       data.clone.returns(clonedData)
@@ -219,7 +219,7 @@ suite('Page create', () => {
 
     test('translated title to path automatically if no path provided', async flags => {
       const expectedPage = {
-        path: '/my-new-page',
+        path: '/my-new-page-23',
         title: 'My New    Page 23?!¢#',
         controller: './pages/start.js',
         next: [],
@@ -239,7 +239,112 @@ suite('Page create', () => {
       const wrapper = shallow(<PageCreate data={data} onCreate={wrappedOnCreate} />)
       const preventDefault = sinon.spy()
       wrapper.find('#page-type').simulate('change', { target: { value: './pages/start.js' } })
-      wrapper.find('#page-title').simulate('blur', { target: { value: 'My New    Page 23?!¢#' } })
+      wrapper.find('#page-title').simulate('change', { target: { value: 'My New    Page 23?!¢#' } })
+
+      data.clone = sinon.stub()
+      data.clone.returns(clonedData)
+      clonedData.addLink.returns(clonedData)
+      clonedData.addPage.returns(clonedData)
+
+      await wrapper.instance().onSubmit({ preventDefault: preventDefault })
+      expect(clonedData.addPage.calledOnce).to.equal(true)
+      expect(clonedData.addPage.firstCall.args[0]).to.equal(expectedPage)
+    })
+
+    test('Generated path ignored when a path is provided', async flags => {
+      const expectedPage = {
+        path: '/dancing-badgers',
+        title: 'My New    Page 23?!¢#',
+        controller: './pages/start.js',
+        next: [],
+        components: []
+      }
+      const onCreate = data => {
+        expect(data.value).to.equal(expectedPage)
+      }
+      const clonedData = {
+        addPage: sinon.stub(),
+        addLink: sinon.stub()
+      }
+      data.save = sinon.stub()
+      data.save.resolves(clonedData)
+      const wrappedOnCreate = flags.mustCall(onCreate, 1)
+
+      const wrapper = shallow(<PageCreate data={data} onCreate={wrappedOnCreate} />)
+      const preventDefault = sinon.spy()
+      wrapper.find('#page-type').simulate('change', { target: { value: './pages/start.js' } })
+      wrapper.find('#page-path').simulate('change', { target: { value: 'dancing-badgers' } })
+      wrapper.find('#page-title').simulate('change', { target: { value: 'My New    Page 23?!¢#' } })
+
+      data.clone = sinon.stub()
+      data.clone.returns(clonedData)
+      clonedData.addLink.returns(clonedData)
+      clonedData.addPage.returns(clonedData)
+
+      await wrapper.instance().onSubmit({ preventDefault: preventDefault })
+      expect(clonedData.addPage.calledOnce).to.equal(true)
+      expect(clonedData.addPage.firstCall.args[0]).to.equal(expectedPage)
+    })
+
+    test('Generated path ignored when a path is provided with a leading /', async flags => {
+      const expectedPage = {
+        path: '/dancing-badgers',
+        title: 'My New    Page 23?!¢#',
+        controller: './pages/start.js',
+        next: [],
+        components: []
+      }
+      const onCreate = data => {
+        expect(data.value).to.equal(expectedPage)
+      }
+      const clonedData = {
+        addPage: sinon.stub(),
+        addLink: sinon.stub()
+      }
+      data.save = sinon.stub()
+      data.save.resolves(clonedData)
+      const wrappedOnCreate = flags.mustCall(onCreate, 1)
+
+      const wrapper = shallow(<PageCreate data={data} onCreate={wrappedOnCreate} />)
+      const preventDefault = sinon.spy()
+      wrapper.find('#page-type').simulate('change', { target: { value: './pages/start.js' } })
+      wrapper.find('#page-path').simulate('change', { target: { value: '/dancing-badgers' } })
+      wrapper.find('#page-title').simulate('change', { target: { value: 'My New    Page 23?!¢#' } })
+
+      data.clone = sinon.stub()
+      data.clone.returns(clonedData)
+      clonedData.addLink.returns(clonedData)
+      clonedData.addPage.returns(clonedData)
+
+      await wrapper.instance().onSubmit({ preventDefault: preventDefault })
+      expect(clonedData.addPage.calledOnce).to.equal(true)
+      expect(clonedData.addPage.firstCall.args[0]).to.equal(expectedPage)
+    })
+
+    test('Whitespace in paths is replaced with hyphens', async flags => {
+      const expectedPage = {
+        path: '/dancing--badger-s',
+        title: 'My New    Page 23?!¢#',
+        controller: './pages/start.js',
+        next: [],
+        components: []
+      }
+      const onCreate = data => {
+        expect(data.value).to.equal(expectedPage)
+      }
+      const clonedData = {
+        addPage: sinon.stub(),
+        addLink: sinon.stub()
+      }
+      data.save = sinon.stub()
+      data.save.resolves(clonedData)
+      const wrappedOnCreate = flags.mustCall(onCreate, 1)
+
+      const wrapper = shallow(<PageCreate data={data} onCreate={wrappedOnCreate} />)
+      const preventDefault = sinon.spy()
+      wrapper.find('#page-type').simulate('change', { target: { value: './pages/start.js' } })
+      wrapper.find('#page-path').simulate('change', { target: { value: 'dancing  badger s' } })
+      wrapper.find('#page-title').simulate('change', { target: { value: 'My New    Page 23?!¢#' } })
 
       data.clone = sinon.stub()
       data.clone.returns(clonedData)

--- a/designer/test/page-edit.test.js
+++ b/designer/test/page-edit.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme'
 import * as Code from '@hapi/code'
 import * as Lab from '@hapi/lab'
 import PageEdit from '../client/page-edit'
-import { Data } from '../client/model/data-model'
+import { Data } from 'digital-form-builder-model'
 import { assertTextInput, assertSelectInput } from './helpers/element-assertions'
 
 const { expect } = Code

--- a/designer/test/page-edit.test.js
+++ b/designer/test/page-edit.test.js
@@ -1,0 +1,218 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import * as Code from '@hapi/code'
+import * as Lab from '@hapi/lab'
+import PageEdit from '../client/page-edit'
+import { Data } from '../client/model/data-model'
+import { assertTextInput, assertSelectInput } from './helpers/element-assertions'
+
+const { expect } = Code
+const lab = Lab.script()
+exports.lab = lab
+const { suite, test } = lab
+
+suite('Page edit', () => {
+  test('Renders a form with the appropriate initial inputs', () => {
+    const data = new Data({
+      pages: [
+        { path: '/1', title: 'My first page', section: 'badger', controller: './pages/start.js' }
+      ],
+      sections: [
+        {
+          name: 'badger',
+          title: 'Badger'
+        },
+        {
+          name: 'personalDetails',
+          title: 'Personal Details'
+        }
+      ]
+    })
+
+    const wrapper = shallow(<PageEdit data={data} page={data.pages[0]} />)
+
+    assertSelectInput(wrapper.find('#page-type'), 'page-type', [
+      { value: '', text: 'Question Page' },
+      { value: './pages/start.js', text: 'Start Page' },
+      { value: './pages/summary.js', text: 'Summary Page' }
+    ], './pages/start.js')
+    assertTextInput(wrapper.find('#page-title'), 'page-title', undefined, { value: 'My first page' })
+    assertTextInput(wrapper.find('#page-path'), 'page-path', undefined, { value: '/1' })
+
+    assertSelectInput(wrapper.find('#page-section'), 'page-section', [
+      { text: '' },
+      { value: 'badger', text: 'Badger' },
+      { value: 'personalDetails', text: 'Personal Details' }
+    ], 'badger')
+    const buttons = wrapper.find('button')
+    expect(buttons.length).to.equal(3)
+    expect(buttons.at(0).text()).to.equal('Save')
+    expect(buttons.at(1).text()).to.equal('Duplicate')
+    expect(buttons.at(2).text()).to.equal('Delete')
+  })
+
+  test('Renders a form with the appropriate initial inputs when no section or controller selected', () => {
+    const data = new Data({
+      pages: [
+        { path: '/1', title: 'My first page' }
+      ],
+      sections: [
+        {
+          name: 'badger',
+          title: 'Badger'
+        },
+        {
+          name: 'personalDetails',
+          title: 'Personal Details'
+        }
+      ]
+    })
+
+    const wrapper = shallow(<PageEdit data={data} page={data.pages[0]} />)
+
+    assertSelectInput(wrapper.find('#page-type'), 'page-type', [
+      { value: '', text: 'Question Page' },
+      { value: './pages/start.js', text: 'Start Page' },
+      { value: './pages/summary.js', text: 'Summary Page' }
+    ], '')
+    assertTextInput(wrapper.find('#page-title'), 'page-title', undefined, { value: 'My first page' })
+    assertTextInput(wrapper.find('#page-path'), 'page-path', undefined, { value: '/1' })
+
+    assertSelectInput(wrapper.find('#page-section'), 'page-section', [
+      { text: '' },
+      { value: 'badger', text: 'Badger' },
+      { value: 'personalDetails', text: 'Personal Details' }
+    ], '')
+    const buttons = wrapper.find('button')
+    expect(buttons.length).to.equal(3)
+    expect(buttons.at(0).text()).to.equal('Save')
+    expect(buttons.at(1).text()).to.equal('Duplicate')
+    expect(buttons.at(2).text()).to.equal('Delete')
+  })
+
+  test('Updating the title changes the path if the path is the auto-generated one', () => {
+    const data = new Data({
+      pages: [
+        { path: '/my-first-page', title: 'My first page' }
+      ],
+      sections: [
+        {
+          name: 'badger',
+          title: 'Badger'
+        },
+        {
+          name: 'personalDetails',
+          title: 'Personal Details'
+        }
+      ]
+    })
+
+    const wrapper = shallow(<PageEdit data={data} page={data.pages[0]} />)
+    wrapper.find('#page-title').simulate('change', { target: { value: 'New Page' } })
+
+    assertTextInput(wrapper.find('#page-title'), 'page-title', undefined, { value: 'New Page' })
+    assertTextInput(wrapper.find('#page-path'), 'page-path', undefined, { value: '/new-page' })
+  })
+
+  test('Updating the title changes the path if the path is the auto-generated one for no title', () => {
+    const data = new Data({
+      pages: [
+        { path: '/' }
+      ],
+      sections: [
+        {
+          name: 'badger',
+          title: 'Badger'
+        },
+        {
+          name: 'personalDetails',
+          title: 'Personal Details'
+        }
+      ]
+    })
+
+    const wrapper = shallow(<PageEdit data={data} page={data.pages[0]} />)
+    wrapper.find('#page-title').simulate('change', { target: { value: 'New Page' } })
+
+    assertTextInput(wrapper.find('#page-title'), 'page-title', undefined, { value: 'New Page' })
+    assertTextInput(wrapper.find('#page-path'), 'page-path', undefined, { value: '/new-page' })
+  })
+
+  test('Updating the title does not change the path if the path is not the auto-generated one', () => {
+    const data = new Data({
+      pages: [
+        { path: '/1', title: 'My first page' }
+      ],
+      sections: [
+        {
+          name: 'badger',
+          title: 'Badger'
+        },
+        {
+          name: 'personalDetails',
+          title: 'Personal Details'
+        }
+      ]
+    })
+
+    const wrapper = shallow(<PageEdit data={data} page={data.pages[0]} />)
+    wrapper.find('#page-title').simulate('change', { target: { value: 'New Page' } })
+
+    assertTextInput(wrapper.find('#page-title'), 'page-title', undefined, { value: 'New Page' })
+    assertTextInput(wrapper.find('#page-path'), 'page-path', undefined, { value: '/1' })
+  })
+
+  test('Changing the section causes the new section to be selected', () => {
+    const data = new Data({
+      pages: [
+        { path: '/1', title: 'My first page' }
+      ],
+      sections: [
+        {
+          name: 'badger',
+          title: 'Badger'
+        },
+        {
+          name: 'personalDetails',
+          title: 'Personal Details'
+        }
+      ]
+    })
+
+    const wrapper = shallow(<PageEdit data={data} page={data.pages[0]} />)
+    wrapper.find('#page-section').simulate('change', { target: { value: 'badger' } })
+
+    assertSelectInput(wrapper.find('#page-section'), 'page-section', [
+      { text: '' },
+      { value: 'badger', text: 'Badger' },
+      { value: 'personalDetails', text: 'Personal Details' }
+    ], 'badger')
+  })
+
+  test('Changing the controller causes the new controller to be selected', () => {
+    const data = new Data({
+      pages: [
+        { path: '/1', title: 'My first page' }
+      ],
+      sections: [
+        {
+          name: 'badger',
+          title: 'Badger'
+        },
+        {
+          name: 'personalDetails',
+          title: 'Personal Details'
+        }
+      ]
+    })
+
+    const wrapper = shallow(<PageEdit data={data} page={data.pages[0]} />)
+    wrapper.find('#page-type').simulate('change', { target: { value: './pages/summary.js' } })
+
+    assertSelectInput(wrapper.find('#page-type'), 'page-type', [
+      { value: '', text: 'Question Page' },
+      { value: './pages/start.js', text: 'Start Page' },
+      { value: './pages/summary.js', text: 'Summary Page' }
+    ], './pages/summary.js')
+  })
+})

--- a/model/src/data-model.js
+++ b/model/src/data-model.js
@@ -91,6 +91,14 @@ class Data {
     return this
   }
 
+  updateLinksTo = function (oldPath, newPath) {
+    this.pages.filter(p => p.next && p.next.find(link => link.path === oldPath))
+      .forEach(page => {
+        page.next.find(link => link.path === oldPath).path = newPath
+      })
+    return this
+  }
+
   addPage (page) {
     this.pages = this.pages || []
     this.pages.push(page)

--- a/model/test/data-model.test.js
+++ b/model/test/data-model.test.js
@@ -798,6 +798,70 @@ suite('data model', () => {
     })
   })
 
+  describe('update links to', () => {
+    test('should update all links pointing to the specified path to the new path', () => {
+      const data = new Data({
+        pages: [
+          {
+            name: 'page0',
+            path: '/0',
+            next: [{ path: '/2', condition: 'badgers' }],
+            components: [{ name: 'name1' }, { name: 'name2' }]
+          },
+          {
+            name: 'page1',
+            section: 'section1',
+            path: '/1',
+            next: [{ path: '/2' }],
+            components: [{ name: 'name1' }, { name: 'name2' }]
+          },
+          {
+            name: 'page2',
+            section: 'section1',
+            path: '/2',
+            next: [{ path: '/3' }],
+            components: [{ name: 'name3' }, { name: 'name4' }]
+          },
+          {
+            name: 'page3',
+            section: 'section1',
+            path: '/3',
+            components: []
+          }
+        ]
+      })
+
+      const returned = data.updateLinksTo('/2', '/7')
+
+      expect(returned.findPage(('/0'))).to.equal({
+        name: 'page0',
+        path: '/0',
+        next: [{ path: '/7', condition: 'badgers' }],
+        components: [{ name: 'name1' }, { name: 'name2' }]
+      })
+      expect(returned.findPage(('/1'))).to.equal({
+        name: 'page1',
+        section: 'section1',
+        path: '/1',
+        next: [{ path: '/7' }],
+        components: [{ name: 'name1' }, { name: 'name2' }]
+      })
+      expect(returned.findPage(('/2'))).to.equal({
+        name: 'page2',
+        section: 'section1',
+        path: '/2',
+        next: [{ path: '/3' }],
+        components: [{ name: 'name3' }, { name: 'name4' }]
+      })
+      expect(returned.findPage(('/3'))).to.equal({
+        name: 'page3',
+        section: 'section1',
+        path: '/3',
+        components: []
+      })
+    })
+  })
+
   describe('find page', () => {
     test('should return the page with the requested path if it exists', () => {
       const data = new Data({


### PR DESCRIPTION
# Description

Allow override of page paths and fix issue where links disappear when paths are amended

- Users now have a 'Path' input on page create and page edit
- Auto-generated path is displayed whenever the title is amended on create (unless the user has already amended the path)
- Auto-generated path is displayed whenever the title is amended on edit (unless the user has already amended the path during edit or the original creation)
- Fix issue whereby changes to the path causes links to disappear

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [X] Unit tests
- [X] Click testing 

# Checklist:

- [X] My code follows the [javascript standard style](https://standardjs.com/)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts




