### PR TITLE
Feature/stp 679 page title label

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -8,7 +8,8 @@
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-private-property-in-object",
     "@babel/plugin-proposal-private-methods",
-    "@babel/plugin-transform-runtime"
+    "@babel/plugin-transform-runtime",
+    "@babel/plugin-syntax-jsx"
   ]
 }
 

--- a/designer/client/page-edit.js
+++ b/designer/client/page-edit.js
@@ -182,7 +182,7 @@ class PageEdit extends React.Component {
         </div>
 
         <div className='govuk-form-group'>
-          <label className='govuk-label govuk-label--s' htmlFor='page-title'>Title</label>
+          <label className='govuk-label govuk-label--s' htmlFor='page-title'>Page Title</label>
           <input
             className='govuk-input' id='page-title' name='title' type='text' value={configuredTitle}
             aria-describedby='page-title-hint' required onChange={this.onChangeTitle}
@@ -191,7 +191,7 @@ class PageEdit extends React.Component {
 
         <div className='govuk-form-group'>
           <label className='govuk-label govuk-label--s' htmlFor='page-path'>Path</label>
-          <span className='govuk-hint'>The path of this page e.g. '/personal-details'.</span>
+          <span className='govuk-hint'>The path of this page e.g. &apos;/personal-details&apos;.</span>
           <input
             className='govuk-input' id='page-path' name='path'
             type='text' aria-describedby='page-path-hint' required


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Please also include any acceptance criteria if you have any.

- Rename input label "Title" to "Page Title".
- Fix lint warning.
- Add missing @babel/plugin-syntax-jsx configuration.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [X] Manually verified that page title input label is "Page Title".
- [X] EsLint is now correctly accepting jsx in js. 

# Checklist:

- [X] My changes do not introduce any new linting errors 
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts




