### PR TITLE
Added link to yarn installation and upgrade docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,19 @@
 # XGov Digital Form Builder
+
 [![Gitter](https://badges.gitter.im/XGovFormBuilder/Public.svg)](https://gitter.im/XGovFormBuilder/Public?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 This repository is a mono repo for
-  - @xgovformbuilder/[runner](https://github.com/XGovFormBuilder/digital-form-builder/tree/master/runner) - Hapi server which can 'run' a form from a JSON file
-  - @xgovformbuilder/[engine](https://github.com/XGovFormBuilder/digital-form-builder/tree/master/engine) - Plugin for the above hapi server which serves a schema and the components
-  - @xgovformbuilder/[designer](https://github.com/XGovFormBuilder/digital-form-builder/tree/master/designer) - A React app to aide in form building
-  - @xgovformbuilder/[model](https://github.com/XGovFormBuilder/digital-form-builder/tree/master/model) - Serves the data model and other helpers
 
-The repos are forked from [DEFRA's digital form builder](https://github.com/DEFRA/digital-form-builder). 
+- @xgovformbuilder/[runner](https://github.com/XGovFormBuilder/digital-form-builder/tree/master/runner) - Hapi server which can 'run' a form from a JSON file
+- @xgovformbuilder/[engine](https://github.com/XGovFormBuilder/digital-form-builder/tree/master/engine) - Plugin for the above hapi server which serves a schema and the components
+- @xgovformbuilder/[designer](https://github.com/XGovFormBuilder/digital-form-builder/tree/master/designer) - A React app to aide in form building
+- @xgovformbuilder/[model](https://github.com/XGovFormBuilder/digital-form-builder/tree/master/model) - Serves the data model and other helpers
 
-This is a (getting close to) zero-install yarn 2 workspaces repository. .yarnrc.yml allows us to align our yarn environments. Please commit any plugins in .yarn, but do not commit your .yarn/cache. CI will save and restore the caches. 
+The repos are forked from [DEFRA's digital form builder](https://github.com/DEFRA/digital-form-builder).
 
-Workspaces will deal with sym-linking the packages, so we do not have to manually run `yarn link`. 
+This is a (getting close to) zero-install yarn 2 workspaces repository. .yarnrc.yml allows us to align our yarn environments. Please commit any plugins in .yarn, but do not commit your .yarn/cache. CI will save and restore the caches.
+
+Workspaces will deal with sym-linking the packages, so we do not have to manually run `yarn link`.
 It will also deal with hoisting the node_modules for any packages that are shared between the repos, thus decreasing any install times. Hopefully it all just works™️.
 
 ## Setup
@@ -20,28 +22,27 @@ after forking or cloning this repository
 
 1. make sure you are using node >=12. `node --version`
 2. run `$ yarn` this should install the dependencies with yarn 2 (berry).
-  **you must use yarn 2**
+  **You must use yarn 2** [migrating from yarn 1](https://yarnpkg.com/getting-started/install)
 3. run `$ yarn build` this will build all the modules
 
-**always run scripts from the root directory.** ${workspace}/node_modules is unlikely to have the scripts or packages you need to run inside the workspace. 
+**always run scripts from the root directory.** ${workspace}/node_modules is unlikely to have the scripts or packages you need to run inside the workspace.
 By running in the root directory yarn 2 can resolve the scripts/packages properly.
-
 
 ### I want to...
 
-#### run a specific workspaces' script 
+#### run a specific workspaces' script
+
 `$ yarn runner/designer/engine/model name-of-script`
 
-
 #### run a script for each of the workspaces
+
 `$ yarn workspaces foreach run name-of-script`
 
-
 #### watch and build for changes across all repos
+
 I wouldn't recommend it unless you have a beefy processor.
 
 `$ yarn watch`
-
 
 #### add a dependency to all workspaces
 
@@ -53,30 +54,29 @@ I wouldn't recommend it unless you have a beefy processor.
     1. `$ mkdir myNewLib`
     2. `$ cd myNewlib`
     3. `$ yarn init`
-2. in the root `package.json` 
+2. in the root `package.json`
     1. add `myNewLib` to the `workspaces` object.
 
-
-
 ## Troubleshooting
+
 If you have any problems, submit an issue or send a message via gitter.
 
-#### Cannot resolve module `xxx`. [cannot-resolve-module]
+### Cannot resolve module `xxx`. [cannot-resolve-module]
+
 1. `$ yarn flow-mono create-symlinks`
 2. `$ yarn flow-mono install-types`
 3. `$ yarn flow-mono create-stubs`
 
-#### Error: ENOENT: no such file or directory, scandir 'xxx/node_modules/node-sass/vendor'
+### Error: ENOENT: no such file or directory, scandir 'xxx/node_modules/node-sass/vendor'
+
 `/vendor` is not present since it hasn't been built or rebuilt. You may also get this issue with `core-js`, `fsevents`, `nodemailer` etc.
 `$ yarn rebuild` to rebuild all the packages
 `$ yarn rebuild only node-sass` to rebuild just node-sass
 
-
-
-
 ## gotchas
 
 ### flow
+
 - We're using [flow](https://flow.org) for static type checking. For each of the modules (runner, engine, designer). To prevent issues with unresolved modules, flow-typed is run on postinstall.
 - Flag a file to be checked by flow with `// @flow` at the top of the file.
 - It's advisable to install the eslint plugin for your text editor, and set the parser to babel-eslint to catch any type errors.
@@ -84,12 +84,14 @@ If you have any problems, submit an issue or send a message via gitter.
 ### CI
 
 #### Build process
+
 1. Pushes to any branch will start the build process
 2. `.circleci/circle_trigger.sh` will check for any changes in our packages, and if builds have failed previously
 3. `circle_trigger.sh` will trigger a workflow via the API. It will pass the parameters model, engine, runner, designer (bool) to the workflow.
-4. If there are any changes to a workspace, it will be built and tested. 
-  - If an upstream dependency, like model or engine has changed, the downstream dependencies (engine, runner, designer) will also be built and tested. 
- 
+4. If there are any changes to a workspace, it will be built and tested.
+
+- If an upstream dependency, like model or engine has changed, the downstream dependencies (engine, runner, designer) will also be built and tested.
 
 ## contributions
+
 Issues and pull requests are welcome. Please check [CONTRIBUTING.md](https://github.com/XGovFormBuilder/digital-form-builder/tree/master/.github/CONTRIBUTING.md) first!


### PR DESCRIPTION
# Description

I had yarn installed but it was an older version and I wasn't sure how to update it to version 2 as required for the project. I updated the readme.md to include a link to the Yarn documentation for installing yarn and migrating from version 1 to 2 and small linting changes to the markdown.

## Type of change

Please delete options that are not relevant.

- [x] This change is a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Tested the link to ensure it links to the correct documentation
- [x] Read through the readme to ensure my addition makes sense

# Checklist:

- [x] My changes do not introduce any new linting errors 
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto master and there are no code conflicts




