### PR TITLE
Bug/path-is-not-populated-STP-749

### DIFF
--- a/designer/client/page-edit.js
+++ b/designer/client/page-edit.js
@@ -11,9 +11,8 @@ export class PageEdit extends React.Component {
   constructor (props) {
     super(props)
     const { page } = this.props
-    const path = page?.path !== this.generatePath(page.title) ? props.page.path : ''
     this.state = {
-      path,
+      path: page?.path ?? this.generatePath(page.title),
       controller: page?.controller ?? '',
       title: page?.title,
       section: page?.section ?? {},


### PR DESCRIPTION
# Description

- Changed how path is assigned. (No longer doing a check)

note: this will only work after change #147 

AC
Given I am adding a new page
when I type something into the title field
then it will auto-generate a path for me

Given I am editing a page with the title 'My Title' and the path '/my-title'
when I change the path to '/my-new-title' and click save
then I will see '/my-new-title' when editing the page again


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] click


# Checklist:

- [x] My changes do not introduce any new linting errors 
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto master and there are no code conflicts




