### PR TITLE
Chore/fix govuk jsx usage

### DIFF
--- a/designer/.babelrc.js
+++ b/designer/.babelrc.js
@@ -17,7 +17,7 @@ module.exports = {
     "@babel/plugin-transform-runtime",
     ["module-resolver", {
       "alias": {
-        '@govuk-jsx': path.join( path.dirname(require.resolve('@xgovformbuilder/govuk-react-jsx')), '/govuk/components')
+        '@govuk-jsx': path.join( path.dirname(require.resolve('@xgovformbuilder/govuk-react-jsx')), '/components')
       }
     }]
   ],

--- a/designer/.babelrc.js
+++ b/designer/.babelrc.js
@@ -1,4 +1,5 @@
-{
+const path = require('path')
+module.exports = {
   "presets": [
     ["@babel/preset-env",
       {
@@ -13,10 +14,15 @@
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-private-methods",
     "@babel/plugin-syntax-dynamic-import",
-    "@babel/plugin-transform-runtime"
+    "@babel/plugin-transform-runtime",
+    ["module-resolver", {
+      "alias": {
+        '@govuk-jsx': path.join( path.dirname(require.resolve('@xgovformbuilder/govuk-react-jsx')), '/govuk/components')
+      }
+    }]
   ],
   "exclude": [
-    "node_modules", 
+    "node_modules",
     "../node_modules/**"
   ]
 }

--- a/designer/client/component-type-edit.js
+++ b/designer/client/component-type-edit.js
@@ -2,7 +2,7 @@ import React from 'react'
 import Editor from './editor'
 import { ComponentTypes } from '@xgovformbuilder/model'
 import ComponentValues from './components/component-values'
-import { Textarea } from '@xgovformbuilder/govuk-react-jsx'
+import { Textarea } from '@govuk-jsx/textarea'
 import Name from './name'
 
 function updateComponent (component, modifier, updateModel) {

--- a/designer/client/components/component-values.js
+++ b/designer/client/components/component-values.js
@@ -4,7 +4,7 @@ import Flyout from '../flyout'
 import DefineComponentValue from './define-component-value'
 import { clone } from '@xgovformbuilder/model'
 import { RenderInPortal } from './render-in-portal'
-import { Radios } from '@xgovformbuilder/govuk-react-jsx'
+import { Radios } from '@govuk-jsx/radios'
 
 function updateComponent (component, modifier, updateModel) {
   modifier(component)

--- a/designer/client/components/define-component-value.js
+++ b/designer/client/components/define-component-value.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Textarea, Input } from '@xgovformbuilder/govuk-react-jsx'
+import { Textarea } from '@govuk-jsx/textarea'
+import { Input } from '@govuk-jsx/input'
 import SelectConditions from '../conditions/select-conditions'
 import { icons } from '../icons'
 import Flyout from '../flyout'

--- a/designer/client/conditions/select-conditions.js
+++ b/designer/client/conditions/select-conditions.js
@@ -2,7 +2,8 @@ import React from 'react'
 import InlineConditions from './inline-conditions'
 import { ConditionsModel } from '@xgovformbuilder/model'
 import Flyout from '../flyout'
-import { Hint, Select } from '@xgovformbuilder/govuk-react-jsx'
+import { Select } from '@govuk-jsx/select'
+import { Hint } from '@govuk-jsx/hint'
 
 class SelectConditions extends React.Component {
   constructor (props) {

--- a/designer/client/form-details.js
+++ b/designer/client/form-details.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import formConfigurationApi from './load-form-configurations'
-import { Radios } from '@xgovformbuilder/govuk-react-jsx'
+import { Radios } from '@govuk-jsx/radios'
 
 class FormDetails extends React.Component {
   constructor (props) {

--- a/designer/client/index.js
+++ b/designer/client/index.js
@@ -9,8 +9,6 @@ import { FlyoutContext } from './context'
 import './index.scss'
 import { initI18n, i18n } from './i18n'
 
-import { Textarea } from '@govuk-jsx/textarea'
-
 initI18n(i18n)
 
 /**
@@ -106,23 +104,6 @@ export class App extends React.Component {
       const data = new Data(this.state.data)
       return (
         <FlyoutContext.Provider value={flyoutContextProviderValue}>
-          <Textarea
-            id="field-hint"
-            name="hint"
-            rows={2}
-            label={{
-              className: 'govuk-label--s',
-              children: [
-                'Help Text (optional)'
-              ]
-            }}
-            hint={{
-              children: [
-                'Text can include HTML'
-              ]
-            }}
-            required={false}
-          />
           <div id='app'>
             <Menu data={data} id={this.state.id} updateDownloadedAt={this.updateDownloadedAt} updatePersona={this.updatePersona} />
             <Visualisation data={data} downloadedAt={this.state.downloadedAt} updatedAt={this.state.updatedAt} persona={this.state.persona} id={id} previewUrl={previewUrl} />

--- a/designer/client/index.js
+++ b/designer/client/index.js
@@ -9,6 +9,8 @@ import { FlyoutContext } from './context'
 import './index.scss'
 import { initI18n, i18n } from './i18n'
 
+import { Textarea } from '@govuk-jsx/textarea'
+
 initI18n(i18n)
 
 /**
@@ -104,6 +106,23 @@ export class App extends React.Component {
       const data = new Data(this.state.data)
       return (
         <FlyoutContext.Provider value={flyoutContextProviderValue}>
+          <Textarea
+            id="field-hint"
+            name="hint"
+            rows={2}
+            label={{
+              className: 'govuk-label--s',
+              children: [
+                'Help Text (optional)'
+              ]
+            }}
+            hint={{
+              children: [
+                'Text can include HTML'
+              ]
+            }}
+            required={false}
+          />
           <div id='app'>
             <Menu data={data} id={this.state.id} updateDownloadedAt={this.updateDownloadedAt} updatePersona={this.updatePersona} />
             <Visualisation data={data} downloadedAt={this.state.downloadedAt} updatedAt={this.state.updatedAt} persona={this.state.persona} id={id} previewUrl={previewUrl} />

--- a/designer/package.json
+++ b/designer/package.json
@@ -70,6 +70,7 @@
     "acorn": "7.2.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
+    "babel-plugin-module-resolver": "^4.0.0",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^6.1.1",
     "cross-env": "^7.0.2",

--- a/designer/test/.transform.js
+++ b/designer/test/.transform.js
@@ -1,5 +1,6 @@
 const Babel = require('@babel/core')
 let internals = {}
+const path = require('path')
 
 internals.transform = function (content, filename) {
   const regexp = new RegExp('node_modules')
@@ -7,43 +8,27 @@ internals.transform = function (content, filename) {
   const isGovUKFrontend = filename.indexOf('govuk-frontend') > -1
   const isGovUKReactJsx = filename.indexOf('govuk-react-jsx') > -1
 
-  if (isGovUKReactJsx) {
+  const stubber = (name) => {
     return `
       "use strict";
       Object.defineProperty(exports, "__esModule", {
         value: true
       });
-      Object.defineProperty(exports, 'Textarea', {
+      Object.defineProperty(exports, '${name}', {
         enumerable: true,
         get: function get() {
-          return function Textarea() { return 'textarea' }
-        }
-      });
-      Object.defineProperty(exports, 'Radios', {
-        enumerable: true,
-        get: function get() {
-          return function Radios() { return 'radios' }
-        }
-      });
-      Object.defineProperty(exports, 'Input', {
-        enumerable: true,
-        get: function get() {
-          return function Input() { return 'input' }
-        }
-      });
-      Object.defineProperty(exports, 'Hint', {
-        enumerable: true,
-        get: function get() {
-          return function Hint() { return 'hint' }
-        }
-      });
-      Object.defineProperty(exports, 'Select', {
-        enumerable: true,
-        get: function get() {
-          return function Select() { return 'select' }
+          return function ${name}() { return '${name}' }
         }
       });
     `
+  }
+
+  if (isGovUKReactJsx) {
+    if (filename.includes('radios')) {
+      return stubber('Radios')
+    } else if(filename.includes('select')) {
+      return stubber('Select')
+    }
   }
 
   if (isNodeModule) {
@@ -51,12 +36,10 @@ internals.transform = function (content, filename) {
   }
 
   let transformed = Babel.transform(content, {
-      presets: [    
+      presets: [
         "@babel/preset-flow",
         ["@babel/preset-env", {
-          "targets": {
-            "node": "12"
-          },
+          "targets": "> 0.25%, not dead"
         }]
       ],
       filename: filename,
@@ -70,11 +53,17 @@ internals.transform = function (content, filename) {
         "@babel/plugin-proposal-private-property-in-object",
         "@babel/plugin-proposal-private-methods",
         "@babel/plugin-transform-runtime",
+        "@babel/plugin-syntax-dynamic-import",
+        ["module-resolver", {
+          "alias": {
+            '@govuk-jsx': path.join( path.dirname(require.resolve('@xgovformbuilder/govuk-react-jsx')), '/components')
+          }
+        }]
       ],
       "exclude": ["node_modules/**"],
       ignore: ['../node_modules', 'node_modules']
     })
-  
+
   return transformed.code
 }
 

--- a/designer/test/.transform.js
+++ b/designer/test/.transform.js
@@ -39,7 +39,9 @@ internals.transform = function (content, filename) {
       presets: [
         "@babel/preset-flow",
         ["@babel/preset-env", {
-          "targets": "> 0.25%, not dead"
+          "targets": {
+            node: 12
+          }
         }]
       ],
       filename: filename,

--- a/designer/test/component-type-edit.test.js
+++ b/designer/test/component-type-edit.test.js
@@ -129,7 +129,12 @@ suite('Component type edit', () => {
         const wrapper = mount(<ComponentTypeEdit data={data} component={component} updateModel={updateModel}/>)
         const field = wrapper.find(`#${testCase.fieldId}`)
         expect(field.exists()).to.equal(true)
-        field.prop(testCase.event)({ target: { value: testCase.value } })
+        if (field.length > 1) {
+          field.first().prop(testCase.event)({ target: { value: testCase.value } })
+        } else {
+          field.prop(testCase.event)({ target: { value: testCase.value } })
+        }
+
         expect(updateModel.firstCall.args[0], JSON.stringify(testCase)).to.equal(testCase.expectedModel)
 
         expect(updateModel.callCount).to.equal(1)
@@ -146,7 +151,7 @@ suite('Component type edit', () => {
       const component = { type: componentType }
       const wrapper = shallow(<ComponentTypeEdit data={data} component={component} updateModel={updateModel} page={page}/>).dive()
 
-      const field = wrapper.find('ComponentValues')
+      const field = wrapper.find('ComponentValues').first()
       expect(field.exists()).to.equal(true)
       expect(Object.keys(field.props()).length).to.equal(5)
       expect(field.prop('component')).to.equal(component)

--- a/designer/test/flyout.test.js
+++ b/designer/test/flyout.test.js
@@ -5,6 +5,7 @@ import * as Lab from '@hapi/lab'
 import { useFlyoutEffect } from '../client/flyout'
 import { FlyoutContext } from '../client/context'
 import sinon from 'sinon'
+
 const { expect } = Code
 const lab = Lab.script()
 exports.lab = lab

--- a/designer/webpack.config.js
+++ b/designer/webpack.config.js
@@ -17,11 +17,6 @@ const client = {
     path: path.resolve(__dirname, 'dist', 'client'),
     filename: 'assets/[name].js'
   },
-  resolve: {
-    alias: {
-      '@govuk-jsx': require.resolve('@xgovformbuilder/govuk-react-jsx', { paths: ['module/govuk/components/'] })
-    }
-  },
   devtool: 'source-map',
   module: {
     rules: [

--- a/designer/webpack.config.js
+++ b/designer/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const nodeExternals = require('webpack-node-externals')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
-const babelOptions = require('./.babelrc.json')
+const babelOptions = require('./.babelrc.js')
 const CopyPlugin = require('copy-webpack-plugin')
 
 const devMode = process.env.NODE_ENV !== 'production'
@@ -16,6 +16,11 @@ const client = {
   output: {
     path: path.resolve(__dirname, 'dist', 'client'),
     filename: 'assets/[name].js'
+  },
+  resolve: {
+    alias: {
+      '@govuk-jsx': require.resolve('@xgovformbuilder/govuk-react-jsx', { paths: ['module/govuk/components/'] })
+    }
   },
   devtool: 'source-map',
   module: {


### PR DESCRIPTION
# Description

when using govuk-react-jsx, our tests end up breaking when using
`import { Textarea } from 'govuk-react-jsx'`. No tree shaking is happening, so actually everything gets imported. This is fine when we are building with webpack since we have the correct loaders, however when running the tests which is babel-runtime, it can't load files like .png for example (which is imported by the header component, nothing to do with `{ Textarea }`. 

There are also issues with radio, checkboxes, since it is doing a dynamic import of govuk-frontend's code, which requires `Window.Element`. We are stubbing those.

- Changed to use a module resolver
  - `@govuk-jsx/textarea` is resolving to `@xgovformbuilder/govuk-react-jsx/module/govuk/component/textarea`. 
- Stubbing radio and checkboxes

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Unit tests are passing


# Checklist:

- [x] My changes do not introduce any new linting errors 
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto master and there are no code conflicts




