### PR TITLE
Reduce size of Docker image by using Alpine image and multi-stage build

### DIFF
--- a/designer/Dockerfile
+++ b/designer/Dockerfile
@@ -1,13 +1,16 @@
-FROM node:12
-
-EXPOSE 3000
-
+FROM node:12-alpine3.12 AS build
 WORKDIR /usr/src/app
-
 COPY . .
-
+RUN apk add --no-cache bash
 RUN yarn
-RUN yarn build:dependencies
+RUN yarn model build
 RUN yarn build
 
-CMD [ "yarn", "designer", "start" ]
+FROM node:12-alpine3.12 AS run
+WORKDIR /usr/src/app
+COPY --from=build /usr/src/app/designer ./designer
+COPY --from=build /usr/src/app/model ./model
+COPY --from=build /usr/src/app/node_modules ./node_modules
+COPY --from=build /usr/src/app/package.json ./
+EXPOSE 3000
+CMD [ "yarn", "designer", "production" ]

--- a/designer/package.json
+++ b/designer/package.json
@@ -7,6 +7,7 @@
     "watch": "NODE_ENV=development webpack --mode development --watch",
     "build": "NODE_ENV=production webpack --mode production",
     "start": "nodemon dist/server.js",
+    "production": "NODE_ENV=production node dist/server.js",
     "dev": "concurrently 'yarn watch' 'yarn start'",
     "lint": "yarn run eslint ./",
     "fix-lint": "yarn run eslint ./ --fix",

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,13 +1,17 @@
-FROM node:12
-
-EXPOSE 3009
-
+FROM node:12-alpine3.12 AS build
 WORKDIR /usr/src/app
-
 COPY . .
-
+RUN apk add --no-cache bash
 RUN yarn
 RUN yarn build:dependencies
 RUN yarn build
 
-CMD [ "yarn", "runner", "start" ]
+FROM node:12-alpine3.12 AS run
+WORKDIR /usr/src/app
+COPY --from=build /usr/src/app/engine ./engine
+COPY --from=build /usr/src/app/model ./model
+COPY --from=build /usr/src/app/node_modules ./node_modules
+COPY --from=build /usr/src/app/runner ./runner
+COPY --from=build /usr/src/app/package.json ./
+EXPOSE 3009
+CMD [ "yarn", "runner", "production" ]

--- a/runner/package.json
+++ b/runner/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "start": "NODE_ENV=development node dist/index.js",
+    "production": "NODE_ENV=production node dist/index.js",
     "dev": "bash -c 'yarn run watch & NODE_ENV=development yarn node dist/index.js'",
     "build:css": "bin/build-css",
     "build": "yarn build:css && yarn babel-build",


### PR DESCRIPTION
# Description

The Docker images are extremely large - nearly 2GB. This change reduces the size by more than half by using an Alpine Linux based image and also a multi-stage build.

```
designer-alpine       latest              85a7703b7caf        12 minutes ago      802MB
runner-alpine         latest              1ad70aa02aa6        13 minutes ago      804MB
runner-node12         latest              14fbeaee1f14        4 hours ago         1.95GB
```

The image sizes could be reduced further by only including the production dependencies in the final image and not the devDependencies.  I had a look at this but don't know enough about yarn to get this working successfully.

- Use Alpine Linux based Docker image
- Change package.json to not use nodemon in production for designer and set NODE_ENV=production for runner

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Docker image builds tested locally

# Checklist:

- [ X] My changes do not introduce any new linting errors 
- [ X] I have performed a self-review of my own code
- [ N/A] I have commented my code, particularly in hard-to-understand areas
- [ N/A] I have made corresponding changes to the documentation and versioning
- [ N/A] My changes generate no new warnings
- [ N/A] I have added tests that prove my fix is effective or that my feature works
- [ N/A] New and existing unit tests pass locally with my changes
- [ X] I have rebased onto master and there are no code conflicts




