### PR TITLE
fix/empty-summary-page-with-new-forms

### DIFF
--- a/designer/new-form.json
+++ b/designer/new-form.json
@@ -1,10 +1,10 @@
 {
   "metadata": {},
-  "startPage": "/",
+  "startPage": "/first-page",
   "pages": [
     {
-      "title": "Question page",
-      "path": "/question-page",
+      "title": "First page",
+      "path": "/first-page",
       "components": []
     },
     {


### PR DESCRIPTION
# Description

Fix runner's summary page empty due to malformed new-form object. 

- Add correct `startPage` path to `new-form.json` .
- Rename `Question Page` to `First Page` (this is to try to add some clarity based on UX feedback yesterday).

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] I have manually tested the runner locally and cannot reproduce the bug anymore. 

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts
