### PR TITLE
Handle webhook response payload as string and test

### DIFF
--- a/runner/src/server/services/webhookService.ts
+++ b/runner/src/server/services/webhookService.ts
@@ -20,15 +20,20 @@ export class WebhookService {
       payload: JSON.stringify(data),
     });
 
-    if (typeof payload === "object") {
-      const { reference } = payload;
-      return reference;
-    }
-
     if (res.statusCode === 202) {
       // send dead letter queue message
     }
 
-    return "UNKNOWN";
+    if (typeof payload === "object") {
+      return payload.reference;
+    }
+
+    try {
+      const { reference } = JSON.parse(payload);
+      return reference;
+    } catch (error) {
+      console.error(error);
+      return "UNKNOWN";
+    }
   }
 }

--- a/runner/src/server/services/webhookService.ts
+++ b/runner/src/server/services/webhookService.ts
@@ -15,14 +15,10 @@ export class WebhookService {
    * @returns { string } webhookResponse.reference webhook should return with a reference number. If the call fails, the reference will be 'UNKNOWN'.
    */
   async postRequest(url: string, data: object) {
-    const { payload, res } = await post(url, {
+    const { payload } = await post(url, {
       ...DEFAULT_OPTIONS,
       payload: JSON.stringify(data),
     });
-
-    if (res.statusCode === 202) {
-      // send dead letter queue message
-    }
 
     if (typeof payload === "object") {
       return payload.reference;

--- a/runner/test/cases/server/services/webhookService.test.ts
+++ b/runner/test/cases/server/services/webhookService.test.ts
@@ -1,0 +1,43 @@
+import * as Code from "@hapi/code";
+import * as Lab from "@hapi/lab";
+import sinon from "sinon";
+
+import { WebhookService } from "server/services/webhookService";
+import * as httpService from "server/services/httpService";
+
+const { expect } = Code;
+const lab = Lab.script();
+exports.lab = lab;
+const { afterEach, beforeEach, suite, test } = lab;
+
+const sandbox = sinon.createSandbox();
+
+suite("Server WebhookService Service", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  test("Webhook returns correct reference when payload is string", async () => {
+    sinon.stub(httpService, "post").returns(
+      Promise.resolve({
+        res: {},
+        payload: JSON.stringify({ reference: "1234" }),
+      })
+    );
+    const webHookeService = new WebhookService();
+    const result = await webHookeService.postRequest("/url", {});
+    expect(result).to.equal("1234");
+  });
+
+  test("Webhook returns correct reference when payload is object", async () => {
+    sinon.stub(httpService, "post").returns(
+      Promise.resolve({
+        res: {},
+        payload: { reference: "ABCD" },
+      })
+    );
+    const webHookeService = new WebhookService();
+    const result = await webHookeService.postRequest("/url", {});
+    expect(result).to.equal("ABCD");
+  });
+});


### PR DESCRIPTION
# Description

Runner's webhook service should handle response payload as string. 
This PR extends Webhook service so it can handle payloads both as string and JSON. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary. 

- [X] I have added tests that prove my fix is effective.
- [X] New and existing unit tests pass locally with my changes

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts
