### PR TITLE
Re-implement uploadConfiguration and ignore it when in preview mode

### DIFF
--- a/designer/server/lib/persistence/previewPersistenceService.ts
+++ b/designer/server/lib/persistence/previewPersistenceService.ts
@@ -11,8 +11,10 @@ import config from "../../config";
 export class PreviewPersistenceService implements PersistenceService {
   logger: any;
 
-  async uploadConfiguration(_id: string, _configuration: string) {
-    return Promise.resolve("OK");
+  async uploadConfiguration(id: string, configuration: string) {
+    return Wreck.post(`${config.previewUrl}/publish`, {
+      payload: JSON.stringify({ id, configuration }),
+    });
   }
 
   async copyConfiguration(configurationId: string, newName: string) {

--- a/designer/server/plugins/designer.ts
+++ b/designer/server/plugins/designer.ts
@@ -74,10 +74,12 @@ export const designerPlugin = {
             const newName = name === "" ? nanoid(10) : name;
             try {
               if (selected.Key === "New") {
-                await persistenceService.uploadConfiguration(
-                  `${newName}.json`,
-                  JSON.stringify(newFormJson)
-                );
+                if (config.persistentBackend !== "preview") {
+                  await persistenceService.uploadConfiguration(
+                    `${newName}.json`,
+                    JSON.stringify(newFormJson)
+                  );
+                }
                 await publish(newName, newFormJson);
               } else {
                 await persistenceService.copyConfiguration(


### PR DESCRIPTION
# Description

Edit existing configuration in preview mode

- Revert `uploadConfiguration` implementation in preview's persistence service
- Skip `uploadConfiguration` when in preview mode

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] I have manually tested the application. 
- [X] New and existing unit tests pass locally with my changes

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts
