### PR TITLE
Fix hardcoding of Matomo URL into code and remove trailing slash

### DIFF
--- a/runner/src/server/views/layout.html
+++ b/runner/src/server/views/layout.html
@@ -34,14 +34,14 @@
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {
-        var u="https://web-analytics.fco.gov.uk/piwik/";
+        var u="{{ matomoUrl }}";
         _paq.push(['setTrackerUrl', u+'piwik.php']);
         _paq.push(['setSiteId', '{{ matomoId }}']);
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
       })();
     </script>
-    <noscript><p><img src="{{ matomoUrl }}/piwik.php?idsite={{ matomoId }}&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+    <noscript><p><img src="{{ matomoUrl }}piwik.php?idsite={{ matomoId }}&amp;rec=1" style="border:0;" alt="" /></p></noscript>
   {% endif %}
   <!-- End Matomo Code -->
 


### PR DESCRIPTION
Fix hardcoding of Matomo URL into code and remove trailing slash

## Fix 

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Check Matomo snippet is correct in header

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X ] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation and versioning
- [N/A] My changes generate no new warnings
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [N/A] New and existing unit tests pass locally with my changes
- [X ] I have rebased onto master and there are no code conflicts
- [N/A ] I have checked deployments are working in all environments
- [N/A ] I have updated the architecture diagrams as per Contribute.md
