### PR TITLE
Fix/docker bundle analyzer and path bug

### DIFF
--- a/designer/package.json
+++ b/designer/package.json
@@ -50,6 +50,7 @@
     "moment-timezone": "^0.5.31",
     "nanoid": "^3.1.12",
     "react-helmet": "^6.1.0",
+    "resolve": "^1.19.0",
     "schmervice": "^1.5.0",
     "vision": "5.4.3"
   },

--- a/designer/server/plugins/view.ts
+++ b/designer/server/plugins/view.ts
@@ -5,6 +5,8 @@ import vision from "vision";
 
 import pkg from "../../package.json";
 
+const basedir = path.join(process.cwd(), "..");
+
 export const viewPlugin = {
   plugin: vision,
   options: {
@@ -46,8 +48,8 @@ export const viewPlugin = {
     path: [
       `${path.join("dist", "client", "views")}`,
       `${path.join(__dirname, "..", "views")}`,
-      `${path.dirname(resolve.sync("govuk-frontend"))}`,
-      `${path.dirname(resolve.sync("govuk-frontend"))}/components`,
+      `${path.dirname(resolve.sync("govuk-frontend", { basedir }))}`,
+      `${path.dirname(resolve.sync("govuk-frontend", { basedir }))}/components`,
     ],
     context: {
       appVersion: pkg.version,

--- a/designer/tsconfig.json
+++ b/designer/tsconfig.json
@@ -10,5 +10,5 @@
     "resolveJsonModule": true,
     "lib": ["DOM"]
   },
-  "include": ["server", "client"],
+  "include": ["server", "client", "package.json"]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,8 @@ services:
       - /usr/src/app/runner/dist
       - ./designer:/usr/src/app/designer:delegated
     command: yarn designer dev
-    # depends_on:
-    # - runner
+    depends_on:
+      - runner
 
   runner:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       - PREVIEW_URL=http://localhost:3009
       - PUBLISH_URL=http://runner:3009
     volumes:
-      - ./designer:/usr/src/app/designer:delegated
       - /usr/src/app/node_modules
       - /usr/src/app/model/node_modules
       - /usr/src/app/model/dist
@@ -25,9 +24,10 @@ services:
       - /usr/src/app/designer/dist
       - /usr/src/app/runner/node_modules
       - /usr/src/app/runner/dist
+      - ./designer:/usr/src/app/designer:delegated
     command: yarn designer dev
-    depends_on:
-      - runner
+    # depends_on:
+    # - runner
 
   runner:
     build:
@@ -45,7 +45,6 @@ services:
       - sandbox=true
       - PREVIEW_MODE=true
     volumes:
-      - ./runner:/usr/src/app/runner
       - /usr/src/app/node_modules
       - /usr/src/app/model/node_modules
       - /usr/src/app/model/dist
@@ -53,6 +52,7 @@ services:
       - /usr/src/app/designer/dist
       - /usr/src/app/runner/node_modules
       - /usr/src/app/runner/dist
+      - ./runner:/usr/src/app/runner
     command: yarn runner dev
     depends_on:
       - redis

--- a/package.json
+++ b/package.json
@@ -66,8 +66,6 @@
     "lint-staged": "^10.4.2",
     "magic-string": "^0.25.7",
     "prettier": "2.1.2",
-    "resolve": "^1.17.0",
-    "rollup": "^2.25.0",
     "typescript": "^4.1.3",
     "wdio-chromedriver-service": "^6.0.4"
   },
@@ -81,9 +79,6 @@
     "govuk-frontend": "^3.10.1",
     "wdio-json-reporter": "^2.0.0",
     "webdriverio": "^6.6.0"
-  },
-  "resolutions": {
-    "resolve": "^1.17"
   },
   "husky": {
     "hooks": {

--- a/runner/package.json
+++ b/runner/package.json
@@ -75,6 +75,7 @@
     "notifications-node-client": "4.7.3",
     "nunjucks": "3.2.1",
     "pdfmake": "0.1.65",
+    "resolve": "^1.19.0",
     "rollup-plugin-includepaths": "^0.2.3",
     "schmervice": "1.5.0",
     "sinon": "9.0.2",

--- a/runner/src/server/plugins/views.ts
+++ b/runner/src/server/plugins/views.ts
@@ -6,6 +6,8 @@ import vision from "vision";
 import config from "../config";
 import pkg from "../../../package.json";
 
+const basedir = path.join(process.cwd(), "..");
+
 export default {
   plugin: vision,
   options: {
@@ -47,9 +49,11 @@ export default {
     path: [
       `${path.join(__dirname, "..", "views")}`,
       `${path.join(__dirname, "engine", "views")}`,
-      `${path.dirname(resolve.sync("govuk-frontend"))}`,
-      `${path.dirname(resolve.sync("govuk-frontend"))}/components`,
-      `${path.dirname(resolve.sync("hmpo-components"))}/components`,
+      `${path.dirname(resolve.sync("govuk-frontend", { basedir }))}`,
+      `${path.dirname(resolve.sync("govuk-frontend", { basedir }))}/components`,
+      `${path.dirname(
+        resolve.sync("hmpo-components", { basedir })
+      )}/components`,
     ],
     isCached: !config.isDev,
     context: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3922,6 +3922,7 @@ __metadata:
     react-helmet: ^6.1.0
     react-simple-code-editor: 0.6.1
     react-sortable-hoc: 0.8.3
+    resolve: ^1.19.0
     resolve-url-loader: ^3.1.1
     sass: ^1.26.11
     sass-loader: ^10.0.2
@@ -4078,6 +4079,7 @@ __metadata:
     notifications-node-client: 4.7.3
     nunjucks: 3.2.1
     pdfmake: 0.1.65
+    resolve: ^1.19.0
     rollup-plugin-includepaths: ^0.2.3
     schmervice: 1.5.0
     sinon: 9.0.2
@@ -8017,8 +8019,6 @@ __metadata:
     lint-staged: ^10.4.2
     magic-string: ^0.25.7
     prettier: 2.1.2
-    resolve: ^1.17.0
-    rollup: ^2.25.0
     typescript: ^4.1.3
     wdio-chromedriver-service: ^6.0.4
     wdio-json-reporter: ^2.0.0
@@ -12288,6 +12288,15 @@ fsevents@~2.1.2:
   bin:
     is-ci: bin.js
   checksum: 09083018edafd63221ff0506356f13c0aaf4b75a6435ea648bc67d07ddab199b2d5b9297de43d0821df1a14c18cd9f1edd1775a0166abfe37390843e79137213
+  languageName: node
+  linkType: hard
+
+"is-core-module@npm:^2.1.0":
+  version: 2.2.0
+  resolution: "is-core-module@npm:2.2.0"
+  dependencies:
+    has: ^1.0.3
+  checksum: 2344744de98a3bc22e2bb30895f307d7889f09e963f9bcb1cc321788f508c8b463f75e0a9ca009eeeb8eb9465181b5c15f1ec9299a6bb6921cfbb2423892e0ba
   languageName: node
   linkType: hard
 
@@ -18007,21 +18016,37 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.17":
-  version: 1.17.0
-  resolution: "resolve@npm:1.17.0"
-  dependencies:
-    path-parse: ^1.0.6
-  checksum: 5e3cdb8cf68c20b0c5edeb6505e7fab20c6776af0cae4b978836e557420aef7bb50acd25339bbb143b7f80533aa1988c7e827a0061aee9c237926a7d2c41f8d0
+resolve@1.1.7:
+  version: 1.1.7
+  resolution: "resolve@npm:1.1.7"
+  checksum: 3e928e9586d51dd985d42f524646267f08269261d844adfb54bf2e3a2f96e9bdb2be8e3db686145a7ac2b65c7cd894bdfa7b48b80b828ea5cb1d2abc403778b0
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.17#builtin<compat/resolve>":
-  version: 1.17.0
-  resolution: "resolve@patch:resolve@npm%3A1.17.0#builtin<compat/resolve>::version=1.17.0&hash=3388aa"
+"resolve@^1.0.0, resolve@^1.1.5, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.6.0, resolve@^1.8.1":
+  version: 1.19.0
+  resolution: "resolve@npm:1.19.0"
   dependencies:
+    is-core-module: ^2.1.0
     path-parse: ^1.0.6
-  checksum: 4bcfb568860d0c361fd16c26b6fce429711138ff0de7dd353bdd73fcb5c7eede2f4602d40ccfa08ff45ec7ef9830845eab2021a46036af0a6e5b58bab1ff6399
+  checksum: 8b23c7fde1224898ffb9fec2a2295a44d1564981343bdbf5fd3769465658f6a6f6647bb7ea66dfb3c1291ca86046b0233be2edfcd8ca05b38886521e8869677c
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@1.1.7#builtin<compat/resolve>":
+  version: 1.1.7
+  resolution: "resolve@patch:resolve@npm%3A1.1.7#builtin<compat/resolve>::version=1.1.7&hash=3388aa"
+  checksum: ca4e21815c78134fdb248d2175d98c2ead024c680a3a9c7b8ee13fc8a7f5157e061b13ae29ee07a60e1b9faea33c3740cb88d48d94966d7e94479add70d3f544
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@^1.0.0#builtin<compat/resolve>, resolve@patch:resolve@^1.1.5#builtin<compat/resolve>, resolve@patch:resolve@^1.1.6#builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#builtin<compat/resolve>, resolve@patch:resolve@^1.10.1#builtin<compat/resolve>, resolve@patch:resolve@^1.11.0#builtin<compat/resolve>, resolve@patch:resolve@^1.12.0#builtin<compat/resolve>, resolve@patch:resolve@^1.13.1#builtin<compat/resolve>, resolve@patch:resolve@^1.15.1#builtin<compat/resolve>, resolve@patch:resolve@^1.17.0#builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#builtin<compat/resolve>, resolve@patch:resolve@^1.3.3#builtin<compat/resolve>, resolve@patch:resolve@^1.6.0#builtin<compat/resolve>, resolve@patch:resolve@^1.8.1#builtin<compat/resolve>":
+  version: 1.19.0
+  resolution: "resolve@patch:resolve@npm%3A1.19.0#builtin<compat/resolve>::version=1.19.0&hash=3388aa"
+  dependencies:
+    is-core-module: ^2.1.0
+    path-parse: ^1.0.6
+  checksum: 188d5167e8578a9af8d194faf382b8f3526aad5145391c24ecdc6246c6fc82c10fc66d6352267f8e93c5977c503d61803169c91b9e2ee36dd2de759915c9b673
   languageName: node
   linkType: hard
 
@@ -18202,20 +18227,6 @@ fsevents@~2.1.2:
   bin:
     rollup: dist/bin/rollup
   checksum: fc59b8af482e0729fd720a6be1221f477ae1848fd88b0474d10f805567aa4ad5f16afa9a976c8fd30fd196fcb689b252826cdd138e7a4ad88462547adb5dbf40
-  languageName: node
-  linkType: hard
-
-"rollup@npm:^2.25.0":
-  version: 2.28.2
-  resolution: "rollup@npm:2.28.2"
-  dependencies:
-    fsevents: ~2.1.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    rollup: dist/bin/rollup
-  checksum: a0cfb9b5f7a3bd6b1528c18de5b86fa9befa78ee5358fe697c058ddd72325ce4d4b72df2391c8b06c538c92827035e26943b09ffa82b99a35bf3034ebd64e4f9
   languageName: node
   linkType: hard
 
@@ -21921,8 +21932,8 @@ typescript@^4.1.3:
   linkType: hard
 
 "ws@npm:^7.3.1":
-  version: 7.4.1
-  resolution: "ws@npm:7.4.1"
+  version: 7.4.2
+  resolution: "ws@npm:7.4.2"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -21931,7 +21942,7 @@ typescript@^4.1.3:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 32b4f83bfeeca2b98d31c2d11c87a11c6e83f9285937e4a8267eb0ccaba479952a70c8b2ba39d0304236043c37a9bdf45cf2e5a1c28f19a77838e4e0b7f37593
+  checksum: 832efdf1440706058ac04708aa56da951b6e5d10d956e6d01f7a2a32cd3f67acaabea8feb4b578b041a55289e421fc4c48769cbcf02f4d42915eb918c3f7e496
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

This PR fixes two bugs with docker-compose dev environment: 

1. Docker-compose build fails to load `webpack-bundle-analyzer` dependency.
2. Resolve module fails to find dependencies paths because yarn workspace organisation. 

- Adjust docker-compose volumes mount order.
- Add `basedir` options when resolving dependencies.
- TS config include package.json.
- Adjust dependencies.
 
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] I have rebuild docker-compose environments locally successfuly. 
- [X] Existing unit tests pass locally with my changes.

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts
- [X] I have checked deployments are working in all environments
- [X] I have updated the architecture diagrams as per Contribute.md
