### PR TITLE
Configure smoke-tests workflow to cache yarn dependencies

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -13,6 +13,16 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: "12.x"
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Docker compose pull
         run: docker-compose pull
       - name: Docker layer caching

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -34,7 +34,7 @@ jobs:
           # and this will eventually build up and increase pull time significantly
           # see https://github.com/satackey/action-docker-layer-caching/issues/55
           # ATM solution is to change keys periodically to avoid the dangling layers
-          # for that just increase the number you see in key and restore-keys below (same number in both keys)
+          # for that just increase the number you see in key and restore-keys below (same number in both keys).
           key: digital-form-builder-1-{hash}
           restore-keys: |
             digital-form-builder-1


### PR DESCRIPTION
# Description

- Configure github smoke-tests workflow to cach yarn cache. 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [X] I have checked the CI smoke-tests workflows caching is effective. https://github.com/XGovFormBuilder/digital-form-builder/pull/278/checks?check_run_id=1750099699

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts
- [X] I have checked deployments are working in all environments
- [X] I have updated the architecture diagrams as per Contribute.md
