### PR TITLE
build with non-root user and chown when copying

### DIFF
--- a/designer/Dockerfile
+++ b/designer/Dockerfile
@@ -3,7 +3,6 @@
 # Base image contains the updated OS and
 # It also configures the non-root user that will be given permission to copied files/folders in every subsequent stages
 FROM node:12-alpine3.12 AS base
-
 RUN mkdir -p /usr/src/app && \
     addgroup -g 1001 appuser && \
     adduser -S -u 1001 -G appuser appuser && \
@@ -25,6 +24,7 @@ COPY --chown=appuser:appuser package.json yarn.lock .yarnrc.yml tsconfig.json  .
 COPY --chown=appuser:appuser model/package.json ./model/
 COPY --chown=appuser:appuser designer/package.json ./designer/
 COPY --chown=appuser:appuser runner/package.json ./runner/
+USER 1001
 RUN yarn
 
 # ----------------------------
@@ -35,9 +35,9 @@ RUN yarn
 # rsync is used to merge folders instead of individually copying files
 FROM dependencies AS model
 WORKDIR /usr/src/app
-COPY ./model ./model/
+COPY --chown=appuser:appuser ./model ./model/
+USER 1001
 RUN yarn model build
-
 
 # ----------------------------
 # Stage 4
@@ -47,7 +47,7 @@ RUN yarn model build
 # rsync is used to merge folders instead of individually copying files
 FROM model AS build-designer
 WORKDIR /usr/src/app
-COPY ./designer ./designer/
+COPY --chown=appuser:appuser ./designer ./designer/
 RUN yarn designer build && \
     rm -rf ./runner
 USER 1001

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -3,7 +3,6 @@
 # Base image contains the updated OS and
 # It also configures the non-root user that will be given permission to copied files/folders in every subsequent stages
 FROM node:12-alpine3.12 AS base
-
 RUN mkdir -p /usr/src/app && \
     addgroup -g 1001 appuser && \
     adduser -S -u 1001 -G appuser appuser && \
@@ -25,6 +24,7 @@ COPY --chown=appuser:appuser package.json yarn.lock .yarnrc.yml tsconfig.json  .
 COPY --chown=appuser:appuser model/package.json ./model/
 COPY --chown=appuser:appuser designer/package.json ./designer/
 COPY --chown=appuser:appuser runner/package.json ./runner/
+USER 1001
 RUN yarn
 
 # ----------------------------
@@ -35,9 +35,9 @@ RUN yarn
 # rsync is used to merge folders instead of individually copying files
 FROM dependencies AS model
 WORKDIR /usr/src/app
-COPY ./model ./model/
+COPY --chown=appuser:appuser ./model ./model/
+USER 1001
 RUN yarn model build
-
 
 # ----------------------------
 # Stage 4
@@ -47,7 +47,7 @@ RUN yarn model build
 # rsync is used to merge folders instead of individually copying files
 FROM model AS build-runner
 WORKDIR /usr/src/app
-COPY ./runner ./runner/
+COPY --chown=appuser:appuser ./runner ./runner/
 RUN yarn runner build && \
     rm -rf ./designer
 USER 1001


### PR DESCRIPTION
# Description

- Adjust designer and runner Dockerfile to build using user 1001 to avoid EACCES bug on ACP. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] I have build both services locally successfully 

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts
- [X] I have checked deployments are working in all environments
- [X] I have updated the architecture diagrams as per Contribute.md
