### PR TITLE
Bug/forms 209-conditions persist

### DIFF
--- a/designer/client/components/FieldEditors/para-edit.tsx
+++ b/designer/client/components/FieldEditors/para-edit.tsx
@@ -3,6 +3,7 @@ import { ComponentContext } from "../../reducers/component/componentReducer";
 import { DataContext } from "../../context";
 import Editor from "../../editor";
 import { Actions } from "../../reducers/component/types";
+import { ContentOptions } from "@xgovformbuilder/model";
 
 type Props = {
   context: any; // TODO
@@ -14,7 +15,7 @@ export function ParaEdit({ context = ComponentContext }: Props) {
   const { state, dispatch } = useContext(context);
   const { selectedComponent } = state;
   const { data } = useContext(DataContext);
-  const { options = {} } = selectedComponent;
+  const { options = {} }: { options: ContentOptions } = selectedComponent;
   const { conditions } = data;
 
   return (

--- a/designer/client/components/FieldEditors/para-edit.tsx
+++ b/designer/client/components/FieldEditors/para-edit.tsx
@@ -51,7 +51,7 @@ export function ParaEdit({ context = ComponentContext }: Props) {
           className="govuk-select"
           id="condition"
           name="options.condition"
-          value={options.conditions}
+          value={options.condition}
           onChange={(e) =>
             dispatch({
               type: Actions.EDIT_OPTIONS_CONDITION,

--- a/designer/client/reducers/component/componentReducer.fields.ts
+++ b/designer/client/reducers/component/componentReducer.fields.ts
@@ -38,11 +38,6 @@ export function fieldsReducer(
         },
       };
     }
-    case Fields.EDIT_CONDITION:
-      return {
-        ...state,
-        selectedComponent: { ...selectedComponent, condition: payload },
-      };
     case Fields.EDIT_HELP:
       return {
         ...state,

--- a/designer/client/reducers/component/componentReducer.options.ts
+++ b/designer/client/reducers/component/componentReducer.options.ts
@@ -1,12 +1,18 @@
 import { Options } from "./types";
 
-export function optionsReducer(
-  state,
-  action: {
-    type: Options;
-    payload: any;
-  }
-) {
+interface ConditionAction {
+  type: Options.EDIT_OPTIONS_CONDITION;
+  payload: string;
+}
+
+interface AnyAction {
+  type: Options;
+  payload: any;
+}
+
+type OptionsActions = ConditionAction | AnyAction;
+
+export function optionsReducer(state, action: OptionsActions) {
   const { type, payload } = action;
   const { selectedComponent } = state;
   const { options } = state;

--- a/designer/client/reducers/component/types.ts
+++ b/designer/client/reducers/component/types.ts
@@ -19,7 +19,6 @@ export enum Schema {
 export enum Fields {
   EDIT_TITLE = "EDIT_TITLE",
   EDIT_NAME = "EDIT_NAME",
-  EDIT_CONDITION = "EDIT_CONDITION",
   EDIT_HELP = "EDIT_HELP",
   EDIT_CONTENT = "EDIT_CONTENT",
   EDIT_TYPE = "EDIT_TYPE",

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -59,6 +59,10 @@ export type ConditionalComponent = {
   subType: "field";
 };
 
+export type ContentOptions = {
+  condition?: string;
+};
+
 // Types for Components JSON structure which are expected by engine and turned into
 // actual form input/content/lists
 interface TextFieldBase {
@@ -120,9 +124,7 @@ interface ContentFieldBase {
   name: string;
   title: string;
   content: string;
-  options: {
-    condition?: string;
-  };
+  options: ContentOptions;
   schema: {};
 }
 


### PR DESCRIPTION
# Description

bug report:
> If I create a condition from Edit Conditions > add an inset text component > set the condition to the one I just created and save > go back into the component, the conditions field is blank (the condition doesn't apply to Preview either)

- change options.conditions to options.condition
- add types

Acceptance criteria 
Given I have a page with an inset text component and conditions available to select
When I select a condition and click save
Then after re-opening the page, I can see my selected condition


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

Before PR's can be merged they will need to be tested by QA and approved where
applicable. To flag the change to QA assign **@XGovFormBuilder/qa** as one of the reviewers.

- [x] manual


# Checklist:

- [x] My changes do not introduce any new linting errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto master and there are no code conflicts
- [x] I have checked deployments are working in all environments
- [x] I have updated the architecture diagrams as per Contribute.md
