### PR TITLE
Forms 223 flyout scrolling issue

### DIFF
--- a/designer/client/components/ComponentCreate/__tests__/ComponentCreate.jest.tsx
+++ b/designer/client/components/ComponentCreate/__tests__/ComponentCreate.jest.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Data } from "@xgovformbuilder/model";
 import userEvent, { TargetElement } from "@testing-library/user-event";
 
@@ -37,23 +37,23 @@ describe("ComponentCreate:", () => {
     );
   };
 
-  test("Selecting a component type should display the component edit form", () => {
+  test("Selecting a component type should display the component edit form", async () => {
     // - when
-    const { container, queryByTestId, getByText } = render(
+    const { getByText } = render(
       <WrappingComponent componentValue={false}>
         <ComponentCreate page={page} />
       </WrappingComponent>
     );
 
-    expect(queryByTestId("standard-inputs")).toBeNull();
+    expect(screen.queryByLabelText("Title")).toBeNull();
     userEvent.click(getByText("Details"));
 
     // - then
-    const editForm = container.querySelector("form");
+    const editForm = await screen.findByLabelText("Title");
     expect(editForm).toBeInTheDocument();
   });
 
-  test("Should store the populated component and call callback on submit", () => {
+  test("Should store the populated component and call callback on submit", async () => {
     // - when
     const { container, getByText } = render(
       <WrappingComponent componentValue={false}>
@@ -63,9 +63,7 @@ describe("ComponentCreate:", () => {
 
     userEvent.click(getByText("Details"));
 
-    const titleInput = container.querySelector(
-      "#details-title"
-    ) as TargetElement;
+    const titleInput = (await screen.findByLabelText("Title")) as TargetElement;
     const contentTextArea = container.querySelector(
       "#field-content"
     ) as TargetElement;
@@ -106,7 +104,7 @@ describe("ComponentCreate:", () => {
     expect(queryByText(backBtnTxt)).toBeNull();
   });
 
-  test("Should display ErrorSummary when validation fails", () => {
+  test("Should display ErrorSummary when validation fails", async () => {
     // - when
     const { container, getByText, queryByRole } = render(
       <WrappingComponent componentValue={false}>
@@ -117,6 +115,7 @@ describe("ComponentCreate:", () => {
     expect(queryByRole("alert")).toBeNull();
 
     userEvent.click(getByText("Details") as TargetElement);
+    await screen.findByLabelText("Title");
     userEvent.click(container.querySelector("button") as TargetElement);
 
     // - then


### PR DESCRIPTION
# Description

This is a simple work around the bug with `CreateComponent Flyout` scrolling in small screens so we can solve the bug with the least amount of effort. 

- Implement a fast two phase render to allow DOM to reflow Flyout without the list, thus resesting it's scroll position
- Adjust tests

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Aceptance Criteria

As a user
Given I have a small screen
When I click `Create component`
And scroll down the components list 
And select `YesNo Field`
Then the `Component Edit` screen renders without being scrolled to the bottom

# How Has This Been Tested?

- [X] I have manually tested the application to confirm bug has been fixed
- [X] I have adjusted the existing tests to accomodate the asynchronous render behavoir of the component
- [X] New and existing unit tests pass locally with my changes

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts
- [X] I have checked deployments are working in all environments
- [X] I have updated the architecture diagrams as per Contribute.md
