### PR TITLE
bug fix for FORMS-136 and issue 219

### DIFF
--- a/model/src/data-model/__tests__/data-model.test.ts
+++ b/model/src/data-model/__tests__/data-model.test.ts
@@ -1375,6 +1375,91 @@ describe("data model", () => {
     });
   });
 
+  describe("all paths", () => {
+    test("_allPathsLeadingTo should work with cycle in paths", () => {
+      const data = new Data({
+        pages: [
+          {
+            name: "page1",
+            path: "/1",
+            next: [{ path: "/2" }],
+          },
+          {
+            name: "page2",
+            path: "/2",
+            next: [{ path: "/1" }],
+          },
+          {
+            name: "page3",
+            path: "/3",
+          },
+        ],
+      } as any);
+
+      const paths = data._allPathsLeadingTo("/2");
+      expect(paths).toEqual(["/1", "/2"]);
+    });
+
+    test("_allPathsLeadingTo should work with single parents", () => {
+      const data = new Data({
+        pages: [
+          {
+            name: "page1",
+            path: "/1",
+            next: [{ path: "/2" }],
+          },
+          {
+            name: "page2",
+            path: "/2",
+            next: [{ path: "/3" }],
+          },
+          {
+            name: "page3",
+            path: "/3",
+          },
+        ],
+      } as any);
+
+      const paths = data._allPathsLeadingTo("/3");
+      expect(paths).toEqual(["/2", "/1"]);
+    });
+
+    test("_allPathsLeadingTo should work with multiple parents", () => {
+      const data = new Data({
+        pages: [
+          {
+            name: "page1",
+            path: "/1",
+            next: [{ path: "/2" }, { path: "/3" }],
+          },
+          {
+            name: "page2",
+            path: "/2",
+            next: [{ path: "/4" }],
+          },
+          {
+            name: "page3",
+            path: "/3",
+            next: [{ path: "/4" }],
+          },
+          {
+            name: "page4",
+            path: "/4",
+          },
+        ],
+      } as any);
+
+      const paths = data._allPathsLeadingTo("/4");
+      expect(paths).toEqual(["/2", "/1", "/3", "/1"]);
+
+      const paths1 = data._allPathsLeadingTo("/3");
+      expect(paths1).toEqual(["/1"]);
+
+      const paths2 = data._allPathsLeadingTo("/1");
+      expect(paths2).toEqual([]);
+    });
+  });
+
   describe("update link", () => {
     test("should remove a condition from a link to the next page", () => {
       const data = new Data({
@@ -1659,7 +1744,7 @@ describe("data model", () => {
       expect(data.findList("/1")).toEqual(undefined);
     });
 
-    test.only("add lists", () => {
+    test("add lists", () => {
       const data = new Data({});
       const list = {
         name: "Colors",

--- a/model/src/data-model/data-model.ts
+++ b/model/src/data-model/data-model.ts
@@ -243,13 +243,18 @@ export class Data {
     return null;
   }
 
-  _allPathsLeadingTo(path: string): Array<string> {
+  _allPathsLeadingTo(
+    path: string,
+    visited: Set<string> = new Set<string>()
+  ): Array<string> {
+    if (visited.has(path)) return [];
+    visited.add(path);
     return this.pages
       .filter(
         (page) => page.next && page.next.find((next) => next.path === path)
       )
       .flatMap((page) =>
-        [page.path].concat(this._allPathsLeadingTo(page.path))
+        [page.path].concat(this._allPathsLeadingTo(page.path, visited))
       );
   }
 


### PR DESCRIPTION
fixes #219

# Description
bug fix  -  cycle in page links is causing the link condition drop down preparation logic to throw stack overflow exception

- method in Data model changed to not process already visited nodes 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Manual Test
- [ ] Unit test

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts
- [ ] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md
