### PR TITLE
Set workspace .env inside action and default to undefined

### DIFF
--- a/.github/workflows/master--lint-unit-build-and-publish-images.yml
+++ b/.github/workflows/master--lint-unit-build-and-publish-images.yml
@@ -90,6 +90,14 @@ jobs:
           restore-keys: |
             digital-form-builder-${{ env.MONTH }}
 
+      - name: Create .env for ${{ matrix.app }} workspace
+        uses: SpicyPizza/create-envfile@v1
+        with:
+          LAST_TAG: "1.0.${{ github.run_number }}-rc"
+          LAST_COMMIT: "${{ github.sha }}"
+          directory: ${{ matrix.app }}
+          file_name: .env
+
       - name: Docker compose build ${{ matrix.app }}
         run: |
           LAST_TAG='1.0.${{ github.run_number }}-rc'

--- a/designer/server/config.ts
+++ b/designer/server/config.ts
@@ -41,8 +41,8 @@ const schema = joi.object({
     .default("debug"),
   phase: joi.string().valid("alpha", "beta").optional(),
   footerText: joi.string().optional(),
-  lastCommit: joi.string().default("undefined"),
-  lastTag: joi.string().default("undefined"),
+  lastCommit: joi.string(),
+  lastTag: joi.string(),
 });
 
 // Build config
@@ -58,8 +58,8 @@ const config = {
   logLevel: process.env.LOG_LEVEL || "error",
   phase: process.env.PHASE || "alpha",
   footerText: process.env.FOOTER_TEXT,
-  lastCommit: process.env.LAST_COMMIT,
-  lastTag: process.env.LAST_TAG,
+  lastCommit: process.env.LAST_COMMIT || "undefined",
+  lastTag: process.env.LAST_TAG || "undefined",
 };
 
 // Validate config

--- a/runner/src/server/config.ts
+++ b/runner/src/server/config.ts
@@ -66,8 +66,8 @@ const schema = Joi.object({
       otherwise: Joi.optional(),
     })
     .label("NOTIFY_API_KEY"),
-  lastCommit: Joi.string().default("undefined"),
-  lastTag: Joi.string().default("undefined"),
+  lastCommit: Joi.string(),
+  lastTag: Joi.string(),
 });
 
 export function buildConfig() {
@@ -101,8 +101,8 @@ export function buildConfig() {
     privacyPolicyUrl: process.env.PRIVACY_POLICY_URL,
     notifyTemplateId: process.env.NOTIFY_TEMPLATE_ID,
     notifyAPIKey: process.env.NOTIFY_API_KEY,
-    lastCommit: process.env.LAST_COMMIT,
-    lastTag: process.env.LAST_TAG,
+    lastCommit: process.env.LAST_COMMIT || "undefined",
+    lastTag: process.env.LAST_TAG || "undefined",
   };
 
   // Validate config


### PR DESCRIPTION
# Description

- Create a `.env` file inside workspaces with required environment variables
- Adjust process.env variables defaults (not sure why Joi ignored previous `.default()`

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
