### PR TITLE
Allow last TAG and COMMIT from GH and ACP environment

### DIFF
--- a/.github/workflows/branch--lint-unit-and-smoke-test.yml
+++ b/.github/workflows/branch--lint-unit-and-smoke-test.yml
@@ -94,8 +94,8 @@ jobs:
       - name: Create .env for ${{ matrix.app }} workspace
         run: |
           touch ./${{ matrix.app }}/.env
-          echo LAST_TAG=1.0.${{ github.run_number }}-rc >> ./${{ matrix.app }}/.env
-          echo LAST_COMMIT=${{ github.sha }} >> ./${{ matrix.app }}/.env
+          echo LAST_TAG_GH=1.0.${{ github.run_number }}-rc >> ./${{ matrix.app }}/.env
+          echo LAST_COMMIT_GH=${{ github.sha }} >> ./${{ matrix.app }}/.env
           cat ./${{ matrix.app }}/.env
       - name: Docker compose build
         run: |

--- a/.github/workflows/master--lint-unit-build-and-publish-images.yml
+++ b/.github/workflows/master--lint-unit-build-and-publish-images.yml
@@ -89,8 +89,8 @@ jobs:
       - name: Create .env for ${{ matrix.app }} workspace
         run: |
           touch ./${{ matrix.app }}/.env
-          echo LAST_TAG=1.0.${{ github.run_number }}-rc >> ./${{ matrix.app }}/.env
-          echo LAST_COMMIT=${{ github.sha }} >> ./${{ matrix.app }}/.env
+          echo LAST_TAG_GH=1.0.${{ github.run_number }}-rc >> ./${{ matrix.app }}/.env
+          echo LAST_COMMIT_GH=${{ github.sha }} >> ./${{ matrix.app }}/.env
           cat ./${{ matrix.app }}/.env
       - name: Docker compose build ${{ matrix.app }}
         run: |

--- a/designer/server/__tests__/config.jest.ts
+++ b/designer/server/__tests__/config.jest.ts
@@ -29,4 +29,20 @@ describe("Config", () => {
     expect(config.lastCommit).toEqual("LAST COMMIT");
     expect(config.lastTag).toEqual("LAST TAG");
   });
+
+  test("lastCommit and lastTag props are set correctly with GH variables", async () => {
+    process.env = {
+      ...OLD_ENV,
+      LAST_COMMIT: "",
+      LAST_TAG: "",
+      LAST_COMMIT_GH: "LAST COMMIT",
+      LAST_TAG_GH: "LAST TAG",
+    };
+
+    jest.resetModules();
+
+    const { default: config } = await import("../config");
+    expect(config.lastCommit).toEqual("LAST COMMIT");
+    expect(config.lastTag).toEqual("LAST TAG");
+  });
 });

--- a/designer/server/config.ts
+++ b/designer/server/config.ts
@@ -58,8 +58,9 @@ const config = {
   logLevel: process.env.LOG_LEVEL || "error",
   phase: process.env.PHASE || "alpha",
   footerText: process.env.FOOTER_TEXT,
-  lastCommit: process.env.LAST_COMMIT || "undefined",
-  lastTag: process.env.LAST_TAG || "undefined",
+  lastCommit:
+    process.env.LAST_COMMIT || process.env.LAST_COMMIT_GH || "undefined",
+  lastTag: process.env.LAST_TAG || process.env.LAST_TAG_GH || "undefined",
 };
 
 // Validate config

--- a/designer/server/config.ts
+++ b/designer/server/config.ts
@@ -41,8 +41,8 @@ const schema = joi.object({
     .default("debug"),
   phase: joi.string().valid("alpha", "beta").optional(),
   footerText: joi.string().optional(),
-  lastCommit: joi.string(),
-  lastTag: joi.string(),
+  lastCommit: joi.string().default("undefined"),
+  lastTag: joi.string().default("undefined"),
 });
 
 // Build config
@@ -58,9 +58,8 @@ const config = {
   logLevel: process.env.LOG_LEVEL || "error",
   phase: process.env.PHASE || "alpha",
   footerText: process.env.FOOTER_TEXT,
-  lastCommit:
-    process.env.LAST_COMMIT || process.env.LAST_COMMIT_GH || "undefined",
-  lastTag: process.env.LAST_TAG || process.env.LAST_TAG_GH || "undefined",
+  lastCommit: process.env.LAST_COMMIT || process.env.LAST_COMMIT_GH,
+  lastTag: process.env.LAST_TAG || process.env.LAST_TAG_GH,
 };
 
 // Validate config

--- a/runner/src/server/config.ts
+++ b/runner/src/server/config.ts
@@ -66,8 +66,8 @@ const schema = Joi.object({
       otherwise: Joi.optional(),
     })
     .label("NOTIFY_API_KEY"),
-  lastCommit: Joi.string(),
-  lastTag: Joi.string(),
+  lastCommit: Joi.string().default("undefined"),
+  lastTag: Joi.string().default("undefined"),
 });
 
 export function buildConfig() {
@@ -101,9 +101,8 @@ export function buildConfig() {
     privacyPolicyUrl: process.env.PRIVACY_POLICY_URL,
     notifyTemplateId: process.env.NOTIFY_TEMPLATE_ID,
     notifyAPIKey: process.env.NOTIFY_API_KEY,
-    lastCommit:
-      process.env.LAST_COMMIT || process.env.LAST_COMMIT_GH || "undefined",
-    lastTag: process.env.LAST_TAG || process.env.LAST_TAG_GH || "undefined",
+    lastCommit: process.env.LAST_COMMIT || process.env.LAST_COMMIT_GH,
+    lastTag: process.env.LAST_TAG || process.env.LAST_TAG_GH,
   };
 
   // Validate config
@@ -123,7 +122,7 @@ export function buildConfig() {
   value.isProd = value.env === "production";
   value.isDev = !value.isProd;
   value.isTest = value.env === "test";
-  value.isSandbox = process.env.sandbox || false; // for heroku instances
+  value.isSandbox = process.env.sandbox === "true"; // for heroku instances
 
   return value;
 }

--- a/runner/src/server/config.ts
+++ b/runner/src/server/config.ts
@@ -101,8 +101,9 @@ export function buildConfig() {
     privacyPolicyUrl: process.env.PRIVACY_POLICY_URL,
     notifyTemplateId: process.env.NOTIFY_TEMPLATE_ID,
     notifyAPIKey: process.env.NOTIFY_API_KEY,
-    lastCommit: process.env.LAST_COMMIT || "undefined",
-    lastTag: process.env.LAST_TAG || "undefined",
+    lastCommit:
+      process.env.LAST_COMMIT || process.env.LAST_COMMIT_GH || "undefined",
+    lastTag: process.env.LAST_TAG || process.env.LAST_TAG_GH || "undefined",
   };
 
   // Validate config

--- a/runner/test/cases/server/config.test.js
+++ b/runner/test/cases/server/config.test.js
@@ -37,6 +37,9 @@ suite(`Server Config`, () => {
       FROM_EMAIL_ADDRESS: "TEST_FROM_EMAIL_ADDRESS",
       SERVICE_START_PAGE: "TEST_SERVICE_START_PAGE",
       PRIVACY_POLICY_URL: "TEST_PRIVACY_POLICY_URL",
+      LAST_COMMIT: "LAST COMMIT",
+      LAST_TAG: "LAST TAG",
+      sandbox: "true",
     };
   });
 
@@ -59,6 +62,8 @@ suite(`Server Config`, () => {
       feedbackLink: "TEST_FEEDBACK_LINK",
       matomoId: "TEST_MATOMO_ID",
       matomoUrl: "https://matomo.url",
+      notifyAPIKey: undefined,
+      notifyTemplateId: undefined,
       payApiUrl: "https://pay.url",
       payReturnUrl: "https://pay.return.url",
       serviceUrl: "TEST_SERVICE_URL",
@@ -80,7 +85,9 @@ suite(`Server Config`, () => {
       isProd: false,
       isDev: true,
       isTest: true,
-      isSandbox: false,
+      isSandbox: true,
+      lastCommit: "LAST COMMIT",
+      lastTag: "LAST TAG",
     };
 
     const result = buildConfig();
@@ -157,6 +164,21 @@ suite(`Server Config`, () => {
       ...customVariables,
       LAST_COMMIT: "LAST COMMIT",
       LAST_TAG: "LAST TAG",
+    };
+
+    const config = buildConfig();
+    expect(config.lastCommit).to.equal("LAST COMMIT");
+    expect(config.lastTag).to.equal("LAST TAG");
+  });
+
+  test("it captures LAST_COMMIT_GH and LAST_TAG_GH environment variables", () => {
+    process.env = {
+      ...process.env,
+      ...customVariables,
+      LAST_COMMIT: "",
+      LAST_TAG: "",
+      LAST_COMMIT_GH: "LAST COMMIT",
+      LAST_TAG_GH: "LAST TAG",
     };
 
     const config = buildConfig();


### PR DESCRIPTION
# Description

Problem: With last changes in CI we are now building images with `docker-compose`. During the build compose sets both `LAST_TAG` and `LAST_COMMIT` ARG values and these are then turned into ENVIRONMENT variables in Dockerfile ([see here](https://github.com/XGovFormBuilder/digital-form-builder/blob/master/designer/Dockerfile#L49)). 

The problem is that when the resulting images are executed outside the compose environment Docker will again try to configure both variables and because the expected arguments are not provided those variables endup being set as empty strings.

To solve this the CI is building a `.env` file with these variables and adding it to both runner and designer workspaces, and because we need to allow ACP to overwrite LAST_COMMIT and LAST_TAG, these variables are being renamed to  `LAST_TAG_GH` and `LAST_COMMIT_GH`.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

- [X] I have tested building and running locally with and without compose and also have tried overwriting the variables while running the images outside compose. 

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts
- [X] I have checked deployments are working in all environments
- [X] I have updated the architecture diagrams as per Contribute.md
