### PR TITLE
Display Scenario run times on the report

### DIFF
--- a/smoke-tests/designer/support/hooks.js
+++ b/smoke-tests/designer/support/hooks.js
@@ -22,6 +22,9 @@ exports.hooks = {
     generate({
       jsonDir: "./reports/json/",
       reportPath: "./reports/",
+      displayDuration: true,
+      durationInSeconds: true,
+      displayReportTime: true,
       // for more options see https://github.com/wswebcreation/multiple-cucumber-html-reporter#options
     });
   },


### PR DESCRIPTION
# Description
 
Enable scenario and steps run times to the report to allow further analysis on long running features/scenarios/steps

## Type of change

Please delete options that are not relevant.

- [x] Better reporting

# How Has This Been Tested?

The smoke-tests were run and the report was checked to see if the new data was present.

# Checklist:

- [x] My changes do not introduce any new linting errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto master and there are no code conflicts

<img width="1390" alt="Screenshot 2021-02-23 at 09 45 25" src="https://user-images.githubusercontent.com/4447278/108826166-e4081080-75bb-11eb-8c81-8c4327576e0c.png">

