### PR TITLE
Adding uptime to health check

### DIFF
--- a/designer/server/plugins/routes/healthCheck.ts
+++ b/designer/server/plugins/routes/healthCheck.ts
@@ -6,12 +6,13 @@ export const healthCheckRoute: ServerRoute = {
   path: "/health-check",
   handler: function () {
     const date = new Date();
-
+    const uptime = process.uptime();
     return {
       status: "OK",
       lastCommit: config.lastCommit,
       lastTag: config.lastTag,
       time: date.toUTCString(),
+      uptime: uptime,
     };
   },
 };

--- a/runner/src/server/routes/health-check.ts
+++ b/runner/src/server/routes/health-check.ts
@@ -5,12 +5,13 @@ export default {
   path: "/health-check",
   handler: function () {
     const date = new Date();
-
+    const uptime = process.uptime();
     return {
       status: "OK",
       lastCommit: config.lastCommit,
       lastTag: config.lastTag,
       time: date.toUTCString(),
+      uptime: uptime,
     };
   },
 };


### PR DESCRIPTION
# Description

Adding uptime to the health check endpoint, so we can see how long the service has been up for.



## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
- [x] Manual test


# Checklist:

- [x] My changes do not introduce any new linting errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto master and there are no code conflicts
- [x] I have checked deployments are working in all environments
- [x] I have updated the architecture diagrams as per Contribute.md
