### PR TITLE
FORMS-359 - setting secure flag on runner cookies

### DIFF
--- a/runner/src/server/config.ts
+++ b/runner/src/server/config.ts
@@ -44,7 +44,9 @@ const schema = Joi.object({
   serviceName: Joi.string().optional(),
   documentUploadApiUrl: Joi.string().default(DEFAULT_DOCUMENT_UPLOAD_API_URL),
   previewMode: Joi.boolean().optional(),
-  sslKey: Joi.string().optional(),
+  sslKey: Joi.string()
+    .optional()
+    .default(process.env.NODE_ENV === "development" ? null : "form-builder"),
   sslCert: Joi.string().optional(),
   sessionTimeout: Joi.number().default(DEFAULT_SESSION_TTL),
   sessionCookiePassword: Joi.string().optional(),


### PR DESCRIPTION
# Description
secure flag on session and crumb  cookies is guided by sslKey  from the config
setting a default will enable setting secure flags on cookies without breaking hapi tls functionality

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Manual Testing

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts
- [ ] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md
