### PR TITLE
Fix httpService response payload format

### DIFF
--- a/runner/src/server/services/httpService.ts
+++ b/runner/src/server/services/httpService.ts
@@ -19,7 +19,7 @@ export const request: Request = async (method, url, options = {}) => {
   const { res, payload } = await wreck[method](url, options);
 
   try {
-    return { res, payload: payload.toString() };
+    return { res, payload };
   } catch (error) {
     return { res, error };
   }

--- a/runner/test/cases/server/services/httpService.test.ts
+++ b/runner/test/cases/server/services/httpService.test.ts
@@ -1,0 +1,30 @@
+import * as Code from "@hapi/code";
+import * as Lab from "@hapi/lab";
+import sinon from "sinon";
+import wreck from "wreck";
+
+import { post } from "server/services/httpService";
+
+const { expect } = Code;
+const lab = Lab.script();
+exports.lab = lab;
+const { afterEach, beforeEach, suite, test } = lab;
+
+const sandbox = sinon.createSandbox();
+
+suite("Http Service", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  test("post request payload format is correct", async () => {
+    sinon.stub(wreck, "post").returns(
+      Promise.resolve({
+        res: {},
+        payload: { reference: "1234" },
+      })
+    );
+    const result = await post("/test", {});
+    expect(result).to.equal({ res: {}, payload: { reference: "1234" } });
+  });
+});


### PR DESCRIPTION
# Description

Payments were failing to be processed because Gov Pay request payload was being stringified, probably a bug introduced during refactor

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] I have tested the application locally to verify Gov Pay is processed successfully

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts
- [X] I have checked deployments are working in all environments
- [X] I have updated the architecture diagrams as per Contribute.md
