### PR TITLE
Fix non-relative payment related urls

### DIFF
--- a/runner/src/server/plugins/applicationStatus.ts
+++ b/runner/src/server/plugins/applicationStatus.ts
@@ -3,7 +3,7 @@ import { nanoid } from "nanoid";
 import {
   decodeFeedbackContextInfo,
   redirectTo,
-  redirectUrl,
+  nonRelativeRedirectUrl,
   RelativeUrl,
 } from "./engine";
 
@@ -197,7 +197,7 @@ const applicationStatus = {
             reference,
             meta.description,
             meta.payApiKey,
-            `${config.payReturnUrl}?visit=${request.query.visit}`
+            nonRelativeRedirectUrl(request, config.payReturnUrl)
           );
           await cacheService.mergeState(request, {
             pay: {

--- a/runner/src/server/plugins/engine/helpers.ts
+++ b/runner/src/server/plugins/engine/helpers.ts
@@ -22,6 +22,27 @@ export function proceed(
 
 type Params = { num?: number; returnUrl: string } | {};
 
+export function nonRelativeRedirectUrl(
+  request: HapiRequest,
+  targetUrl: string,
+  params: Params = {}
+) {
+  const url = new URL(targetUrl);
+
+  Object.entries(params).forEach(([name, value]) => {
+    url.searchParams.append(name, `${value}`);
+  });
+
+  paramsToCopy.forEach((key) => {
+    const value = request.query[key];
+    if (typeof value === "string") {
+      url.searchParams.append(key, value);
+    }
+  });
+
+  return url.toString();
+}
+
 export function redirectUrl(
   request: HapiRequest,
   targetUrl: string,

--- a/runner/src/server/plugins/engine/index.ts
+++ b/runner/src/server/plugins/engine/index.ts
@@ -3,5 +3,5 @@ export {
   FeedbackContextInfo,
   decodeFeedbackContextInfo,
 } from "./feedback";
-export { redirectTo, redirectUrl } from "./helpers";
+export { redirectTo, redirectUrl, nonRelativeRedirectUrl } from "./helpers";
 export { configureEnginePlugin } from "./configureEnginePlugin";

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -3,7 +3,7 @@ import { nanoid } from "nanoid";
 import config from "server/config";
 import { SummaryViewModel } from "../models";
 import { PageController } from "./PageController";
-import { redirectTo, redirectUrl } from "../helpers";
+import { redirectTo, redirectUrl, nonRelativeRedirectUrl } from "../helpers";
 import { HapiRequest, HapiResponseToolkit } from "server/types";
 import {
   RelativeUrl,
@@ -167,7 +167,7 @@ export class SummaryPageController extends PageController {
         paymentReference,
         description,
         summaryViewModel.payApiKey || "",
-        redirectUrl(request, payReturnUrl)
+        nonRelativeRedirectUrl(request, payReturnUrl)
       );
 
       request.yar.set("basePath", model.basePath);

--- a/runner/test/cases/server/plugins/engine/helpers.test.ts
+++ b/runner/test/cases/server/plugins/engine/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   proceed,
   redirectTo,
   redirectUrl,
+  nonRelativeRedirectUrl,
 } from "src/server/plugins/engine/helpers";
 import sinon from "sinon";
 const lab = Lab.script();
@@ -320,6 +321,21 @@ suite("Helpers", () => {
       const nextUrl = "badgers/monkeys";
       const returned = redirectUrl(request, nextUrl, { f_t: "newValue" });
       expect(returned).to.equal(`${nextUrl}?f_t=newValue`);
+    });
+  });
+
+  describe("nonRelativeRedirectUrl", () => {
+    test("Should return non-relative url with correct query parameters", () => {
+      const request = {
+        query: {
+          visit: "123",
+          f_t: "true",
+          ignored: true,
+        },
+      };
+      const nextUrl = "https://test.com";
+      const url = nonRelativeRedirectUrl(request, nextUrl);
+      expect(url).to.equal("https://test.com/?f_t=true&visit=123");
     });
   });
 });


### PR DESCRIPTION
# Description

Urls used for payments (which are set via environment variables) were failing because they were incorrectly treated as relative urls. This PR improves the fixes I added yersterday, adding a specific helper method which follows the already existing way of building redirect urls which copies over the existing query parameters. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] New and existing unit tests pass locally with my changes
- [X] I have tested the payment flow locally and it is running correctly

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts
- [X] I have checked deployments are working in all environments
- [X] I have updated the architecture diagrams as per Contribute.md
