### PR TITLE
Feature/notify personalisation include references

### DIFF
--- a/designer/client/__tests__/helpers/renderers.tsx
+++ b/designer/client/__tests__/helpers/renderers.tsx
@@ -24,6 +24,7 @@ export function RenderWithContextAndDataContext({
   children,
   stateProps = {},
   mockData = {},
+  mockSave = jest.fn(),
 }) {
   const [state, dispatch] = useReducer(
     componentReducer,
@@ -33,7 +34,7 @@ export function RenderWithContextAndDataContext({
   );
 
   return (
-    <DataContext.Provider value={{ data: mockData, save: jest.fn() }}>
+    <DataContext.Provider value={{ data: mockData, save: mockSave }}>
       <ComponentContext.Provider value={{ state, dispatch }}>
         {children}
       </ComponentContext.Provider>

--- a/designer/client/i18n/translations/en.translation.json
+++ b/designer/client/i18n/translations/en.translation.json
@@ -306,6 +306,12 @@
     }
   },
   "optional": "{{noun}} (optional)",
+  "outputEdit": {
+    "notifyEdit": {
+      "includeReferenceTitle": "Include webhook and payment references",
+      "includeReferenceHint": "If webhook or payment references are available, they will be included in Notify's personalisation object. The included fields are: hasWebhookReference (boolean), webhookReference: (string), hasPaymentReference: (boolean), paymentReference: string."
+    }
+  },
   "page": {
     "noun": "page",
     "noun_plural": "pages",

--- a/designer/client/outputs/__tests__/output-edit.jest.tsx
+++ b/designer/client/outputs/__tests__/output-edit.jest.tsx
@@ -5,7 +5,7 @@ import { Data } from "@xgovformbuilder/model";
 
 import OutputEdit from "../output-edit";
 
-describe("ComponentTypeEdit", () => {
+describe("OutputEdit", () => {
   let mockData: Data;
   let mockSave: any;
 

--- a/designer/client/outputs/__tests__/output-edit.jest.tsx
+++ b/designer/client/outputs/__tests__/output-edit.jest.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+// import ComponentTypeEdit from "../ComponentTypeEdit";
+// import {
+//   ComponentContext,
+//   componentReducer,
+//   initComponentState,
+// } from "../reducers/component/componentReducer";
+import { RenderWithContextAndDataContext } from "../../__tests__/helpers/renderers";
+// import { DataContext } from "../../context";
+import { Data } from "@xgovformbuilder/model";
+
+import OutputEdit from "../output-edit";
+
+describe("ComponentTypeEdit", () => {
+  let mockData: Data;
+  let mockSave: any;
+
+  beforeEach(() => {
+    mockSave = jest.fn().mockResolvedValue(mockData);
+    mockData = new Data({
+      pages: [
+        {
+          title: "First page",
+          path: "/first-page",
+          components: [
+            {
+              name: "9WH4EX",
+              options: {},
+              type: "TextField",
+              title: "Email",
+            },
+          ],
+          controller: "./pages/summary.js",
+        },
+      ],
+      outputs: [],
+    } as any);
+  });
+
+  describe("Notify", () => {
+    test("Notify Output object is created correctly", async () => {
+      const props: any = {
+        onEdit: jest.fn(),
+        onCancel: jest.fn(),
+        data: mockData,
+        output: {
+          name: "Notify Test",
+          title: "Notify Test",
+          type: "notify",
+          outputConfiguration: {
+            templateId: "123ID",
+            apiKey: "123KEY",
+            emailField: "9WH4EX",
+            personalisation: [],
+          },
+        },
+      };
+
+      const { getByText, getByLabelText } = render(
+        <RenderWithContextAndDataContext
+          mockData={mockData}
+          mockSave={mockSave}
+        >
+          <OutputEdit {...props} />
+        </RenderWithContextAndDataContext>
+      );
+
+      // change title
+      fireEvent.change(getByLabelText("Title"), {
+        target: { value: "NewTitle" },
+      });
+
+      // change name
+      fireEvent.change(getByLabelText("Name"), {
+        target: { value: "NewName" },
+      });
+
+      // change templateId
+      fireEvent.change(getByLabelText("Template ID"), {
+        target: { value: "NewTemplateId" },
+      });
+
+      // change apiKey
+      fireEvent.change(getByLabelText("API Key"), {
+        target: { value: "NewAPIKey" },
+      });
+
+      // change email field
+      fireEvent.change(getByLabelText("Email field"), {
+        target: { value: "9WH4EX" },
+      });
+
+      // include references
+      fireEvent.click(getByText("Include webhook and payment references"));
+
+      // save
+      fireEvent.click(getByText("Save"));
+
+      await waitFor(() => expect(mockSave).toHaveBeenCalledTimes(1));
+
+      expect(mockSave.mock.calls[0][0].outputs).toEqual([
+        {
+          name: "NewName",
+          title: "NewTitle",
+          type: "notify",
+          outputConfiguration: {
+            personalisation: [],
+            templateId: "NewTemplateId",
+            apiKey: "NewAPIKey",
+            emailField: "9WH4EX",
+            addReferencesToPersonalisation: true,
+          },
+        },
+      ]);
+    });
+  });
+});

--- a/designer/client/outputs/__tests__/output-edit.jest.tsx
+++ b/designer/client/outputs/__tests__/output-edit.jest.tsx
@@ -1,13 +1,6 @@
 import React from "react";
 import { render, fireEvent, waitFor } from "@testing-library/react";
-// import ComponentTypeEdit from "../ComponentTypeEdit";
-// import {
-//   ComponentContext,
-//   componentReducer,
-//   initComponentState,
-// } from "../reducers/component/componentReducer";
 import { RenderWithContextAndDataContext } from "../../__tests__/helpers/renderers";
-// import { DataContext } from "../../context";
 import { Data } from "@xgovformbuilder/model";
 
 import OutputEdit from "../output-edit";

--- a/designer/client/outputs/notify-edit.tsx
+++ b/designer/client/outputs/notify-edit.tsx
@@ -3,7 +3,7 @@ import React, { Component } from "react";
 import NotifyEditItems from "./notify-edit-items";
 import { Output, NotifyOutputConfiguration, ValidationErrors } from "./types";
 import { Input } from "@govuk-jsx/input";
-import { Checkboxes } from "@govuk-jsx/Checkboxes";
+import { Checkboxes } from "@govuk-jsx/checkboxes";
 import { ErrorMessage } from "@govuk-jsx/error-message";
 import classNames from "classnames";
 

--- a/designer/client/outputs/notify-edit.tsx
+++ b/designer/client/outputs/notify-edit.tsx
@@ -6,6 +6,7 @@ import { Input } from "@govuk-jsx/input";
 import { Checkboxes } from "@govuk-jsx/checkboxes";
 import { ErrorMessage } from "@govuk-jsx/error-message";
 import classNames from "classnames";
+import { i18n } from "../i18n";
 
 type State = {};
 
@@ -119,19 +120,12 @@ class NotifyEdit extends Component<Props, State> {
             items={[
               {
                 children: (
-                  <strong>Include webhook and payment references</strong>
+                  <strong>
+                    {i18n("outputEdit.notifyEdit.includeReferenceTitle")}
+                  </strong>
                 ),
                 hint: {
-                  children: (
-                    <div>
-                      If webhook or payment references are available, they will
-                      be included in Notify&apos;s personalisation object.
-                      <br />
-                      The included fields are: hasWebhookReference (boolean),
-                      webhookReference: (string), hasPaymentReference:
-                      (boolean), paymentReference: string.
-                    </div>
-                  ),
+                  children: i18n("outputEdit.notifyEdit.includeReferenceHint"),
                 },
                 value: true,
               },

--- a/designer/client/outputs/notify-edit.tsx
+++ b/designer/client/outputs/notify-edit.tsx
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 import NotifyEditItems from "./notify-edit-items";
 import { Output, NotifyOutputConfiguration, ValidationErrors } from "./types";
 import { Input } from "@govuk-jsx/input";
+import { Checkboxes } from "@govuk-jsx/Checkboxes";
 import { ErrorMessage } from "@govuk-jsx/error-message";
 import classNames from "classnames";
 
@@ -113,6 +114,31 @@ class NotifyEdit extends Component<Props, State> {
           data={data}
           onEdit={onEdit}
         />
+        <div className="govuk-form-group">
+          <Checkboxes
+            items={[
+              {
+                children: (
+                  <strong>Include webhook and payment references</strong>
+                ),
+                hint: {
+                  children: (
+                    <div>
+                      If webhook or payment references are available, they will
+                      be included in Notify&apos;s personalisation object.
+                      <br />
+                      The included fields are: hasWebhookReference (boolean),
+                      webhookReference: (string), hasPaymentReference:
+                      (boolean), paymentReference: string.
+                    </div>
+                  ),
+                },
+                value: true,
+              },
+            ]}
+            name="add-references-to-personalisation"
+          />
+        </div>
       </div>
     );
   }

--- a/designer/client/outputs/output-edit.tsx
+++ b/designer/client/outputs/output-edit.tsx
@@ -106,7 +106,6 @@ class OutputEdit extends Component<Props, State> {
       copy.outputs = copy.outputs || [];
       copy.outputs.push(output);
     }
-    console.log("XXXSUBBMITED", copy.outputs);
     save(copy)
       .then((data) => {
         this.props.onEdit({ data });

--- a/designer/client/outputs/output-edit.tsx
+++ b/designer/client/outputs/output-edit.tsx
@@ -82,6 +82,8 @@ class OutputEdit extends Component<Props, State> {
           templateId: formData.get("template-id") as string,
           apiKey: formData.get("api-key") as string,
           emailField: formData.get("email-field") as string,
+          addReferencesToPersonalisation:
+            formData.get("add-references-to-personalisation") === "true",
         };
         break;
       case OutputType.Webhook:
@@ -104,7 +106,7 @@ class OutputEdit extends Component<Props, State> {
       copy.outputs = copy.outputs || [];
       copy.outputs.push(output);
     }
-
+    console.log("XXXSUBBMITED", copy.outputs);
     save(copy)
       .then((data) => {
         this.props.onEdit({ data });

--- a/designer/client/outputs/output-edit.tsx
+++ b/designer/client/outputs/output-edit.tsx
@@ -106,6 +106,7 @@ class OutputEdit extends Component<Props, State> {
       copy.outputs = copy.outputs || [];
       copy.outputs.push(output);
     }
+
     save(copy)
       .then((data) => {
         this.props.onEdit({ data });

--- a/designer/client/outputs/types.ts
+++ b/designer/client/outputs/types.ts
@@ -13,6 +13,7 @@ export type NotifyOutputConfiguration = {
   templateId: string;
   emailField: string;
   personalisation: string[];
+  addReferencesToPersonalisation?: boolean;
 };
 
 export type WebhookOutputConfiguration = {

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -194,8 +194,9 @@ const feeSchema = joi.object().keys({
 const notifySchema = joi.object().keys({
   apiKey: joi.string().allow("").optional(),
   templateId: joi.string(),
-  personalisation: joi.array().items(joi.string()),
   emailField: joi.string(),
+  personalisation: joi.array().items(joi.string()),
+  addReferencesToPersonalisation: joi.boolean().optional(),
 });
 
 const emailSchema = joi.object().keys({

--- a/runner/src/server/plugins/applicationStatus.ts
+++ b/runner/src/server/plugins/applicationStatus.ts
@@ -121,7 +121,17 @@ const applicationStatus = {
                       templateId,
                       emailAddress,
                       personalisation = {},
+                      addReferencesToPersonalisation = false,
                     } = output.outputData;
+
+                    if (addReferencesToPersonalisation) {
+                      Object.assign(personalisation, {
+                        hasWebhookReference: !!newReference,
+                        webhookReference: newReference,
+                        hasPaymentReference: !!payState?.reference,
+                        paymentReference: payState?.reference,
+                      });
+                    }
 
                     return notifyService.sendNotification({
                       apiKey,

--- a/runner/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/runner/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -321,6 +321,8 @@ export class SummaryViewModel {
       personalisation,
       emailAddress: flatState[outputConfiguration.emailField],
       apiKey: outputConfiguration.apiKey,
+      addReferencesToPersonalisation:
+        outputConfiguration.addReferencesToPersonalisation,
     };
   }
 

--- a/runner/src/server/plugins/session.ts
+++ b/runner/src/server/plugins/session.ts
@@ -16,7 +16,7 @@ export default {
           .join(""),
       isSecure: !!config.isDev,
       isHttpOnly: true,
-      isSameSite: "Strict",
+      isSameSite: "Lax",
     },
   },
 };


### PR DESCRIPTION
# Description

Allow notify personalisation object to include webhook and payment references. 

## Changes

- Extend model to include `addReferencesToPersonalisation` flag to notifySchema
- Extend designer to allow a flag to be set in the Notify output configuration (screenshot below)
- Extend runner notify output behaviour to include references and respective flags in the notify personalisation object whenever `addReferencesToPersonalisation` flag is present

![Screenshot 2021-03-10 at 14 10 45](https://user-images.githubusercontent.com/2582353/110641944-71e21f00-81aa-11eb-94b8-7a5de559bbd2.png)

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] I have added new tests to validate new designer behaviour
- [X] New and existing unit tests pass locally with my changes
- [X] I have manually tested the runner and functionality is working as expected

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts
- [X] I have checked deployments are working in all environments
- [X] I have updated the architecture diagrams as per Contribute.md
