### PR TITLE
Error hint made more generic

### DIFF
--- a/designer/client/i18n/translations/en.translation.json
+++ b/designer/client/i18n/translations/en.translation.json
@@ -374,7 +374,7 @@
   "yes": "yes",
   "saveErrorPage": {
     "sorry": "Sorry, there is a problem with the service",
-    "error": "An error occurred while saving the component.",
+    "error": "An error occurred while saving.",
     "hint": "We saved the last valid version of your form. Return to the Designer to continue.",
     "report": "So we can check what went wrong, complete the following:",
     "downloadCrashReport": "download your crash report",

--- a/designer/client/pages/ErrorPages/SaveError.tsx
+++ b/designer/client/pages/ErrorPages/SaveError.tsx
@@ -36,7 +36,7 @@ export function SaveError({ history, location }: Props): ReactElement {
               </li>
               <li>
                 <a
-                  href="https://github.com/XGovFormBuilder/digital-form-builder/issues"
+                  href="https://github.com/XGovFormBuilder/digital-form-builder/issues/new?template=bug_report.md"
                   className="govuk-link"
                   target="_blank"
                   rel="noopener noreferrer"

--- a/designer/client/pages/ErrorPages/__tests__/SaveError.jest.tsx
+++ b/designer/client/pages/ErrorPages/__tests__/SaveError.jest.tsx
@@ -48,7 +48,7 @@ describe("SaveErrorPage", () => {
       screen.getByText("create an issue on GitHub").closest("a")
     ).toHaveAttribute(
       "href",
-      "https://github.com/XGovFormBuilder/digital-form-builder/issues"
+      "https://github.com/XGovFormBuilder/digital-form-builder/issues/new?template=bug_report.md"
     );
   });
 

--- a/designer/client/pages/ErrorPages/__tests__/SaveError.jest.tsx
+++ b/designer/client/pages/ErrorPages/__tests__/SaveError.jest.tsx
@@ -24,7 +24,7 @@ describe("SaveErrorPage", () => {
       await screen.findByText("Sorry, there is a problem with the service")
     ).toBeInTheDocument();
     expect(
-      await screen.findByText("An error occurred while saving the component.")
+      await screen.findByText("An error occurred while saving.")
     ).toBeInTheDocument();
     expect(
       await screen.findByText(

--- a/runner/src/server/plugins/applicationStatus.ts
+++ b/runner/src/server/plugins/applicationStatus.ts
@@ -126,9 +126,9 @@ const applicationStatus = {
                     if (addReferencesToPersonalisation) {
                       Object.assign(personalisation, {
                         hasWebhookReference: !!newReference,
-                        webhookReference: newReference,
+                        webhookReference: newReference || "",
                         hasPaymentReference: !!payState?.reference,
-                        paymentReference: payState?.reference,
+                        paymentReference: payState?.reference || "",
                       });
                     }
 


### PR DESCRIPTION
# Description
Error message on save error page changed , the save error page was originally intended for errors while saving components , but since we cannot differentiate save of other form details vs save of components , error message is made generic 

- Change i18n text
- Change test case

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Unit Test modified
- [X] Manual test

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts
- [ ] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md
