### PR TITLE
Fix/runner autocomplete missing empty option 

### DIFF
--- a/runner/src/server/plugins/engine/components/AutocompleteField.ts
+++ b/runner/src/server/plugins/engine/components/AutocompleteField.ts
@@ -3,10 +3,17 @@ import { ListComponentsDef } from "@xgovformbuilder/model";
 import { SelectField } from "./SelectField";
 import { FormModel } from "../models";
 import { addClassOptionIfNone } from "./helpers";
+import { FormSubmissionErrors, FormData } from "../types";
 
 export class AutocompleteField extends SelectField {
   constructor(def: ListComponentsDef, model: FormModel) {
     super(def, model);
     addClassOptionIfNone(this.options, "govuk-input--width-20");
+  }
+
+  getViewModel(formData: FormData, errors: FormSubmissionErrors) {
+    const viewModel = super.getViewModel(formData, errors);
+    viewModel.items = [{ value: "" }, ...(viewModel.items ?? [])];
+    return viewModel;
   }
 }

--- a/runner/test/cases/server/plugins/engine/components/AutocompleteField.test.ts
+++ b/runner/test/cases/server/plugins/engine/components/AutocompleteField.test.ts
@@ -1,0 +1,84 @@
+import * as Code from "@hapi/code";
+import * as Lab from "@hapi/lab";
+import { AutocompleteField } from "server/plugins/engine/components/AutocompleteField";
+const lab = Lab.script();
+exports.lab = lab;
+const { expect } = Code;
+const { suite, describe, it } = lab;
+import sinon from "sinon";
+
+const lists = [
+  {
+    name: "Countries",
+    title: "Countries",
+    type: "string",
+    items: [
+      {
+        text: "United Kingdom",
+        value: "United Kingdom",
+        description: "",
+        condition: "",
+      },
+      {
+        text: "Thailand",
+        value: "Thailand",
+        description: "",
+        condition: "",
+      },
+      {
+        text: "Spain",
+        value: "Spain",
+        description: "",
+        condition: "",
+      },
+      {
+        text: "France",
+        value: "France",
+        description: "",
+        condition: "",
+      },
+      {
+        text: "Thailand",
+        value: "Thailand",
+        description: "",
+        condition: "",
+      },
+    ],
+  },
+];
+
+suite("AutocompleteField", () => {
+  describe("Generated schema", () => {
+    const componentDefinition = {
+      subType: "field",
+      type: "AutocompleteField",
+      name: "MyAutocomplete",
+      title: "Country?",
+      options: {},
+      list: "Countries",
+      schema: {},
+    };
+
+    const formModel = {
+      getList: (_name) => lists[0],
+      makePage: () => sinon.stub(),
+    };
+
+    const component = new AutocompleteField(componentDefinition, formModel);
+
+    it("is required by default", () => {
+      expect(component.formSchema.describe().flags.presence).to.equal(
+        "required"
+      );
+    });
+
+    it("validates correctly", () => {
+      expect(component.formSchema.validate({}).error).to.exist();
+    });
+
+    it("includes the first empty item in items list", () => {
+      const { items } = component.getViewModel({ lang: "en" });
+      expect(items[0]).to.equal({ value: "" });
+    });
+  });
+});


### PR DESCRIPTION
# Description

Fix bug where Autocomplete input was showing the first autocomplete option by default.

- Overriding Autocomplete getViewModel to include the first empty item and test

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto master and there are no code conflicts
- [X] I have checked deployments are working in all environments
- [X] I have updated the architecture diagrams as per Contribute.md
