### PR TITLE
Chore/visit-id-#152

### DIFF
--- a/runner/src/server/plugins/engine/helpers.ts
+++ b/runner/src/server/plugins/engine/helpers.ts
@@ -2,9 +2,8 @@ import { RelativeUrl } from "./feedback";
 import { HapiRequest, HapiResponseToolkit } from "server/types";
 
 export const feedbackReturnInfoKey = "f_t";
-export const visitIdentifierKey = "visit";
 
-const paramsToCopy = [feedbackReturnInfoKey, visitIdentifierKey];
+const paramsToCopy = [feedbackReturnInfoKey];
 
 export function proceed(
   request: HapiRequest,

--- a/runner/src/server/plugins/engine/plugin.ts
+++ b/runner/src/server/plugins/engine/plugin.ts
@@ -1,16 +1,13 @@
 import path from "path";
 import { configure } from "nunjucks";
 import { redirectTo } from "./helpers";
-import { RelativeUrl } from "./feedback";
 import { FormConfiguration } from "@xgovformbuilder/model";
 import { HapiServer, HapiRequest, HapiResponseToolkit } from "server/types";
 
 import { FormModel } from "./models";
-import { nanoid } from "nanoid";
 import Boom from "boom";
 import { PluginSpecificConfiguration } from "@hapi/hapi";
 import { FormPayload } from "./types";
-import { visitIdentifierKey } from "./helpers";
 
 configure([
   // Configure Nunjucks to allow rendering of content that is revealed conditionally.
@@ -42,21 +39,6 @@ function getStartPageRedirect(
   }
 
   return startPageRedirect;
-}
-
-function redirectWithVisitParameter(
-  request: HapiRequest,
-  h: HapiResponseToolkit
-) {
-  const visitId = request.query[visitIdentifierKey];
-
-  if (!visitId) {
-    const params = Object.assign({}, request.query);
-    params[visitIdentifierKey] = nanoid(10);
-    return redirectTo(request, h, request.url.pathname, params);
-  }
-
-  return undefined;
 }
 
 type PluginOptions = {
@@ -153,20 +135,16 @@ export const plugin = {
       method: "get",
       path: "/",
       handler: (request: HapiRequest, h: HapiResponseToolkit) => {
-        function handle() {
-          const keys = Object.keys(forms);
-          let id = "";
-          if (keys.length === 1) {
-            id = keys[0];
-          }
-          const model = forms[id];
-          if (model) {
-            return getStartPageRedirect(request, h, id, model);
-          }
-          throw Boom.notFound("No default form found");
+        const keys = Object.keys(forms);
+        let id = "";
+        if (keys.length === 1) {
+          id = keys[0];
         }
-
-        return redirectWithVisitParameter(request, h) || handle();
+        const model = forms[id];
+        if (model) {
+          return getStartPageRedirect(request, h, id, model);
+        }
+        throw Boom.notFound("No default form found");
       },
     });
 
@@ -174,16 +152,12 @@ export const plugin = {
       method: "get",
       path: "/{id}",
       handler: (request: HapiRequest, h: HapiResponseToolkit) => {
-        function handle() {
-          const { id } = request.params;
-          const model = forms[id];
-          if (model) {
-            return getStartPageRedirect(request, h, id, model);
-          }
-          throw Boom.notFound("No form found for id");
+        const { id } = request.params;
+        const model = forms[id];
+        if (model) {
+          return getStartPageRedirect(request, h, id, model);
         }
-
-        return redirectWithVisitParameter(request, h) || handle();
+        throw Boom.notFound("No form found for id");
       },
     });
 
@@ -191,25 +165,18 @@ export const plugin = {
       method: "get",
       path: "/{id}/{path*}",
       handler: (request: HapiRequest, h: HapiResponseToolkit) => {
-        function handle() {
-          const { path, id } = request.params;
-          const model = forms[id];
-
-          if (model) {
-            const page = model.pages.find(
-              (page) => normalisePath(page.path) === normalisePath(path)
-            );
-            if (page) {
-              return page.makeGetRouteHandler()(request, h);
-            }
-            if (normalisePath(path) === "") {
-              return getStartPageRedirect(request, h, id, model);
-            }
-          }
-          throw Boom.notFound("No form or page found");
+        const { path, id } = request.params;
+        const model = forms[id];
+        const page = model?.pages.find(
+          (page) => normalisePath(page.path) === normalisePath(path)
+        );
+        if (page) {
+          return page.makeGetRouteHandler()(request, h);
         }
-
-        return redirectWithVisitParameter(request, h) || handle();
+        if (normalisePath(path) === "") {
+          return getStartPageRedirect(request, h, id, model);
+        }
+        throw Boom.notFound("No form or page found");
       },
     });
 

--- a/runner/src/server/services/cacheService.ts
+++ b/runner/src/server/services/cacheService.ts
@@ -37,7 +37,7 @@ export class CacheService {
     nullOverride = true,
     arrayMerge = false
   ) {
-    const key = this.Key(request.yar.id, request.query.visit);
+    const key = this.Key(request.yar.id, request.params.id);
     const state = await this.getState(request);
     hoek.merge(state, value, nullOverride, arrayMerge);
     await this.cache.set(key, state, sessionTimeout);
@@ -46,14 +46,21 @@ export class CacheService {
 
   async clearState(request: HapiRequest) {
     if (request.yar && request.yar.id) {
-      this.cache.drop(this.Key(request.yar.id, request.query.visit));
+      this.cache.drop(this.Key(request.yar.id, request.params.id));
     }
   }
 
-  Key(sessionId: string, visitId: string | string[]) {
+  /**
+   * The key used to store user session data against.
+   * If there are multiple forms on the same runner instance, for example `form-a` and `form-a-feedback` this will prevent CacheService from clearing data from `form-a` if a user gave feedback before they finished `form-a`
+   *
+   * @param sessionId - provided by @hapi/yar
+   * @param formId - this is the id of the form the server was initiated with
+   */
+  Key(sessionId: string, formId: string) {
     return {
       segment: partition,
-      id: `${sessionId}:${visitId}`,
+      id: `${sessionId}:${formId}`,
     };
   }
 }

--- a/runner/src/server/services/cacheService.ts
+++ b/runner/src/server/services/cacheService.ts
@@ -26,7 +26,7 @@ export class CacheService {
 
   async getState(request: HapiRequest): Promise<FormSubmissionState> {
     const cached = await this.cache.get(
-      this.Key(request.yar.id, request.query.visit)
+      this.Key(request.yar.id, request.params.id)
     );
     return cached || {};
   }

--- a/runner/test/cases/server/plugins/engine/helpers.test.ts
+++ b/runner/test/cases/server/plugins/engine/helpers.test.ts
@@ -79,20 +79,6 @@ suite("Helpers", () => {
       expect(returned).to.equal(returnValue);
     });
 
-    test("Should copy visit param from the original request", () => {
-      const request = {
-        query: {
-          visit: "myValue",
-        },
-      };
-      const nextUrl = "badgers/monkeys";
-      const returned = proceed(request, h, nextUrl);
-
-      expect(h.redirect.callCount).to.equal(1);
-      expect(h.redirect.firstCall.args[0]).to.equal(`${nextUrl}?visit=myValue`);
-      expect(returned).to.equal(returnValue);
-    });
-
     test("Should use params provided in nextUrl in preference to those in the original request", () => {
       const request = {
         query: {
@@ -156,20 +142,6 @@ suite("Helpers", () => {
 
       expect(h.redirect.callCount).to.equal(1);
       expect(h.redirect.firstCall.args[0]).to.equal(`${nextUrl}?f_t=myValue`);
-      expect(returned).to.equal(returnValue);
-    });
-
-    test("Should copy visit param from the original request", () => {
-      const request = {
-        query: {
-          visit: "myValue",
-        },
-      };
-      const nextUrl = "badgers/monkeys";
-      const returned = redirectTo(request, h, nextUrl);
-
-      expect(h.redirect.callCount).to.equal(1);
-      expect(h.redirect.firstCall.args[0]).to.equal(`${nextUrl}?visit=myValue`);
       expect(returned).to.equal(returnValue);
     });
 
@@ -271,18 +243,6 @@ suite("Helpers", () => {
       expect(returned).to.equal(`${nextUrl}?f_t=myValue`);
     });
 
-    test("Should copy visit param from the original request", () => {
-      const request = {
-        query: {
-          visit: "myValue",
-        },
-      };
-      const nextUrl = "badgers/monkeys";
-      const returned = redirectUrl(request, nextUrl);
-
-      expect(returned).to.equal(`${nextUrl}?visit=myValue`);
-    });
-
     test("Should use params provided in nextUrl in preference to those in the original request", () => {
       const request = {
         query: {
@@ -335,7 +295,7 @@ suite("Helpers", () => {
       };
       const nextUrl = "https://test.com";
       const url = nonRelativeRedirectUrl(request, nextUrl);
-      expect(url).to.equal("https://test.com/?f_t=true&visit=123");
+      expect(url).to.equal("https://test.com/?f_t=true");
     });
   });
 });


### PR DESCRIPTION
# Description

the visit query parameter was added as part of #81. IIRC the purpose of having the query param was to prevent the cache being cleared for `form-a` if someone decided to fill out the feedback form halfway through. It was causing some issues though, see #152. 

- Removing the copying of visit parameter
- Change `Key` from `${sessionId}:${visitId}` to `${sessionId}:${formId}` <- where formId is `request.params.id`, the id of the form. Comes from: https://github.com/XGovFormBuilder/digital-form-builder/blob/9953ff825ed7e205c63374fa6906d89860517e0a/runner/src/server/plugins/engine/plugin.ts#L192

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

Before PR's can be merged they will need to be tested by QA and approved where
applicable. To flag the change to QA assign **@XGovFormBuilder/qa** as one of the reviewers.

- manual, visitId no longer appended
- manual, going to the summary, changing an answer, return url works fine
- manual, going through a few pages, going back a few pages, answers are still persisted 


# Checklist:

- [x] My changes do not introduce any new linting errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto main and there are no code conflicts
- [n/a] I have checked deployments are working in all environments
- [n/a] I have updated the architecture diagrams as per Contribute.md
