### PR TITLE
Fix/runner summary page "not supplied" bug

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  reviewers:
+  - gstevenson
+  ignore:
+  - dependency-name: "@babel/plugin-transform-runtime"
+    versions:
+    - 7.12.15
+    - 7.13.10
+    - 7.13.9
+  - dependency-name: webpack
+    versions:
+    - 5.22.0
+    - 5.23.0
+    - 5.24.2
+  - dependency-name: i18next
+    versions:
+    - 19.8.8
+    - 19.9.0
+  - dependency-name: "@babel/register"
+    versions:
+    - 7.12.13
+  - dependency-name: "@wdio/local-runner"
+    versions:
+    - 7.0.4
+  - dependency-name: copy-webpack-plugin
+    versions:
+    - 7.0.0
+  - dependency-name: "@babel/plugin-proposal-export-default-from"
+    versions:
+    - 7.12.13

--- a/runner/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/runner/src/server/plugins/engine/components/ListFormComponent.ts
@@ -49,7 +49,8 @@ export class ListFormComponent extends FormComponent {
   getDisplayStringFromState(state: FormSubmissionState): string | string[] {
     const { name, items } = this;
     const value = state[name];
-    return `${items.find((item) => item.value === value)?.value ?? ""}`;
+    const item = items.find((item) => String(item.value) === String(value));
+    return `${item?.value ?? ""}`;
   }
   getViewModel(formData: FormData, errors: FormSubmissionErrors) {
     const { name, items } = this;

--- a/runner/src/server/plugins/engine/models/submission/FeesModel.ts
+++ b/runner/src/server/plugins/engine/models/submission/FeesModel.ts
@@ -7,28 +7,29 @@ export function FeesModel(
   model: FormModel,
   state: FormSubmissionState
 ): Fees | undefined {
-  let applicableFees: FeeDetails[] = [];
-
   if (model.def.fees) {
-    applicableFees = model.def.fees.filter((fee) => {
+    const applicableFees: FeeDetails[] = model.def.fees.filter((fee) => {
       return !fee.condition || model.conditions[fee.condition].fn(state);
     });
 
-    const flatState = flatten(state);
+    if (applicableFees.length > 0) {
+      // @ts-ignore
+      const flatState = flatten(state);
 
-    return {
-      details: applicableFees,
-      total: Object.values(applicableFees)
-        .map((fee) => {
-          if (fee.multiplier) {
-            const multiplyBy = flatState[fee.multiplier];
-            fee.multiplyBy = Number(multiplyBy);
-            return fee.multiplyBy * fee.amount;
-          }
-          return fee.amount;
-        })
-        .reduce((a, b) => a + b, 0),
-    };
+      return {
+        details: applicableFees,
+        total: Object.values(applicableFees)
+          .map((fee) => {
+            if (fee.multiplier) {
+              const multiplyBy = flatState[fee.multiplier];
+              fee.multiplyBy = Number(multiplyBy);
+              return fee.multiplyBy * fee.amount;
+            }
+            return fee.amount;
+          })
+          .reduce((a, b) => a + b, 0),
+      };
+    }
   }
 
   return undefined;

--- a/runner/test/cases/server/plugins/engine/components/ListFormComponents.test.ts
+++ b/runner/test/cases/server/plugins/engine/components/ListFormComponents.test.ts
@@ -1,0 +1,64 @@
+import * as Code from "@hapi/code";
+import * as Lab from "@hapi/lab";
+import { ListFormComponent } from "server/plugins/engine/components/ListFormComponent";
+import { FormSubmissionState } from "server/plugins/engine";
+const lab = Lab.script();
+exports.lab = lab;
+const { expect } = Code;
+const { suite, describe, it, beforeEach } = lab;
+import sinon from "sinon";
+
+const lists = [
+  {
+    title: "Turnaround",
+    name: "Turnaround",
+    type: "string",
+    items: [
+      { text: "1 hour", value: "1" },
+      { text: "2 hours", value: "2" },
+    ],
+  },
+];
+
+suite("ListFormComponent", () => {
+  let componentDefinition;
+  let formModel;
+  let component;
+
+  beforeEach(() => {
+    componentDefinition = {
+      subType: "field",
+      type: "ListFormComponent",
+      name: "MyListFormComponent",
+      title: "Turnaround?",
+      options: {},
+      list: "Turnaround",
+      schema: {},
+    };
+
+    formModel = {
+      getList: () => lists[0],
+      makePage: () => sinon.stub(),
+    };
+
+    component = new ListFormComponent(componentDefinition, formModel);
+  });
+
+  describe("getDisplayStringFromState", () => {
+    it("it gets value correctly when state value is string", () => {
+      const state: FormSubmissionState = {
+        progress: [],
+        MyListFormComponent: "2",
+      };
+      expect(component.getDisplayStringFromState(state)).to.equal("2");
+    });
+
+    it("it gets value correctly when state value is number", () => {
+      const state: FormSubmissionState = {
+        progress: [],
+        MyListFormComponent: 2,
+      };
+      expect(component.getDisplayStringFromState(state)).to.equal("2");
+    });
+  });
+});

--- a/smoke-tests/designer/package.json
+++ b/smoke-tests/designer/package.json
@@ -21,7 +21,7 @@
     "@wdio/selenium-standalone-service": "^6.12.1",
     "@wdio/spec-reporter": "^6.6.0",
     "@wdio/sync": "^6.6.0",
-    "chromedriver": "^88.0.0",
+    "chromedriver": "~89.0.0",
     "fs-extra": "^9.0.1",
     "multiple-cucumber-html-reporter": "^1.18.0",
     "wdio-chromedriver-service": "^6.0.4"

--- a/smoke-tests/designer/wdio.conf.js
+++ b/smoke-tests/designer/wdio.conf.js
@@ -1,6 +1,6 @@
 const { hooks } = require("./support/hooks");
 const drivers = {
-  chrome: { version: "89.0.4389.23" }, // https://chromedriver.chromium.org/
+  chrome: { version: "91.0.4472.101" }, // https://chromedriver.chromium.org/
   firefox: { version: "0.27.0" }, // https://github.com/mozilla/geckodriver/releases
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4893,7 +4893,7 @@ __metadata:
     arkit: ^1.6.4
     chai: ^4.2.0
     chai-webdriverio: ^1.0.0
-    chromedriver: ^88.0.0
+    chromedriver: ~91.0.1
     cucumber-html-reporter: ^5.2.0
     fs-extra: ^9.0.1
     multiple-cucumber-html-reporter: ^1.18.0
@@ -7194,21 +7194,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromedriver@npm:^88.0.0":
-  version: 88.0.0
-  resolution: "chromedriver@npm:88.0.0"
+"chromedriver@npm:~91.0.1":
+  version: 91.0.1
+  resolution: "chromedriver@npm:91.0.1"
   dependencies:
     "@testim/chrome-version": ^1.0.7
     axios: ^0.21.1
     del: ^6.0.0
     extract-zip: ^2.0.1
     https-proxy-agent: ^5.0.0
-    mkdirp: ^1.0.4
     proxy-from-env: ^1.1.0
     tcp-port-used: ^1.0.1
   bin:
     chromedriver: bin/chromedriver
-  checksum: 2036cbabf57ca724cd5dac18e1ea794599b8f525396dec1454947f48d67dc0d24c671e1c42b09f9493c4e190babccc69e78a3391d6d370279dcb86312798c797
+  checksum: c0e343c1a72cb2bd36d5918a36ceb1b3b3061dc40d1425c5d8d7d56ed2e38e636f9271da8139224758afd619cdb596faf07b603cce2a48ec0d59b1f44ff87327
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Bug: If we create a list with numeric values and assign it to any list based component, the selected value(s) appear in the summary page as `not supplied`

**Steps to Reproduce**:
1. Load the following form: 
{"startPage":"/first-page","pages":[{"title":"First page","path":"/first-page","components":[{"values":{"type":"listRef","list":"UTITt1"},"name":"GI4G9Q","options":{},"type":"RadiosField","title":"Turnaround time?"}],"next":[{"path":"/summary"}]},{"title":"Summary","path":"/summary","controller":"./pages/summary.js","components":[]}],"lists":[{"title":"Turnaround","name":"UTITt1","type":"string","items":[{"text":"1 hour","value":"1"},{"text":"2 hours","value":"2"}]}],"sections":[],"phaseBanner":{},"metadata":{},"fees":[],"outputs":[],"version":2,"conditions":[]}
2. Preview it on runner and select any Turnaround time, then click next.
3. You will see that the summary page displays: `Turnaround	Not supplied`

# Changes
- Refactor ListFormComponent.ts method getDisplayStringFromState so it strictly compare values as String
- ListFormComponent getDisplayStringFromState unit tests

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] I have added tests that prove my fix is effective
- [X] I have manually tested to confirm bug is fixed

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto main and there are no code conflicts
- [X] I have checked deployments are working in all environments
- [X] I have updated the architecture diagrams as per Contribute.md
