### PR TITLE
fix: Make sure types are correct before strictly comparing and tests

### DIFF
--- a/runner/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/runner/src/server/plugins/engine/components/ListFormComponent.ts
@@ -53,8 +53,10 @@ export class ListFormComponent extends FormComponent {
   getDisplayStringFromState(state: FormSubmissionState): string | string[] {
     const { name, items } = this;
     const value = state[name];
-    return `${items.find((item) => item.value === value)?.value ?? ""}`;
+    const item = items.find((item) => String(item.value) === String(value));
+    return `${item?.value ?? ""}`;
   }
+
   getViewModel(formData: FormData, errors: FormSubmissionErrors) {
     const { name, items } = this;
     const viewModel = super.getViewModel(formData, errors);

--- a/runner/test/cases/server/plugins/engine/components/ListFormComponents.test.ts
+++ b/runner/test/cases/server/plugins/engine/components/ListFormComponents.test.ts
@@ -1,0 +1,64 @@
+import * as Code from "@hapi/code";
+import * as Lab from "@hapi/lab";
+import sinon from "sinon";
+import { ListFormComponent } from "server/plugins/engine/components/ListFormComponent";
+import { FormSubmissionState } from "server/plugins/engine";
+const lab = Lab.script();
+exports.lab = lab;
+const { expect } = Code;
+const { suite, describe, it, beforeEach } = lab;
+
+const lists = [
+  {
+    title: "Turnaround",
+    name: "Turnaround",
+    type: "string",
+    items: [
+      { text: "1 hour", value: "1" },
+      { text: "2 hours", value: "2" },
+    ],
+  },
+];
+
+suite("ListFormComponent", () => {
+  let componentDefinition;
+  let formModel;
+  let component;
+
+  beforeEach(() => {
+    componentDefinition = {
+      subType: "field",
+      type: "ListFormComponent",
+      name: "MyListFormComponent",
+      title: "Turnaround?",
+      options: {},
+      list: "Turnaround",
+      schema: {},
+    };
+
+    formModel = {
+      getList: () => lists[0],
+      makePage: () => sinon.stub(),
+    };
+
+    component = new ListFormComponent(componentDefinition, formModel);
+  });
+
+  describe("getDisplayStringFromState", () => {
+    it("it gets value correctly when state value is string", () => {
+      const state: FormSubmissionState = {
+        progress: [],
+        MyListFormComponent: "2",
+      };
+      expect(component.getDisplayStringFromState(state)).to.equal("2");
+    });
+
+    it("it gets value correctly when state value is number", () => {
+      const state: FormSubmissionState = {
+        progress: [],
+        MyListFormComponent: 2,
+      };
+      expect(component.getDisplayStringFromState(state)).to.equal("2");
+    });
+  });
+});

--- a/smoke-tests/designer/features/steps/completeAForm.steps.js
+++ b/smoke-tests/designer/features/steps/completeAForm.steps.js
@@ -66,7 +66,7 @@ Then(/^the Summary page is displayed with my answers$/, function () {
     "22 March 2021"
   );
   expect(formRunner.summaryAnswer(formData.radio2.question)).toHaveText(
-    "Not supplied"
+    "2"
   );
   expect(formRunner.summaryAnswer(formData.multiLine.question)).toHaveText(
     "I've turned it into a spaceship capable of interstellar travel"

--- a/smoke-tests/designer/features/steps/completeAForm.steps.js
+++ b/smoke-tests/designer/features/steps/completeAForm.steps.js
@@ -57,7 +57,7 @@ Then(/^the Summary page is displayed with my answers$/, function () {
     "1, 2"
   );
   expect(formRunner.summaryAnswer(formData.autoComp.question)).toHaveText(
-    "Not supplied"
+    "2"
   );
   expect(formRunner.summaryAnswer(formData.textField.question)).toHaveText(
     "740"

--- a/smoke-tests/designer/features/steps/completeAForm.steps.js
+++ b/smoke-tests/designer/features/steps/completeAForm.steps.js
@@ -66,7 +66,7 @@ Then(/^the Summary page is displayed with my answers$/, function () {
     "22 March 2021"
   );
   expect(formRunner.summaryAnswer(formData.radio2.question)).toHaveText(
-    "2"
+    "3"
   );
   expect(formRunner.summaryAnswer(formData.multiLine.question)).toHaveText(
     "I've turned it into a spaceship capable of interstellar travel"


### PR DESCRIPTION
# Description

Bug: If we create a list with numeric values and assign it to any list based component, the selected value(s) appear in the summary page as `not supplied`

**Steps to Reproduce**:
1. Load the following form: 
{"startPage":"/first-page","pages":[{"title":"First page","path":"/first-page","components":[{"values":{"type":"listRef","list":"UTITt1"},"name":"GI4G9Q","options":{},"type":"RadiosField","title":"Turnaround time?"}],"next":[{"path":"/summary"}]},{"title":"Summary","path":"/summary","controller":"./pages/summary.js","components":[]}],"lists":[{"title":"Turnaround","name":"UTITt1","type":"string","items":[{"text":"1 hour","value":"1"},{"text":"2 hours","value":"2"}]}],"sections":[],"phaseBanner":{},"metadata":{},"fees":[],"outputs":[],"version":2,"conditions":[]}
2. Preview it on runner and select any Turnaround time, then click next.
3. You will see that the summary page displays: `Turnaround	Not supplied`

# Changes
- Refactor ListFormComponent.ts method getDisplayStringFromState so it strictly compare values as String
- ListFormComponent getDisplayStringFromState unit tests

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] I have added tests that prove my fix is effective
- [X] I have manually tested to confirm bug is fixed

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto main and there are no code conflicts
- [X] I have checked deployments are working in all environments
- [X] I have updated the architecture diagrams as per Contribute.md
