### PR TITLE
Cookie banner

### DIFF
--- a/designer/package.json
+++ b/designer/package.json
@@ -121,7 +121,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-tsdoc": "^0.2.14",
     "file-loader": "^6.1.0",
-    "govuk-frontend": "^3.10.1",
+    "govuk-frontend": "^3.13.0",
     "html-webpack-plugin": "^4.5.0",
     "i18next-parser": "^3.3.0",
     "jest": "^26.6.3",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "govuk-frontend": "^3.10.1"
+    "govuk-frontend": "^3.13.0"
   },
   "resolutions": {
     "braces": "2.3.1",

--- a/runner/package.json
+++ b/runner/package.json
@@ -63,7 +63,7 @@
     "flat": "5.0.2",
     "form-data": "3.0.0",
     "googleapis": "64.0.0",
-    "govuk-frontend": "^3.10.1",
+    "govuk-frontend": "^3.13.0",
     "hapi-pino": "8.0.0",
     "hapi-pulse": "3.0.0",
     "hapi-rate-limit": "4.1.0",

--- a/runner/public/static/govuk-template.js
+++ b/runner/public/static/govuk-template.js
@@ -49,6 +49,7 @@
   GOVUK.getCookie = function (name) {
     var nameEQ = name + '='
     var cookies = document.cookie.split(';')
+    
     for (var i = 0, len = cookies.length; i < len; i++) {
       var cookie = cookies[i]
       while (cookie.charAt(0) === ' ') {
@@ -69,13 +70,18 @@
   }
 
   GOVUK.addCookieMessage = function () {
-    var message = document.getElementById('global-cookie-message')
+    var message = document.getElementById('global-cookie-message');
+    var cookiesPolicy = GOVUK.getCookie('cookies_policy');
 
-    var hasCookieMessage = (message && GOVUK.cookie('seen_cookie_message') === null)
-
-    if (hasCookieMessage) {
-      message.style.display = 'block'
-      GOVUK.cookie('seen_cookie_message', 'yes', { days: 28 })
+    try {
+      cookiesPolicy = JSON.parse(atob(cookiesPolicy));
+    } catch (error) {
+      cookiesPolicy = {};
+    }
+    
+    if (message && !cookiesPolicy.essential) {
+      message.style.display = 'block';
+      GOVUK.setCookie('cookies_policy', btoa(JSON.stringify({ "essential":true })), { days: 28 });
     }
   }
 }).call(this);

--- a/runner/src/client/sass/_hmpo.scss
+++ b/runner/src/client/sass/_hmpo.scss
@@ -1,6 +1,6 @@
-@import "../../../../node_modules/hmpo-components/assets/stylesheets/mixins";
-@import "../../../../node_modules/hmpo-components/components/hmpo-circle-step/style";
-@import "../../../../node_modules/hmpo-components/components/hmpo-flash-card/style";
+@import "./../../../node_modules/hmpo-components/assets/stylesheets/mixins";
+@import "./../../../node_modules/hmpo-components/components/hmpo-circle-step/style";
+@import "./../../../node_modules/hmpo-components/components/hmpo-flash-card/style";
 
 /* from "hmpo-components/assets/stylesheets/_typeography.scss"
  * fixes typography for circle steps. The whole file messes up confirmation/panel.

--- a/runner/src/client/sass/application.scss
+++ b/runner/src/client/sass/application.scss
@@ -63,8 +63,4 @@
 #global-cookie-message {
   width: 100%;
   display: none;
-
-  // .js-enabled & {
-  //   display: none;
-  // }
 }

--- a/runner/src/client/sass/application.scss
+++ b/runner/src/client/sass/application.scss
@@ -1,4 +1,4 @@
-@import "../../../../node_modules/govuk-frontend/govuk/all";
+@import "../node_modules/govuk-frontend/govuk/all";
 @import "../node_modules/accessible-autocomplete/src/autocomplete";
 @import "hmpo";
 @import "modal-dialog";
@@ -62,11 +62,9 @@
 
 #global-cookie-message {
   width: 100%;
-  background-color: #d5e8f3;
-  padding-top: 10px;
-  padding-bottom: 10px;
+  display: none;
 
-  .js-enabled & {
-    display: none;
-  }
+  // .js-enabled & {
+  //   display: none;
+  // }
 }

--- a/runner/src/server/index.ts
+++ b/runner/src/server/index.ts
@@ -141,6 +141,10 @@ async function createServer(routeConfig: RouteConfig) {
     await server.register(blipp);
   }
 
+  server.state("cookies_policy", {
+    encoding: "base64json",
+  });
+
   return server;
 }
 

--- a/runner/src/server/plugins/views.ts
+++ b/runner/src/server/plugins/views.ts
@@ -54,9 +54,7 @@ export default {
       `${path.join(__dirname, "engine", "views")}`,
       `${path.dirname(resolve.sync("govuk-frontend", { basedir }))}`,
       `${path.dirname(resolve.sync("govuk-frontend", { basedir }))}/components`,
-      `${path.dirname(
-        resolve.sync("hmpo-components", { basedir })
-      )}/components`,
+      `${path.dirname(resolve.sync("hmpo-components"))}/components`,
     ],
     isCached: !config.isDev,
     context: {

--- a/runner/src/server/routes/public.ts
+++ b/runner/src/server/routes/public.ts
@@ -15,7 +15,12 @@ export default [
             path.join(runnerFolder, "public", "build"),
             path.join(rootNodeModules, "govuk-frontend", "govuk"),
             path.join(rootNodeModules, "govuk-frontend", "govuk", "assets"),
-            path.join(rootNodeModules, "hmpo-components", "assets"),
+            path.join(
+              runnerFolder,
+              "node_modules",
+              "hmpo-components",
+              "assets"
+            ),
           ],
         },
       },

--- a/runner/src/server/views/layout.html
+++ b/runner/src/server/views/layout.html
@@ -4,6 +4,8 @@
 {% from "footer/macro.njk" import govukFooter -%}
 {% from "phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "skip-link/macro.njk" import govukSkipLink -%}
+{% from "cookie-banner/macro.njk" import govukCookieBanner %}
+
 
 {% block head %}
   <!--[if !IE 8]><!-->
@@ -53,18 +55,10 @@
 {% endblock %}
 
 {% block skipLink %}
-    {{ govukSkipLink({
-        href: '#main-content',
-        text: 'Skip to main content'
-    }) }}
-    <div id="global-cookie-message">
-        <div class="govuk-width-container">
-            <p class="govuk-body-s govuk-!-margin-0">
-                <span>This service uses cookies, including one which is required to complete an online application. </span>
-                <a href="/help/cookies" target="_blank">Review your cookie settings.</a>
-            </p>
-        </div>
-    </div>
+  {{ govukSkipLink({
+    href: '#main-content',
+    text: 'Skip to main content'
+  }) }} 
 {% endblock %}
 
 
@@ -78,6 +72,9 @@
 
 {% endblock %}
 
+{% block bodyStart %}
+  {% include "partials/cookie-banner.html" %}
+{% endblock %}
 
 {% block beforeContent %}
     {% if feedbackLink %}
@@ -155,5 +152,3 @@
         }
     }) }}
 {% endblock %}
-
-

--- a/runner/src/server/views/partials/cookie-banner.html
+++ b/runner/src/server/views/partials/cookie-banner.html
@@ -5,20 +5,24 @@
   Cookies on {{ name if name else serviceName }}
 {% endset %}
 
-{{ 
-  govukCookieBanner({
-    ariaLabel: cookieBannerHeader,
-    messages: [
-      {
-        headingText: cookieBannerHeader,
-        html: cookieBannerHtml,
-        actions: [
-          {
-          text: "View cookies",
-          href: "/help/cookies"
+<div id="global-cookie-message">
+  {{
+    govukCookieBanner({
+      classes: ["global-cookie-message"],
+      ariaLabel: cookieBannerHeader,
+      messages: [
+        {
+          headingText: cookieBannerHeader,
+          html: cookieBannerHtml,
+          actions: [
+            {
+            text: "View cookies",
+            href: "/help/cookies"
+          }
+          ]
         }
-        ]
-      }
-    ]
-  }) 
-}}
+      ]
+    })
+  }}
+</div>
+

--- a/runner/src/server/views/partials/cookie-banner.html
+++ b/runner/src/server/views/partials/cookie-banner.html
@@ -1,0 +1,24 @@
+{% set cookieBannerHtml %}
+  <p>We use some essential cookies to make this service work.</p> 
+{% endset %}
+{% set cookieBannerHeader %}
+  Cookies on {{ name if name else serviceName }}
+{% endset %}
+
+{{ 
+  govukCookieBanner({
+    ariaLabel: cookieBannerHeader,
+    messages: [
+      {
+        headingText: cookieBannerHeader,
+        html: cookieBannerHtml,
+        actions: [
+          {
+          text: "View cookies",
+          href: "/help/cookies"
+        }
+        ]
+      }
+    ]
+  }) 
+}}

--- a/runner/test/cases/server/plugins/router.test.ts
+++ b/runner/test/cases/server/plugins/router.test.ts
@@ -1,5 +1,6 @@
 import * as Code from "@hapi/code";
 import * as Lab from "@hapi/lab";
+import config from "src/server/config";
 
 import createServer from "src/server";
 
@@ -30,7 +31,11 @@ suite("Server Router", () => {
 
     expect(res.statusCode).to.equal(200);
     expect(
-      res.result.indexOf('<h1 class="govuk-heading-xl">Cookies on </h1>') > -1
+      res.result.indexOf(
+        `<h1 class="govuk-heading-xl">Cookies on ${
+          config.serviceName ?? ""
+        }</h1>`
+      ) > -1
     ).to.equal(true);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4904,7 +4904,7 @@ __metadata:
     flagg: ^1.1.2
     flat: 5.0.2
     focus-trap-react: ^8.3.2
-    govuk-frontend: ^3.10.1
+    govuk-frontend: ^3.13.0
     hapi-pino: ^8.0.1
     hoek: ^6.1.3
     html-webpack-plugin: ^4.5.0
@@ -5077,7 +5077,7 @@ __metadata:
     flat: 5.0.2
     form-data: 3.0.0
     googleapis: 64.0.0
-    govuk-frontend: ^3.10.1
+    govuk-frontend: ^3.13.0
     hapi-pino: 8.0.0
     hapi-pulse: 3.0.0
     hapi-rate-limit: 4.1.0
@@ -9130,7 +9130,7 @@ __metadata:
     eslint-plugin-prettier: ^3.1.4
     eslint-plugin-promise: ^4.2.1
     eslint-plugin-tsdoc: ^0.2.14
-    govuk-frontend: ^3.10.1
+    govuk-frontend: ^3.13.0
     husky: ^4.3.0
     lint-staged: ^10.4.2
     magic-string: ^0.25.7
@@ -12357,6 +12357,13 @@ fsevents@^1.2.7:
   version: 3.10.2
   resolution: "govuk-frontend@npm:3.10.2"
   checksum: f21d4410a7f7da68199d9ecdad3d27930640d56fdad53631c57c652b8daf4608318af0d6eb0417f55a6d7ec8b022a781f6aeb237d3a004dd8c583fae26206825
+  languageName: node
+  linkType: hard
+
+"govuk-frontend@npm:^3.13.0":
+  version: 3.13.0
+  resolution: "govuk-frontend@npm:3.13.0"
+  checksum: 9b4456a0881b51213fdbfd596f27aa2cc609ea0e5d6977930842be01e187a1afbfe3116850c02860f0cb365877a4a931894748c78980c702b1b46502f7d6673a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

- Upgrade runner's govuk-frontend dependency.
- Refactor cookie banner to use latest govuk-frontend `govukCookieBanner` macro.
- Refactor `addCookieMessage` helper to implement latest `cookies_policy` pattern which is used in `gov.uk`.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [ ] I have manually tested the application to confirm the cookie banner and cookies_policy cookie behaves correctly. 

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto main and there are no code conflicts
- [X] I have checked deployments are working in all environments
- [X] I have updated the architecture diagrams as per Contribute.md
