### PR TITLE
fix: changed options reducer in designer to get options from selectedComponent

### DIFF
--- a/designer/client/reducers/component/componentReducer.options.ts
+++ b/designer/client/reducers/component/componentReducer.options.ts
@@ -15,7 +15,7 @@ type OptionsActions = ConditionAction | AnyAction;
 export function optionsReducer(state, action: OptionsActions) {
   const { type, payload } = action;
   const { selectedComponent } = state;
-  const { options } = state;
+  const { options } = selectedComponent;
   switch (type) {
     case Options.EDIT_OPTIONS_HIDE_TITLE:
       return {


### PR DESCRIPTION
# Description

Fixed bug where multiple options couldn't be checked at once on a component in the designer

- Changed [Line 18 of componentReducer.options.ts](https://github.com/XGovFormBuilder/digital-form-builder/blob/main/designer/client/reducers/component/componentReducer.options.ts#L18) from:
`{ options } = state`
to:
`{ options } = selectedComponent`

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Manually tested to see if multiple options could be chosen and that the options for the component were updated in the state, and that the component was still savable.

# Checklist:

- [X] My changes do not introduce any new linting errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased onto main and there are no code conflicts
- [X] I have checked deployments are working in all environments
- [X] I have updated the architecture diagrams as per Contribute.md
