### PR TITLE
Switch to using Intl.NumberFormat to format Pay descriptions.

### DIFF
--- a/runner/src/server/services/payService.ts
+++ b/runner/src/server/services/payService.ts
@@ -16,6 +16,11 @@ export type Fees = {
   paymentReference?: string;
 };
 
+const currencyFormat = new Intl.NumberFormat("en-GB", {
+  style: "currency",
+  currency: "GBP",
+});
+
 export class PayService {
   /**
    * Service responsible for handling requests to GOV.UK Pay. This service has been registered by {@link createServer}
@@ -66,7 +71,7 @@ export class PayService {
   }
 
   /**
-   * Returns a string with a textual description of what a user will pay. Pay requests are in pence, so `/ 100` to get the £ value.
+   * Returns a string with a textual description of what a user will pay.
    */
   descriptionFromFees(fees: Fees): string {
     return fees.details
@@ -74,12 +79,12 @@ export class PayService {
         const { multiplier, multiplyBy, description, amount } = detail;
 
         if (multiplier && multiplyBy) {
-          return `${multiplyBy} x ${description}: £${
-            (multiplyBy * amount) / 100
-          }`;
+          return `${multiplyBy} x ${description}: ${currencyFormat.format(
+            multiplyBy * amount
+          )}`;
         }
 
-        return `${detail.description}: £${detail.amount / 100}`;
+        return `${detail.description}: ${currencyFormat.format(detail.amount)}`;
       })
       .join(", ");
   }

--- a/runner/test/cases/server/services/payService.test.ts
+++ b/runner/test/cases/server/services/payService.test.ts
@@ -1,0 +1,61 @@
+import * as Code from "@hapi/code";
+import * as Lab from "@hapi/lab";
+
+import { PayService } from "server/services/payService";
+
+const { expect } = Code;
+const lab = Lab.script();
+exports.lab = lab;
+const { suite, test } = lab;
+
+suite("Server PayService Service", () => {
+  test("Currency formatted correctly in description", async () => {
+    const service = new PayService();
+    const result = service.descriptionFromFees({
+      total: 3.5,
+      details: [
+        {
+          description: "A",
+          amount: "3.5",
+        },
+      ],
+    });
+    expect(result).to.equal("A: £3.50");
+  });
+
+  test("Currency formatted correctly in description with multipliers", async () => {
+    const service = new PayService();
+    const result = service.descriptionFromFees({
+      total: 3.5,
+      details: [
+        {
+          description: "A",
+          amount: "3.5",
+          multiplier: "numberOf",
+          multiplyBy: 3,
+        },
+      ],
+    });
+    expect(result).to.equal("3 x A: £10.50");
+  });
+
+  test("Currency formatted correctly in description with multiple fees", async () => {
+    const service = new PayService();
+    const result = service.descriptionFromFees({
+      total: 3.5,
+      details: [
+        {
+          description: "A",
+          amount: "3.5",
+          multiplier: "numberOf",
+          multiplyBy: 3,
+        },
+        {
+          description: "B",
+          amount: "150",
+        },
+      ],
+    });
+    expect(result).to.equal("3 x A: £10.50, B: £150.00");
+  });
+});

--- a/smoke-tests/designer/wdio.conf.js
+++ b/smoke-tests/designer/wdio.conf.js
@@ -1,7 +1,7 @@
 const { hooks } = require("./support/hooks");
 const drivers = {
-  chrome: { version: "91.0.4472.19" }, // https://chromedriver.chromium.org/
-  firefox: { version: "0.27.0" }, // https://github.com/mozilla/geckodriver/releases
+  chrome: { version: "93.0.4577.63" }, // https://chromedriver.chromium.org/
+  firefox: { version: "0.29.1" }, // https://github.com/mozilla/geckodriver/releases
 };
 
 exports.config = {


### PR DESCRIPTION
# Description

Current use of numbers leads to '£3.5' rather than '£3.50' in description. Updating to use Intl.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added unit tests ... 😱 


# Checklist:

- [x] My changes do not introduce any new linting errors
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x New and existing unit tests pass locally with my changes
- [x] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md
