### PR TITLE
fix: return yyyy-MM-DD for webhooks 

### DIFF
--- a/runner/package.json
+++ b/runner/package.json
@@ -58,6 +58,7 @@
     "btoa": "^1.2.1",
     "chrome-launcher": "^0.13.4",
     "concurrently": "^5.3.0",
+    "date-fns": "^2.24.0",
     "dotenv": "8.2.0",
     "expr-eval": "^2.0.2",
     "flat": "5.0.2",

--- a/runner/src/server/plugins/engine/components/ComponentBase.ts
+++ b/runner/src/server/plugins/engine/components/ComponentBase.ts
@@ -7,7 +7,7 @@ import {
 
 import { FormModel } from "../models";
 import { FormData, FormSubmissionErrors } from "../types";
-import { ViewModel } from "./types";
+import { DataType, ViewModel } from "./types";
 
 export class ComponentBase {
   type: ComponentDef["type"];
@@ -17,7 +17,10 @@ export class ComponentBase {
   options: ComponentDef["options"];
   hint?: InputFieldsComponentsDef["hint"];
   content?: ContentComponentsDef["content"];
-
+  /**
+   * This is passed onto webhooks, see {@link answerFromDetailItem}
+   */
+  dataType?: DataType = "text";
   model: FormModel;
 
   /** joi schemas based on a component defined in the form JSON. This validates a user's answer and is generated from {@link ComponentDef} */

--- a/runner/src/server/plugins/engine/components/DatePartsField.ts
+++ b/runner/src/server/plugins/engine/components/DatePartsField.ts
@@ -159,7 +159,5 @@ export class DatePartsField extends FormComponent {
     };
   }
 
-  get dataType() {
-    return "date";
-  }
+  dataType = "monthYear";
 }

--- a/runner/src/server/plugins/engine/components/DatePartsField.ts
+++ b/runner/src/server/plugins/engine/components/DatePartsField.ts
@@ -12,9 +12,11 @@ import {
   FormSubmissionState,
 } from "../types";
 import { FormModel } from "../models";
+import { DataType } from "server/plugins/engine/components/types";
 
 export class DatePartsField extends FormComponent {
   children: ComponentCollection;
+  dataType = "date" as DataType;
 
   constructor(def: InputFieldsComponentsDef, model: FormModel) {
     super(def, model);
@@ -158,6 +160,4 @@ export class DatePartsField extends FormComponent {
       items: componentViewModels,
     };
   }
-
-  dataType = "monthYear";
 }

--- a/runner/src/server/plugins/engine/components/FormComponent.ts
+++ b/runner/src/server/plugins/engine/components/FormComponent.ts
@@ -16,7 +16,6 @@ import { ComponentDef } from "@xgovformbuilder/model";
 export class FormComponent extends ComponentBase {
   isFormComponent: boolean = true;
   __lang: string = "en";
-
   constructor(def: ComponentDef, model: FormModel) {
     super(def, model);
   }
@@ -135,9 +134,5 @@ export class FormComponent extends ComponentBase {
 
   getDisplayStringFromState(state) {
     return state[this.name];
-  }
-
-  get dataType() {
-    return "text";
   }
 }

--- a/runner/src/server/plugins/engine/components/MonthYearField.ts
+++ b/runner/src/server/plugins/engine/components/MonthYearField.ts
@@ -68,10 +68,10 @@ export class MonthYearField extends FormComponent {
 
   getDisplayStringFromState(state: FormSubmissionState) {
     const values = state[this.name];
-    const year = values[`${this.name}__year`] ?? "Not supplied";
-    let monthString = "Not supplied";
-    const monthValue = values[`${this.name}__month`];
+    const year = values?.[`${this.name}__year`] ?? "Not supplied";
 
+    let monthString = "Not supplied";
+    const monthValue = values?.[`${this.name}__month`];
     if (monthValue) {
       const date = new Date();
       date.setMonth(values[`${this.name}__month`]);

--- a/runner/src/server/plugins/engine/components/MonthYearField.ts
+++ b/runner/src/server/plugins/engine/components/MonthYearField.ts
@@ -74,7 +74,7 @@ export class MonthYearField extends FormComponent {
     const monthValue = values?.[`${this.name}__month`];
     if (monthValue) {
       const date = new Date();
-      date.setMonth(values[`${this.name}__month`]);
+      date.setMonth(monthValue - 1);
       monthString = date.toLocaleString("default", { month: "long" });
     }
 

--- a/runner/src/server/plugins/engine/components/MonthYearField.ts
+++ b/runner/src/server/plugins/engine/components/MonthYearField.ts
@@ -10,9 +10,11 @@ import {
 } from "../types";
 import { FormModel } from "../models";
 import { Schema } from "joi";
+import { DataType } from "./types";
 
 export class MonthYearField extends FormComponent {
   children: ComponentCollection;
+  dataType = "monthYear" as DataType;
 
   constructor(def: InputFieldsComponentsDef, model: FormModel) {
     super(def, model);
@@ -66,10 +68,17 @@ export class MonthYearField extends FormComponent {
 
   getDisplayStringFromState(state: FormSubmissionState) {
     const values = state[this.name];
-    const month = values[`${this.name}__month`] ?? "Not supplied";
     const year = values[`${this.name}__year`] ?? "Not supplied";
+    let monthString = "Not supplied";
+    const monthValue = values[`${this.name}__month`];
 
-    return [month, year].join(" / ");
+    if (monthValue) {
+      const date = new Date();
+      date.setMonth(values[`${this.name}__month`]);
+      monthString = date.toLocaleString("default", { month: "long" });
+    }
+
+    return `${monthString} ${year}`;
   }
 
   // @ts-ignore - eslint does not report this as an error, only tsc

--- a/runner/src/server/plugins/engine/components/types.ts
+++ b/runner/src/server/plugins/engine/components/types.ts
@@ -65,3 +65,11 @@ export type ComponentCollectionViewModel = {
   isFormComponent: boolean;
   model: ViewModel;
 }[];
+
+export type DataType =
+  | "list"
+  | "text"
+  | "date"
+  | "monthYear"
+  | "number"
+  | "file";

--- a/runner/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/runner/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -7,39 +7,29 @@ import { formSchema } from "server/schemas/formSchema";
 import { SummaryPageController } from "../pageControllers";
 import type { Fees } from "server/services/payService";
 import { FormSubmissionState } from "../types";
-import {
-  FEEDBACK_CONTEXT_ITEMS,
-  Fields,
-  Question,
-  Questions,
-  WebhookData,
-} from "./types";
+import { FEEDBACK_CONTEXT_ITEMS, WebhookData } from "./types";
 import {
   FeesModel,
   EmailModel,
   NotifyModel,
 } from "server/plugins/engine/models/submission";
 import { FormDefinition, isMultipleApiKey } from "@xgovformbuilder/model";
-
-const { serviceName } = config;
+import { WebhookModel } from "server/plugins/engine/models/submission/WebhookModel";
 
 /**
  * TODO - extract submission behaviour dependencies from the viewmodel
- * Webhookdata
- * outputs
  * skipSummary (replace with reference to this.def.skipSummary?)
  * _payApiKey
  * replace result with errors?
  * remove state and value?
  *
  * TODO - Pull out summary behaviours into separate service classes?
- * TODO - Move outputs conversion to an outputs service?
- * TODO - Move outputs / pay integration etc etc into a submission service rather than applicationStatus.js
  */
 
 export class SummaryViewModel {
   /**
    * Responsible for parsing state values to the govuk-frontend summary list template and parsing data for outputs
+   * The plain object is also used to generate data for outputs
    */
 
   pageTitle: string;
@@ -99,7 +89,7 @@ export class SummaryViewModel {
       this.processErrors(result, details);
     } else {
       this.fees = FeesModel(model, state);
-      this.parseDataForWebhook(model, relevantPages, details, state);
+      this._webhookData = WebhookModel(relevantPages, details);
       this._webhookData = this.addFeedbackSourceDataToWebhook(
         this._webhookData,
         model,
@@ -279,18 +269,6 @@ export class SummaryViewModel {
     return { relevantPages, endPage };
   }
 
-  private parseDataForWebhook(model: FormModel, relevantPages, details) {
-    this._webhookData = {
-      metadata: model.def.metadata,
-      name: model.name?.en ?? model.name ?? `${serviceName} ${model.basePath}`,
-      questions: parseDetailsToWebhookQuestion(relevantPages, details),
-    };
-
-    if (this.fees) {
-      this._webhookData.fees = this.fees;
-    }
-  }
-
   get validatedWebhookData() {
     const result = formSchema.validate(this._webhookData, {
       abortEarly: false,
@@ -400,7 +378,7 @@ function gatherRepeatPages(state) {
 }
 
 /**
- * Creates an Item object for webhook data
+ * Creates an Item object for Details
  */
 function Item(
   request,
@@ -439,64 +417,4 @@ function Item(
     title: component.title,
     dataType: component.dataType,
   };
-}
-
-function detailItemToWebhookAnswer(item) {
-  switch (item.dataType) {
-    case "list":
-    case "date":
-      return item.rawValue;
-    default:
-      return item.value;
-  }
-}
-
-function parseDetailsToWebhookQuestion(relevantPages, details) {
-  const questions = relevantPages.map((page) => {
-    const isRepeatable = !!page.repeatField;
-
-    const filteredItems = details.flatMap((detail) =>
-      detail.items.filter((item) => item.path === page.path)
-    );
-
-    const items = isRepeatable ? [filteredItems] : filteredItems;
-    let index;
-    const fields = items.flatMap((item, i) => {
-      index = i;
-      const answer = detailItemToWebhookAnswer(item);
-      const fields = [
-        { key: item.name, title: item.title, type: item.dataType, answer },
-      ];
-      if (item.items) {
-        const selectedItem = items.items.find((i) => i.value === answer);
-        const nestedFields = selectedItem.childrenCollection.formItems.map(
-          (cc) => {
-            const itemDetailItem = items.items.find(
-              (detailItem) => detailItem.name === cc.name
-            );
-            return {
-              key: cc.name,
-              title: cc.title?.en ?? cc.title,
-              type: cc.dataType,
-              answer: detailItemToWebhookAnswer(itemDetailItem),
-            };
-          }
-        );
-        fields.push(nestedFields);
-      }
-      return fields;
-    });
-
-    return {
-      category: page.section,
-      question:
-        page.title?.en ??
-        page.title ??
-        page.components.formItems.map((item) => item.title),
-      fields,
-      index,
-    };
-  });
-
-  return questions;
 }

--- a/runner/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/runner/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -12,9 +12,9 @@ import {
   FeesModel,
   EmailModel,
   NotifyModel,
+  WebhookModel,
 } from "server/plugins/engine/models/submission";
 import { FormDefinition, isMultipleApiKey } from "@xgovformbuilder/model";
-import { WebhookModel } from "server/plugins/engine/models/submission/WebhookModel";
 
 /**
  * TODO - extract submission behaviour dependencies from the viewmodel

--- a/runner/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/runner/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -89,7 +89,7 @@ export class SummaryViewModel {
       this.processErrors(result, details);
     } else {
       this.fees = FeesModel(model, state);
-      this._webhookData = WebhookModel(relevantPages, details);
+      this._webhookData = WebhookModel(relevantPages, details, model);
       this._webhookData = this.addFeedbackSourceDataToWebhook(
         this._webhookData,
         model,

--- a/runner/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/runner/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -10,6 +10,7 @@ import { FormSubmissionState } from "../types";
 import {
   FEEDBACK_CONTEXT_ITEMS,
   Fields,
+  Question,
   Questions,
   WebhookData,
 } from "./types";
@@ -98,7 +99,7 @@ export class SummaryViewModel {
       this.processErrors(result, details);
     } else {
       this.fees = FeesModel(model, state);
-      this.parseDataForWebhook(model, relevantPages, details);
+      this.parseDataForWebhook(model, relevantPages, details, state);
       this._webhookData = this.addFeedbackSourceDataToWebhook(
         this._webhookData,
         model,
@@ -278,103 +279,13 @@ export class SummaryViewModel {
     return { relevantPages, endPage };
   }
 
-  private toEnglish(localisableString) {
-    let englishString = "";
-    if (localisableString) {
-      if (typeof localisableString === "string") {
-        englishString = localisableString;
-      } else {
-        englishString = localisableString.en;
-      }
-    }
-    return englishString;
-  }
-
   private parseDataForWebhook(model: FormModel, relevantPages, details) {
-    const questions: Questions = [];
-
-    for (const page of relevantPages) {
-      const category = page.section?.name;
-      const isRepeatable = !!page.repeatField;
-      const detail = details.find((d) => d.name === category);
-
-      let question;
-      if (page.title) {
-        question = this.toEnglish(page.title);
-      } else {
-        question = page.components.formItems
-          .map((item) => this.toEnglish(item.title))
-          .join(", ");
-      }
-
-      let items;
-      if (isRepeatable) {
-        items = detail.items;
-      } else {
-        items = [detail.items];
-      }
-
-      for (let index = 0; index < items.length; index++) {
-        const item = items[index].filter(
-          (detailItem) => detailItem.pageId === `/${model.basePath}${page.path}`
-        );
-        const fields: Fields = [];
-
-        for (const detailItem of item) {
-          const answer =
-            detailItem.dataType !== "list"
-              ? detailItem.value
-              : detailItem.rawValue;
-          fields.push({
-            key: detailItem.name,
-            title: this.toEnglish(detailItem.title),
-            type: detailItem.dataType,
-            answer,
-          });
-
-          if (detailItem.items) {
-            const selectedItem = detailItem.items.filter(
-              (i) => i.value === answer
-            )[0];
-            if (selectedItem && selectedItem.childrenCollection) {
-              selectedItem.childrenCollection.formItems.forEach((cc) => {
-                const itemDetailItem = detail.items.find(
-                  (detailItem) => detailItem.name === cc.name
-                );
-                fields.push({
-                  key: cc.name,
-                  title: this.toEnglish(cc.title),
-                  type: cc.dataType,
-                  answer:
-                    itemDetailItem.dataType !== "list"
-                      ? itemDetailItem.value
-                      : itemDetailItem.rawValue,
-                });
-              });
-            }
-          }
-        }
-
-        questions.push({
-          category,
-          question,
-          fields,
-          index,
-        });
-      }
-    }
-
-    // default name if no name is provided
-    let englishName = `${serviceName} ${model.basePath}`;
-    if (model.name) {
-      englishName = typeof model.name === "string" ? model.name : model.name.en;
-    }
-
     this._webhookData = {
       metadata: model.def.metadata,
-      name: englishName,
-      questions: questions,
+      name: model.name?.en ?? model.name ?? `${serviceName} ${model.basePath}`,
+      questions: parseDetailsToWebhookQuestion(relevantPages, details),
     };
+
     if (this.fees) {
       this._webhookData.fees = this.fees;
     }
@@ -528,4 +439,64 @@ function Item(
     title: component.title,
     dataType: component.dataType,
   };
+}
+
+function detailItemToWebhookAnswer(item) {
+  switch (item.dataType) {
+    case "list":
+    case "date":
+      return item.rawValue;
+    default:
+      return item.value;
+  }
+}
+
+function parseDetailsToWebhookQuestion(relevantPages, details) {
+  const questions = relevantPages.map((page) => {
+    const isRepeatable = !!page.repeatField;
+
+    const filteredItems = details.flatMap((detail) =>
+      detail.items.filter((item) => item.path === page.path)
+    );
+
+    const items = isRepeatable ? [filteredItems] : filteredItems;
+    let index;
+    const fields = items.flatMap((item, i) => {
+      index = i;
+      const answer = detailItemToWebhookAnswer(item);
+      const fields = [
+        { key: item.name, title: item.title, type: item.dataType, answer },
+      ];
+      if (item.items) {
+        const selectedItem = items.items.find((i) => i.value === answer);
+        const nestedFields = selectedItem.childrenCollection.formItems.map(
+          (cc) => {
+            const itemDetailItem = items.items.find(
+              (detailItem) => detailItem.name === cc.name
+            );
+            return {
+              key: cc.name,
+              title: cc.title?.en ?? cc.title,
+              type: cc.dataType,
+              answer: detailItemToWebhookAnswer(itemDetailItem),
+            };
+          }
+        );
+        fields.push(nestedFields);
+      }
+      return fields;
+    });
+
+    return {
+      category: page.section,
+      question:
+        page.title?.en ??
+        page.title ??
+        page.components.formItems.map((item) => item.title),
+      fields,
+      index,
+    };
+  });
+
+  return questions;
 }

--- a/runner/src/server/plugins/engine/models/submission/WebhookModel.ts
+++ b/runner/src/server/plugins/engine/models/submission/WebhookModel.ts
@@ -1,5 +1,6 @@
 import { DetailItem } from "../types";
 import { format } from "date-fns";
+import config from "server/config";
 
 function answerFromDetailItem(item) {
   switch (item.dataType) {
@@ -24,8 +25,8 @@ function detailItemToField(item: DetailItem) {
   };
 }
 
-export function WebhookModel(relevantPages, details) {
-  return relevantPages?.map((page) => {
+export function WebhookModel(relevantPages, details, model) {
+  const questions = relevantPages?.map((page) => {
     const isRepeatable = !!page.repeatField;
 
     const itemsForPage = details.flatMap((detail) =>
@@ -61,4 +62,15 @@ export function WebhookModel(relevantPages, details) {
       index,
     };
   });
+
+  // default name if no name is provided
+  let englishName = `${config.serviceName} ${model.basePath}`;
+  if (model.name) {
+    englishName = model.name.en ?? model.name;
+  }
+  return {
+    metadata: model.def.metadata,
+    name: englishName,
+    questions: questions,
+  };
 }

--- a/runner/src/server/plugins/engine/models/submission/WebhookModel.ts
+++ b/runner/src/server/plugins/engine/models/submission/WebhookModel.ts
@@ -6,7 +6,7 @@ function answerFromDetailItem(item) {
     case "list":
       return item.rawValue;
     case "date":
-      return format(new Date(item.rawValue), "yyyy-MM-DD");
+      return format(new Date(item.rawValue), "yyyy-MM-dd");
     case "monthYear":
       const [month, year] = Object.values(item.rawValue);
       return `${year}-${month}`;

--- a/runner/src/server/plugins/engine/models/submission/WebhookModel.ts
+++ b/runner/src/server/plugins/engine/models/submission/WebhookModel.ts
@@ -10,7 +10,8 @@ function answerFromDetailItem(item) {
       return format(new Date(item.rawValue), "yyyy-MM-dd");
     case "monthYear":
       const [month, year] = Object.values(item.rawValue);
-      return `${year}-${month}`;
+      const date = format(new Date(`${year}-${month}-1`), "yyyy-MM");
+      return date;
     default:
       return item.value;
   }

--- a/runner/src/server/plugins/engine/models/submission/WebhookModel.ts
+++ b/runner/src/server/plugins/engine/models/submission/WebhookModel.ts
@@ -32,10 +32,13 @@ export function WebhookModel(relevantPages, details) {
       detail.items.filter((item) => item.path === page.path)
     );
 
-    const detailItems = isRepeatable ? [itemsForPage] : itemsForPage;
+    const detailItems = isRepeatable
+      ? [itemsForPage].map((item) => ({ ...item, isRepeatable }))
+      : itemsForPage;
+
     let index = 0;
     const fields = detailItems.flatMap((item, i) => {
-      index = i;
+      item.isRepeatable ? (index = i) : 0;
       const fields = [detailItemToField(item)];
 
       /**

--- a/runner/src/server/plugins/engine/models/submission/index.ts
+++ b/runner/src/server/plugins/engine/models/submission/index.ts
@@ -1,3 +1,4 @@
 export { EmailModel } from "./EmailModel";
 export { FeesModel } from "./FeesModel";
 export { NotifyModel } from "./NotifyModel";
+export { WebhookModel } from "./WebhookModel";

--- a/runner/src/server/plugins/engine/models/types.ts
+++ b/runner/src/server/plugins/engine/models/types.ts
@@ -1,7 +1,8 @@
 import type { Fees } from "server/services/payService";
 import { FeedbackContextInfo } from "./../feedback";
 import { ConditionRawData } from "@xgovformbuilder/model";
-
+import { Page, Section } from "@xgovformbuilder/model";
+import { Component } from "./../components";
 export type Fields = {
   key: string;
   title: string;
@@ -9,12 +10,14 @@ export type Fields = {
   answer: string | number | boolean;
 }[];
 
-export type Questions = {
+export type Question = {
   category: string | null;
   question: string;
   fields: Fields;
   index?: number;
-}[];
+};
+
+export type Questions = Question[];
 
 export type WebhookData = {
   name: string;
@@ -52,4 +55,51 @@ export const FEEDBACK_CONTEXT_ITEMS: Readonly<FeedbackContextItem[]> = [
 
 export type ExecutableCondition = ConditionRawData & {
   fn: (state: any) => boolean;
+};
+
+/**
+ * Used to render a row on a Summary List (check your answers)
+ */
+
+export type DetailItem = {
+  /**
+   * Name of the component defined in the JSON {@link FormDefinition}
+   */
+  name: Component["name"];
+
+  /**
+   * Title of the component defined in the JSON {@link FormDefinition}
+   * Used as a human readable form of {@link Component.#name} and HTML content for HTML Label tag
+   */
+  label: Component["title"];
+
+  /**
+   * Path to redirect the user to if they decide to change this value
+   */
+  path: Page["path"];
+
+  /**
+   * String and/or display value of a field. For example, a Date will be displayed as 25 December 2022
+   */
+  value: string;
+
+  /**
+   * Raw value of a field. For example, a Date will be displayed as 2022-12-25
+   */
+  rawValue: string | number | object;
+  url: string;
+  pageId: string;
+  type: Component["type"];
+  title: Component["title"];
+  dataType?: Component["dataType"];
+  items: DetailItem[];
+};
+
+/**
+ * Used to render a row on a Summary List (check your answers)
+ */
+export type Detail = {
+  name: Section["name"] | undefined;
+  title: Section["title"] | undefined;
+  items: DetailItem[];
 };

--- a/runner/test/cases/server/plugins/engine/SummaryViewModel.json
+++ b/runner/test/cases/server/plugins/engine/SummaryViewModel.json
@@ -1,55 +1,123 @@
 {
-  "startPage": "/uk-passport",
+  "metadata": {},
+  "startPage": "/first-page",
   "pages": [
     {
-      "path": "/uk-passport",
+      "title": "When will you get married?",
+      "path": "/first-page",
       "components": [
         {
-          "type": "YesNoField",
-          "name": "ukPassport",
-          "title": "Do you have a UK passport?",
+          "name": "approximate",
           "options": {
             "required": true
           },
+          "type": "MonthYearField",
+          "title": "Approximate date of marriage",
+          "schema": {}
+        },
+        {
+          "name": "caz",
+          "type": "SelectField",
+          "options": {
+            "required": true
+          },
+          "list": "zone",
+          "title": "caz zone",
           "schema": {}
         }
       ],
-      "section": "checkBeforeYouStart",
+      "next": [
+        {
+          "path": "/second-page"
+        }
+      ]
+    },
+    {
+      "title": "Second page",
+      "path": "/second-page",
+      "section": "aSection",
+      "components": [
+        {
+          "name": "fullDate",
+          "options": {
+            "required": false
+          },
+          "type": "DatePartsField",
+          "title": "full date",
+          "schema": {}
+        }
+      ],
       "next": [
         {
           "path": "/summary"
         }
-      ],
-      "title": "Do you have a UK passport?"
+      ]
     },
     {
+      "title": "Summary",
       "path": "/summary",
       "controller": "./pages/summary.js",
-      "title": "Summary",
-      "components": [],
-      "next": []
+      "components": []
     }
   ],
   "lists": [
+    {
+      "title": "CAZ Location",
+      "name": "zone",
+      "type": "string",
+      "items": [
+        {
+          "text": "Bath",
+          "value": 1
+        },
+        {
+          "text": "Bristol",
+          "value": 2
+        },
+        {
+          "text": "Birmingham",
+          "value": 3
+        },
+        {
+          "text": "Cardiff",
+          "value": 4
+        },
+        {
+          "text": "Liverpool",
+          "value": 6
+        },
+        {
+          "text": "Leeds",
+          "value": 7
+        },
+        {
+          "text": "Manchester",
+          "value": 8
+        }
+      ]
+    }
   ],
   "sections": [
     {
-      "name": "checkBeforeYouStart",
-      "title": "Check before you start"
+      "name": "aSection",
+      "title": "Named Section"
     }
   ],
-  "phaseBanner": {},
-  "feedback": {
-    "emailAddress": "test@feedback.cat",
-    "feedbackForm": false
-  },
+  "conditions": [
+  ],
   "fees": [
   ],
-  "payApiKey": {"test": "test_api_key", "production": "production_api_key"},
   "outputs": [
+    {
+      "name": "webhook",
+      "title": "webhook",
+      "type": "webhook",
+      "outputConfiguration": {
+        "url": "https://b4bf0fcd-1dd3-4650-92fe-d1f83885a447.mock.pstmn.io"
+      }
+    }
   ],
-  "declaration": "<p class=\"govuk-body\">All the answers you have provided are true to the best of your knowledge.</p>",
   "version": 2,
-  "conditions": [
-  ]
+  "payApiKey": {"test": "test_api_key", "production": "production_api_key"},
+  "skipSummary": false
 }

--- a/runner/test/cases/server/plugins/engine/WebhookModel.test.ts
+++ b/runner/test/cases/server/plugins/engine/WebhookModel.test.ts
@@ -72,6 +72,7 @@ suite("WebhookModel", () => {
   });
   const formModel = new FormModel(form, {});
   formModel.basePath = "test";
+  formModel.name = "My Service";
   const viewModel = new SummaryViewModel(
     "summary",
     formModel,
@@ -94,44 +95,49 @@ suite("WebhookModel", () => {
 
     const parsed = WebhookModel(
       formModel.pages.filter((page) => page.path !== "/summary"),
-      viewModel.details
+      viewModel.details,
+      formModel
     );
-    expect(parsed).to.equal([
-      {
-        category: undefined,
-        fields: [
-          {
-            answer: "2000-11",
-            key: "approximate",
-            title: "Approximate date of marriage",
-            type: "monthYear",
-          },
-          {
-            answer: "Bath",
-            key: "caz",
-            title: "caz zone",
-            type: "text",
-          },
-        ],
-        index: 0,
-        question: "When will you get married?",
-      },
-      {
-        category: {
-          name: "aSection",
-          title: "Named Section",
+    expect(parsed).to.equal({
+      metadata: {},
+      name: "My Service",
+      questions: [
+        {
+          category: undefined,
+          fields: [
+            {
+              answer: "2000-11",
+              key: "approximate",
+              title: "Approximate date of marriage",
+              type: "monthYear",
+            },
+            {
+              answer: "Bath",
+              key: "caz",
+              title: "caz zone",
+              type: "text",
+            },
+          ],
+          index: 0,
+          question: "When will you get married?",
         },
-        fields: [
-          {
-            answer: "2000-12-11",
-            key: "fullDate",
-            title: "full date",
-            type: "date",
+        {
+          category: {
+            name: "aSection",
+            title: "Named Section",
           },
-        ],
-        index: 0,
-        question: "Second page",
-      },
-    ]);
+          fields: [
+            {
+              answer: "2000-12-11",
+              key: "fullDate",
+              title: "full date",
+              type: "date",
+            },
+          ],
+          index: 0,
+          question: "Second page",
+        },
+      ],
+    });
   });
 });

--- a/runner/test/cases/server/plugins/engine/WebhookModel.test.ts
+++ b/runner/test/cases/server/plugins/engine/WebhookModel.test.ts
@@ -19,9 +19,9 @@ const testDetails = [
         name: "approximate",
         path: "/first-page",
         label: "Approximate date of marriage",
-        value: "December 2000",
+        value: "January 2000",
         rawValue: {
-          approximate__month: 11,
+          approximate__month: 1,
           approximate__year: 2000,
         },
         url: "/test/first-page?returnUrl=%2Ftest%2Fsummary",
@@ -79,7 +79,7 @@ suite("WebhookModel", () => {
     {
       progress: ["/test/first-page", "/test/second-page"],
       approximate: {
-        approximate__month: 11,
+        approximate__month: 1,
         approximate__year: 2000,
       },
       caz: "1",
@@ -106,7 +106,7 @@ suite("WebhookModel", () => {
           category: undefined,
           fields: [
             {
-              answer: "2000-11",
+              answer: "2000-01",
               key: "approximate",
               title: "Approximate date of marriage",
               type: "monthYear",

--- a/runner/test/cases/server/plugins/engine/WebhookModel.test.ts
+++ b/runner/test/cases/server/plugins/engine/WebhookModel.test.ts
@@ -60,7 +60,7 @@ const testDetails = [
         pageId: "/test/second-page",
         type: "DatePartsField",
         title: "full date",
-        dataType: "monthYear",
+        dataType: "date",
       },
     ],
   },
@@ -123,10 +123,10 @@ suite("WebhookModel", () => {
         },
         fields: [
           {
-            answer: "0-2",
+            answer: "2000-12-11",
             key: "fullDate",
             title: "full date",
-            type: "monthYear",
+            type: "date",
           },
         ],
         index: 0,

--- a/runner/test/cases/server/plugins/engine/WebhookModel.test.ts
+++ b/runner/test/cases/server/plugins/engine/WebhookModel.test.ts
@@ -1,0 +1,137 @@
+import * as Code from "@hapi/code";
+import * as Lab from "@hapi/lab";
+import sinon from "sinon";
+import { WebhookModel } from "../../../../../src/server/plugins/engine/models/submission/WebhookModel";
+import form from "./SummaryViewModel.json";
+import {
+  FormModel,
+  SummaryViewModel,
+} from "../../../../../src/server/plugins/engine/models";
+const { expect } = Code;
+const lab = Lab.script();
+exports.lab = lab;
+const { afterEach, suite, test } = lab;
+
+const testDetails = [
+  {
+    items: [
+      {
+        name: "approximate",
+        path: "/first-page",
+        label: "Approximate date of marriage",
+        value: "December 2000",
+        rawValue: {
+          approximate__month: 11,
+          approximate__year: 2000,
+        },
+        url: "/test/first-page?returnUrl=%2Ftest%2Fsummary",
+        pageId: "/test/first-page",
+        type: "MonthYearField",
+        title: "Approximate date of marriage",
+        dataType: "monthYear",
+      },
+      {
+        name: "caz",
+        path: "/first-page",
+        label: "caz zone",
+        value: "Bath",
+        rawValue: "1",
+        url: "/test/first-page?returnUrl=%2Ftest%2Fsummary",
+        pageId: "/test/first-page",
+        type: "SelectField",
+        title: "caz zone",
+        dataType: "text",
+      },
+    ],
+    name: undefined,
+    title: undefined,
+  },
+  {
+    name: "aSection",
+    title: "Named Section",
+    items: [
+      {
+        name: "fullDate",
+        path: "/second-page",
+        label: "full date",
+        value: "11 December 2000",
+        rawValue: "2000-12-11T00:00:00.000Z",
+        url: "/test/second-page?returnUrl=%2Ftest%2Fsummary",
+        pageId: "/test/second-page",
+        type: "DatePartsField",
+        title: "full date",
+        dataType: "monthYear",
+      },
+    ],
+  },
+];
+
+suite("WebhookModel", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+  const formModel = new FormModel(form, {});
+  formModel.basePath = "test";
+  const viewModel = new SummaryViewModel(
+    "summary",
+    formModel,
+    {
+      progress: ["/test/first-page", "/test/second-page"],
+      approximate: {
+        approximate__month: 11,
+        approximate__year: 2000,
+      },
+      caz: "1",
+      aSection: {
+        fullDate: "2000-12-11T00:00:00.000Z",
+      },
+    },
+    { query: {} }
+  );
+
+  test("parses Details correctly", () => {
+    expect(viewModel.details).to.equal(testDetails);
+
+    const parsed = WebhookModel(
+      formModel.pages.filter((page) => page.path !== "/summary"),
+      viewModel.details
+    );
+    expect(parsed).to.equal([
+      {
+        category: undefined,
+        fields: [
+          {
+            answer: "2000-11",
+            key: "approximate",
+            title: "Approximate date of marriage",
+            type: "monthYear",
+          },
+          {
+            answer: "Bath",
+            key: "caz",
+            title: "caz zone",
+            type: "text",
+          },
+        ],
+        index: 0,
+        question: "When will you get married?",
+      },
+      {
+        category: {
+          name: "aSection",
+          title: "Named Section",
+        },
+        fields: [
+          {
+            answer: "0-2",
+            key: "fullDate",
+            title: "full date",
+            type: "monthYear",
+          },
+        ],
+        index: 0,
+        question: "Second page",
+      },
+    ]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5069,6 +5069,7 @@ __metadata:
     cli-ux: ^5.5.1
     code: 5.2.4
     concurrently: ^5.3.0
+    date-fns: ^2.24.0
     dotenv: 8.2.0
     eslint: ^7.6.0
     eslint-plugin-import: ^2.22.0
@@ -8637,6 +8638,13 @@ __metadata:
   version: 2.16.1
   resolution: "date-fns@npm:2.16.1"
   checksum: fbe5d9aa1dc4c92c7cf9c0b31e58f532ac9fe059f85fc622641b1ac9c673150329620ea6bf941a8ba10e8e677aa0b6ccdc04ce001f81e70fd49acd1760edcba0
+  languageName: node
+  linkType: hard
+
+"date-fns@npm:^2.24.0":
+  version: 2.24.0
+  resolution: "date-fns@npm:2.24.0"
+  checksum: 9f1944e92bbb5da0f4be8c4b3a8aa9f5b8ee3873ed97303194df8d5b62b6cdab74a673e239afbe87d99aceb37e6b989fbdc3345de2b61fafc60979dd354a79ec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

- refactor SummaryViewModel.parseDataForWebhook as it's own function
  - tidy up some of the iterations 
- fix date format for webhooks 
  - change `get dataType()` into a field (getter wasn't getting invoked properly; was returning undefined) 
  - added `answerFromDetailItem()` which makes it easier to change/return the desired value for a webhook
  - typings
- add date-fns (moment is self deprecated), keeping both until we can refactor moment out..

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

Before PR's can be merged they will need to be tested by QA and approved where
applicable. To flag the change to QA assign **@XGovFormBuilder/qa** as one of the reviewers.

- [ ] unit

# Checklist:

- [x] My changes do not introduce any new linting errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto main and there are no code conflicts
- [x] I have checked deployments are working in all environments
- [x] I have updated the architecture diagrams as per Contribute.md
