### PR TITLE
fix: pass page.section?.name instead of entire object

### DIFF
--- a/runner/src/server/plugins/engine/models/submission/WebhookModel.ts
+++ b/runner/src/server/plugins/engine/models/submission/WebhookModel.ts
@@ -54,7 +54,7 @@ export function WebhookModel(relevantPages, details, model) {
     });
 
     return {
-      category: page.section,
+      category: page.section?.name,
       question:
         page.title?.en ??
         page.title ??


### PR DESCRIPTION
# Description
