### PR TITLE
fix: replace dataType getter with property 

### DIFF
--- a/runner/src/server/plugins/engine/components/DateField.ts
+++ b/runner/src/server/plugins/engine/components/DateField.ts
@@ -9,8 +9,10 @@ import { InputFieldsComponentsDef } from "@xgovformbuilder/model";
 import { FormComponent } from "./FormComponent";
 import { FormData, FormSubmissionErrors, FormSubmissionState } from "../types";
 import { FormModel } from "../models";
+import { DataType } from "server/plugins/engine/components/types";
 
 export class DateField extends FormComponent {
+  dataType = "date" as DataType;
   constructor(def: InputFieldsComponentsDef, model: FormModel) {
     super(def, model);
     addClassOptionIfNone(this.options, "govuk-input--width-10");
@@ -41,9 +43,5 @@ export class DateField extends FormComponent {
       ...super.getViewModel(formData, errors),
       type: "date",
     };
-  }
-
-  get dataType() {
-    return "date";
   }
 }

--- a/runner/src/server/plugins/engine/components/FileUploadField.ts
+++ b/runner/src/server/plugins/engine/components/FileUploadField.ts
@@ -2,9 +2,10 @@ import { FormData, FormSubmissionErrors } from "../types";
 import { FormComponent } from "./FormComponent";
 import * as helpers from "./helpers";
 
-import { ViewModel } from "./types";
+import { DataType, ViewModel } from "./types";
 
 export class FileUploadField extends FormComponent {
+  dataType = "file" as DataType;
   getFormSchemaKeys() {
     return helpers.getFormSchemaKeys(this.name, "string", this);
   }
@@ -31,9 +32,5 @@ export class FileUploadField extends FormComponent {
     }
 
     return viewModel;
-  }
-
-  get dataType() {
-    return "file";
   }
 }

--- a/runner/src/server/plugins/engine/models/submission/WebhookModel.ts
+++ b/runner/src/server/plugins/engine/models/submission/WebhookModel.ts
@@ -10,8 +10,7 @@ function answerFromDetailItem(item) {
       return format(new Date(item.rawValue), "yyyy-MM-dd");
     case "monthYear":
       const [month, year] = Object.values(item.rawValue);
-      const date = format(new Date(`${year}-${month}-1`), "yyyy-MM");
-      return date;
+      return format(new Date(`${year}-${month}-1`), "yyyy-MM");
     default:
       return item.value;
   }

--- a/runner/src/server/plugins/logging.ts
+++ b/runner/src/server/plugins/logging.ts
@@ -4,7 +4,7 @@ import pino from "hapi-pino";
 export default {
   plugin: pino,
   options: {
-    prettyPrint: config.isDev,
+    prettyPrint: config.serviceUrl.includes("localhost"),
     level: config.logLevel,
     formatters: {
       level: (label) => {

--- a/runner/src/server/services/webhookService.ts
+++ b/runner/src/server/services/webhookService.ts
@@ -22,6 +22,10 @@ export class WebhookService {
    * @returns object with the property `reference` webhook if the response returns with a reference number. If the call fails, the reference will be 'UNKNOWN'.
    */
   async postRequest(url: string, data: object) {
+    this.logger.info(
+      ["WebhookService", "postRequest body"],
+      JSON.stringify(data)
+    );
     const { payload } = await post(url, {
       ...DEFAULT_OPTIONS,
       payload: JSON.stringify(data),
@@ -44,7 +48,6 @@ export class WebhookService {
       return reference;
     } catch (error) {
       this.logger.error(["WebhookService", "postRequest"], error);
-      this.logger.error(["WebhookService", "request body"], data);
       return "UNKNOWN";
     }
   }

--- a/runner/test/cases/server/services/webhookService.test.ts
+++ b/runner/test/cases/server/services/webhookService.test.ts
@@ -23,9 +23,9 @@ suite("Server WebhookService Service", () => {
       })
     );
     const loggerSpy = {
-      error: sinon.spy(),
-      info: sinon.spy(),
-      debug: sinon.spy(),
+      error: () => sinon.spy(),
+      info: () => sinon.spy(),
+      debug: () => sinon.spy(),
     };
     const serverMock = { logger: loggerSpy };
     const webHookeService = new WebhookService(serverMock);
@@ -40,7 +40,11 @@ suite("Server WebhookService Service", () => {
         payload: { reference: "ABCD" },
       })
     );
-    const loggerSpy = sinon.spy();
+    const loggerSpy = {
+      error: () => sinon.spy(),
+      info: () => sinon.spy(),
+      debug: () => sinon.spy(),
+    };
     const serverMock = { logger: loggerSpy };
     const webHookeService = new WebhookService(serverMock);
     const result = await webHookeService.postRequest("/url", {});


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

- replace `get dataType()` with a property. The getter didn't seem to be returning anything so was defaulting to text
- force prettyPrint off for non localhost 


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

