### PR TITLE
fix: make address line 2 optional

### DIFF
--- a/runner/src/server/plugins/engine/components/helpers.ts
+++ b/runner/src/server/plugins/engine/components/helpers.ts
@@ -32,7 +32,7 @@ export function buildFormSchema(schemaType, component, isRequired = true) {
   }
 
   if (component.options.required === false) {
-    schema = schema.allow("");
+    schema = schema.allow(null, "").optional();
   }
 
   if (schema.trim && component.schema.trim !== false) {
@@ -56,7 +56,7 @@ export function buildStateSchema(schemaType, component) {
   }
 
   if (component.options.required === false) {
-    schema = schema.allow(null);
+    schema = schema.allow(null, "").optional();
   }
 
   if (schema.trim && component.schema.trim !== false) {

--- a/runner/test/cases/server/plugins/engine/components/TextField.test.ts
+++ b/runner/test/cases/server/plugins/engine/components/TextField.test.ts
@@ -34,32 +34,21 @@ suite("TextField", () => {
       );
     });
 
+    it("is not required when explicitly configured", () => {
+      const component = new TextField(
+        {
+          ...componentDefinition,
+          options: { required: false },
+        },
+        formModel
+      );
+      expect(component.formSchema.describe().flags.presence).to.not.equal(
+        "required"
+      );
+    });
+
     it("validates correctly", () => {
       expect(component.formSchema.validate({}).error).to.exist();
-    });
-  });
-
-  describe("Optional field generated schema", () => {
-    const componentDefinition = {
-      subType: "field",
-      type: "TextField",
-      name: "middleName",
-      title: "What's your middle name?",
-      options: {
-        autocomplete: "middle-name",
-        required: false,
-      },
-      schema: {},
-    };
-
-    const formModel = {
-      makePage: () => sinon.stub(),
-    };
-
-    const component = new TextField(componentDefinition, formModel);
-
-    it("is not required", () => {
-      expect(component.formSchema.describe().flags.presence).to.equal(null);
     });
   });
 });

--- a/runner/test/cases/server/plugins/engine/components/TextField.test.ts
+++ b/runner/test/cases/server/plugins/engine/components/TextField.test.ts
@@ -38,4 +38,28 @@ suite("TextField", () => {
       expect(component.formSchema.validate({}).error).to.exist();
     });
   });
+
+  describe("Optional field generated schema", () => {
+    const componentDefinition = {
+      subType: "field",
+      type: "TextField",
+      name: "middleName",
+      title: "What's your middle name?",
+      options: {
+        autocomplete: "middle-name",
+        required: false,
+      },
+      schema: {},
+    };
+
+    const formModel = {
+      makePage: () => sinon.stub(),
+    };
+
+    const component = new TextField(componentDefinition, formModel);
+
+    it("is not required", () => {
+      expect(component.formSchema.describe().flags.presence).to.equal(null);
+    });
+  });
 });

--- a/smoke-tests/designer/wdio.conf.js
+++ b/smoke-tests/designer/wdio.conf.js
@@ -1,6 +1,6 @@
 const { hooks } = require("./support/hooks");
 const drivers = {
-  chrome: { version: "93.0.4577.63" }, // https://chromedriver.chromium.org/
+  chrome: { version: "95.0.4638.69" }, // https://chromedriver.chromium.org/
   firefox: { version: "0.29.1" }, // https://github.com/mozilla/geckodriver/releases
 };
 


### PR DESCRIPTION
# Description

Fixes #690

- Allow null and "" input in text field if set to optional
- Explicitly set `.optional()` on the schema in the above case - I don't think this is strictly needed since we're allowing null and empty input, but is seemingly required to make the `presence` check in the test give the correct result

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Basic functional test - submitted form without address line 2 and checked that it passed 
- Some manual regression testing - checked that:
    - Other text fields are still required
    - Fields set to optional in the CMS are optional
    - Data for these fields is still collected (appears on the summary page) 

# Checklist:

- [ ] My changes do not introduce any new linting errors
- [ ] I have performed a self-review of my own code
- [na (very minor change) ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and versioning
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased onto main and there are no code conflicts
- [na] I have checked deployments are working in all environments
- [na] I have updated the architecture diagrams as per Contribute.md
