### PR TITLE
fix: visualisation link a11y fixes

### DIFF
--- a/designer/client/components/Visualisation/Lines.tsx
+++ b/designer/client/components/Visualisation/Lines.tsx
@@ -58,7 +58,9 @@ export class Lines extends React.Component<Props, State> {
                 <polyline
                   onClick={() => this.editLink(edge)}
                   onKeyPress={(event) =>
-                    event.key === "Enter" ? this.editLink(edge) : null
+                    event.key === "Enter" || event.key === " "
+                      ? this.editLink(edge)
+                      : null
                   }
                   tabIndex={0}
                   points={pointsString}

--- a/designer/client/components/Visualisation/Lines.tsx
+++ b/designer/client/components/Visualisation/Lines.tsx
@@ -57,9 +57,17 @@ export class Lines extends React.Component<Props, State> {
               <g key={pointsString}>
                 <polyline
                   onClick={() => this.editLink(edge)}
+                  onKeyPress={(event) =>
+                    event.key === "Enter" ? this.editLink(edge) : null
+                  }
+                  tabIndex={0}
                   points={pointsString}
                   className={`${highlight ? "highlight" : ""}`}
                   data-testid={`${source}-${target}`.replace(/\//g, "")}
+                  aria-label={`Link from ${source} to ${target}`.replace(
+                    /\//g,
+                    ""
+                  )}
                 />
                 {label && (
                   <text

--- a/designer/client/components/Visualisation/Lines.tsx
+++ b/designer/client/components/Visualisation/Lines.tsx
@@ -33,6 +33,12 @@ export class Lines extends React.Component<Props, State> {
     });
   };
 
+  handlePolylineKeyPress = (event: React.KeyboardEvent, edge: Edge) => {
+    if (event.key === "Enter" || event.key == " ") {
+      this.editLink(edge);
+    }
+  };
+
   render() {
     const { layout, persona } = this.props;
     const { data } = this.context;
@@ -58,9 +64,7 @@ export class Lines extends React.Component<Props, State> {
                 <polyline
                   onClick={() => this.editLink(edge)}
                   onKeyPress={(event) =>
-                    event.key === "Enter" || event.key === " "
-                      ? this.editLink(edge)
-                      : null
+                    this.handlePolylineKeyPress(event, edge)
                   }
                   tabIndex={0}
                   points={pointsString}

--- a/designer/client/components/Visualisation/Lines.tsx
+++ b/designer/client/components/Visualisation/Lines.tsx
@@ -64,9 +64,10 @@ export class Lines extends React.Component<Props, State> {
                   points={pointsString}
                   className={`${highlight ? "highlight" : ""}`}
                   data-testid={`${source}-${target}`.replace(/\//g, "")}
+                  role="button"
                 >
                   <title>
-                    {`Link from ${source} to ${target}`.replace(/\//g, "")}
+                    {`Edit link from ${source} to ${target}`.replace(/\//g, "")}
                   </title>
                 </polyline>
                 {label && (

--- a/designer/client/components/Visualisation/Lines.tsx
+++ b/designer/client/components/Visualisation/Lines.tsx
@@ -64,11 +64,11 @@ export class Lines extends React.Component<Props, State> {
                   points={pointsString}
                   className={`${highlight ? "highlight" : ""}`}
                   data-testid={`${source}-${target}`.replace(/\//g, "")}
-                  aria-label={`Link from ${source} to ${target}`.replace(
-                    /\//g,
-                    ""
-                  )}
-                />
+                >
+                  <title>
+                    {`Link from ${source} to ${target}`.replace(/\//g, "")}
+                  </title>
+                </polyline>
                 {label && (
                   <text
                     textAnchor="middle"

--- a/designer/client/components/Visualisation/__tests__/Visualisation.jest.tsx
+++ b/designer/client/components/Visualisation/__tests__/Visualisation.jest.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Visualisation } from "../Visualisation";
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, fireEvent, getRoles } from "@testing-library/react";
 import { DataContext } from "../../../context";
 import { Router } from "react-router-dom";
 import { createMemoryHistory } from "history";
@@ -64,4 +64,46 @@ test("Graph is rendered with correct number of pages and updates ", async () => 
   );
 
   await waitFor(() => expect(queryAllByText("my third page").length).toBe(2));
+});
+
+test("Links between pages are navigable via keyboard", async () => {
+  const data = {
+    pages: [
+      {
+        title: "link source",
+        path: "/link-source",
+        next: [{ path: "/link-target" }],
+      },
+      { title: "link target", path: "/link-target" },
+    ],
+    conditions: [],
+  };
+  const providerProps = {
+    data,
+    save: jest.fn(),
+  };
+
+  const { queryByTestId, queryAllByText } = customRender(
+    <Visualisation previewUrl={"http://localhost:3000"} id={"aa"} />,
+    {
+      providerProps,
+    }
+  );
+
+  // Check link exists and has the expected label
+  const link = await queryAllByText(
+    "Link from link-source to link-target"
+  )?.[0];
+  expect(link).toBeTruthy();
+
+  // Check that link works when selected with the keyboard
+  expect(queryByTestId("flyout-0")).toBeNull();
+
+  fireEvent.keyPress(link, {
+    key: "Enter",
+    code: "Enter",
+    charCode: 13,
+  });
+
+  expect(queryByTestId("flyout-0")).toBeInTheDocument();
 });

--- a/designer/client/components/Visualisation/__tests__/Visualisation.jest.tsx
+++ b/designer/client/components/Visualisation/__tests__/Visualisation.jest.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Visualisation } from "../Visualisation";
-import { render, waitFor, fireEvent, getRoles } from "@testing-library/react";
+import { render, waitFor, fireEvent } from "@testing-library/react";
 import { DataContext } from "../../../context";
 import { Router } from "react-router-dom";
 import { createMemoryHistory } from "history";
@@ -83,7 +83,7 @@ test("Links between pages are navigable via keyboard", async () => {
     save: jest.fn(),
   };
 
-  const { queryByTestId, queryAllByText } = customRender(
+  const { queryByTestId, queryAllByText, getByText } = customRender(
     <Visualisation previewUrl={"http://localhost:3000"} id={"aa"} />,
     {
       providerProps,
@@ -92,17 +92,30 @@ test("Links between pages are navigable via keyboard", async () => {
 
   // Check link exists and has the expected label
   const link = await queryAllByText(
-    "Link from link-source to link-target"
+    "Edit link from link-source to link-target"
   )?.[0];
   expect(link).toBeTruthy();
 
-  // Check that link works when selected with the keyboard
+  // Check that link works when selected with the enter key
   expect(queryByTestId("flyout-0")).toBeNull();
 
   fireEvent.keyPress(link, {
     key: "Enter",
     code: "Enter",
     charCode: 13,
+  });
+
+  expect(queryByTestId("flyout-0")).toBeInTheDocument();
+
+  fireEvent.click(getByText("Close"));
+
+  // Check that link works when selected with the space key
+  expect(queryByTestId("flyout-0")).toBeNull();
+
+  fireEvent.keyPress(link, {
+    key: " ",
+    code: "Space",
+    charCode: 32,
   });
 
   expect(queryByTestId("flyout-0")).toBeInTheDocument();


### PR DESCRIPTION
# Description

Fixes #701 
Fixes #702 

- Link polylines in the visualisation now have `role="button"` and an appropriate `title` so that screen reader users know they can be used to edit the corresponding link
- Space bar and enter events on the link polyline will open the Edit Link menu - thi smatches the behaviour of native buttons

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Manual testing with keyboard navigation
- [ ] Manual testing in VoiceOver
- [ ] Automated tests added

# Checklist:

- [ ] My changes do not introduce any new linting errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ n/a ] I have made corresponding changes to the documentation and versioning
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased onto main and there are no code conflicts
- [ n/a ] I have checked deployments are working in all environments
- [ n/a ] I have updated the architecture diagrams as per Contribute.md
