### PR TITLE
fix: phase banner tag

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -75,7 +75,8 @@ LINK_TO is optional, it defaults to `./${PROJECT_DIR}`.
 | PREVIEW_MODE       | Preview mode                          |    no    | false   |                             | This should only be used in a dev or testing environment. Setting true will allow POST requests from the designer to add or mutate forms. |
 | LOG_LEVEL          | Log level                             |    no    | debug   |   trace,debug,info,error    |                                                                                                                                           |
 | PRIVACY_POLICY_URL | The url used in footer's privacy link |    no    | #       |                             |                                                                                                                                           |
-| API_ENV            | Switch for API keys                   |    no    |         | test,production             | If the JSON file supplies test and live API keys, this is used to switch between which key which needs to be used                         |
+| API_ENV            | Switch for API keys                   |    no    |         |       test,production       |             If the JSON file supplies test and live API keys, this is used to switch between which key which needs to be used             |
+| PHASE_TAG          | Tag to use for phase banner           |    no    | beta    |  alpha, beta, empty string  |                                                                                                                                           |
 
 # Testing
 

--- a/runner/src/server/config.ts
+++ b/runner/src/server/config.ts
@@ -1,8 +1,11 @@
 import dotEnv from "dotenv";
-dotEnv.config({ path: ".env" });
 import Joi, { CustomHelpers } from "joi";
 
 import { isUrlSecure } from "src/server/utils/url";
+
+if (process.env.NODE_ENV !== "test") {
+  dotEnv.config({ path: ".env" });
+}
 
 const minute = 60 * 1000;
 const DEFAULT_SESSION_TTL = 20 * minute;
@@ -34,6 +37,7 @@ const schema = Joi.object({
   ordnanceSurveyKey: Joi.string().optional(),
   browserRefreshUrl: Joi.string().optional(),
   feedbackLink: Joi.string().default("#"),
+  phaseTag: Joi.string().optional().valid("", "alpha", "beta").default("beta"),
   gtmId1: Joi.string().optional(),
   gtmId2: Joi.string().optional(),
   matomoId: Joi.string().optional(),
@@ -86,6 +90,7 @@ export function buildConfig() {
     ordnanceSurveyKey: process.env.ORDNANCE_SURVEY_KEY,
     browserRefreshUrl: process.env.BROWSER_REFRESH_URL,
     feedbackLink: process.env.FEEDBACK_LINK,
+    phaseTag: process.env.PHASE_TAG,
     gtmId1: process.env.GTM_ID_1,
     gtmId2: process.env.GTM_ID_2,
     matomoId: process.env.MATOMO_ID,

--- a/runner/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/runner/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -5,12 +5,11 @@ import { feedbackReturnInfoKey, redirectUrl } from "../helpers";
 import { decodeFeedbackContextInfo } from "../feedback";
 import { formSchema } from "server/schemas/formSchema";
 import { SummaryPageController } from "../pageControllers";
-import type { Fees } from "server/services/payService";
 import { FormSubmissionState } from "../types";
 import { FEEDBACK_CONTEXT_ITEMS, WebhookData } from "./types";
 import {
-  FeesModel,
   EmailModel,
+  FeesModel,
   NotifyModel,
   WebhookModel,
 } from "server/plugins/engine/models/submission";
@@ -44,6 +43,7 @@ export class SummaryViewModel {
   fees: FeesModel | undefined;
   name: string | undefined;
   feedbackLink: string | undefined;
+  phaseTag: string | undefined;
   declarationError: any; // TODO
   errors:
     | {

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -1,11 +1,11 @@
 import { SummaryViewModel } from "../models";
 import { PageController } from "./PageController";
-import { redirectTo, redirectUrl, feedbackReturnInfoKey } from "../helpers";
+import { feedbackReturnInfoKey, redirectTo, redirectUrl } from "../helpers";
 import { HapiRequest, HapiResponseToolkit } from "server/types";
 import {
-  RelativeUrl,
-  FeedbackContextInfo,
   decodeFeedbackContextInfo,
+  FeedbackContextInfo,
+  RelativeUrl,
 } from "../feedback";
 import config from "server/config";
 
@@ -89,7 +89,6 @@ export class SummaryPageController extends PageController {
       if (declarationError.length) {
         viewModel.declarationError = declarationError[0];
       }
-
       return h.view("summary", viewModel);
     };
   }

--- a/runner/src/server/plugins/views.ts
+++ b/runner/src/server/plugins/views.ts
@@ -77,6 +77,7 @@ export default {
       skipTimeoutWarning: false,
       serviceStartPage: config.serviceStartPage || "#",
       privacyPolicyUrl: config.privacyPolicyUrl || "#",
+      phaseTag: config.phaseTag,
     }),
   },
 };

--- a/runner/src/server/views/layout.html
+++ b/runner/src/server/views/layout.html
@@ -111,19 +111,21 @@
 {% endblock %}
 
 {% block beforeContent %}
-    {% if feedbackLink %}
-        {{ govukPhaseBanner({
-            tag: {
-              text: "beta"
-            },
-            html: 'This is a new service – your <a class="govuk-link" href=' + feedbackLink + '>feedback</a> will help us to improve it.'
-        }) }}
-    {% else %}
-        {{ govukPhaseBanner({
-        tag: {
-        text: "beta"
-        }
-        }) }}
+    {% if phaseTag %}
+        {% if feedbackLink %}
+            {{ govukPhaseBanner({
+                tag: {
+                    text: phaseTag
+                },
+                html: 'This is a new service – your <a class="govuk-link" href=' + feedbackLink + '>feedback</a> will help us to improve it.'
+            }) }}
+        {% else %}
+            {{ govukPhaseBanner({
+                tag: {
+                    text: phaseTag
+                }
+            }) }}
+        {% endif %}
     {% endif %}
     {% if backLink %}
         {{ govukBackLink({

--- a/runner/test/cases/server/feedback.json
+++ b/runner/test/cases/server/feedback.json
@@ -30,25 +30,20 @@
       "next": []
     }
   ],
-  "lists": [
-  ],
+  "lists": [],
   "sections": [
     {
       "name": "checkBeforeYouStart",
       "title": "Check before you start"
     }
   ],
-  "phaseBanner": {},
   "feedback": {
     "emailAddress": "test@feedback.cat"
   },
-  "fees": [
-  ],
+  "fees": [],
   "payApiKey": "",
-  "outputs": [
-  ],
+  "outputs": [],
   "declaration": "<p class=\"govuk-body\">All the answers you have provided are true to the best of your knowledge.</p>",
   "version": 2,
-  "conditions": [
-  ]
+  "conditions": []
 }

--- a/runner/test/cases/server/forms/phase-alpha.json
+++ b/runner/test/cases/server/forms/phase-alpha.json
@@ -1,0 +1,37 @@
+{
+  "metadata": {},
+  "startPage": "/first-page",
+  "pages": [
+    {
+      "title": "First page",
+      "path": "/first-page",
+      "components": [],
+      "next": [
+        {
+          "path": "/summary"
+        }
+      ]
+    },
+    {
+      "path": "/summary",
+      "controller": "./pages/summary.js",
+      "title": "Summary",
+      "components": [],
+      "next": []
+    }
+  ],
+  "lists": [],
+  "sections": [],
+  "conditions": [],
+  "fees": [],
+  "outputs": [],
+  "version": 2,
+  "skipSummary": false,
+  "name": "Alpha form",
+  "feedback": {
+    "feedbackForm": false
+  },
+  "phaseBanner": {
+    "phase": "alpha"
+  }
+}

--- a/runner/test/cases/server/forms/phase-default.json
+++ b/runner/test/cases/server/forms/phase-default.json
@@ -1,0 +1,30 @@
+{
+  "metadata": {},
+  "startPage": "/first-page",
+  "pages": [
+    {
+      "title": "First page",
+      "path": "/first-page",
+      "components": [],
+      "next": [
+        {
+          "path": "/summary"
+        }
+      ]
+    },
+    {
+      "path": "/summary",
+      "controller": "./pages/summary.js",
+      "title": "Summary",
+      "components": [],
+      "next": []
+    }
+  ],
+  "lists": [],
+  "sections": [],
+  "conditions": [],
+  "fees": [],
+  "outputs": [],
+  "version": 2,
+  "skipSummary": false
+}

--- a/runner/test/cases/server/forms/phase-none.json
+++ b/runner/test/cases/server/forms/phase-none.json
@@ -1,0 +1,35 @@
+{
+  "metadata": {},
+  "startPage": "/first-page",
+  "pages": [
+    {
+      "title": "First page",
+      "path": "/first-page",
+      "components": [],
+      "next": [
+        {
+          "path": "/summary"
+        }
+      ]
+    },
+    {
+      "path": "/summary",
+      "controller": "./pages/summary.js",
+      "title": "Summary",
+      "components": [],
+      "next": []
+    }
+  ],
+  "lists": [],
+  "sections": [],
+  "conditions": [],
+  "fees": [],
+  "outputs": [],
+  "version": 2,
+  "skipSummary": false,
+  "name": "Phase None form",
+  "feedback": {
+    "feedbackForm": false
+  },
+  "phaseBanner": {}
+}

--- a/runner/test/cases/server/phase-banner.test.js
+++ b/runner/test/cases/server/phase-banner.test.js
@@ -1,0 +1,80 @@
+import Lab from "@hapi/lab";
+import { expect } from "@hapi/code";
+import cheerio from "cheerio";
+import createServer from "src/server";
+
+const { test, suite, afterEach } = (exports.lab = Lab.script());
+
+suite(`Phase banner`, () => {
+  let server;
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  test("shows the beta tag by default", async () => {
+    // For backwards-compatibility, as the main layout template currently always shows 'beta'.
+    // TODO: default to no phase banner? TBD
+    server = await createServer({
+      formFileName: `phase-default.json`,
+      formFilePath: __dirname + "/forms",
+    });
+    await server.start();
+
+    const options = {
+      method: "GET",
+      url: `/phase-default/first-page`,
+    };
+
+    const response = await server.inject(options);
+    expect(response.statusCode).to.equal(200);
+
+    const $ = cheerio.load(response.payload);
+
+    expect($(".govuk-phase-banner__content__tag").text().trim()).to.equal(
+      "beta"
+    );
+  });
+
+  test("shows the alpha tag if selected", async () => {
+    server = await createServer({
+      formFileName: `phase-alpha.json`,
+      formFilePath: __dirname + "/forms",
+    });
+    await server.start();
+
+    const options = {
+      method: "GET",
+      url: `/phase-alpha/first-page`,
+    };
+
+    const response = await server.inject(options);
+    expect(response.statusCode).to.equal(200);
+
+    const $ = cheerio.load(response.payload);
+
+    expect($(".govuk-phase-banner__content__tag").text().trim()).to.equal(
+      "alpha"
+    );
+  });
+
+  test("does not show the phase banner if None", async () => {
+    server = await createServer({
+      formFileName: `phase-none.json`,
+      formFilePath: __dirname + "/forms",
+    });
+    await server.start();
+
+    const options = {
+      method: "GET",
+      url: `/phase-none/first-page`,
+    };
+
+    const response = await server.inject(options);
+    expect(response.statusCode).to.equal(200);
+
+    const $ = cheerio.load(response.payload);
+
+    expect($(".govuk-phase-banner").html()).to.equal(null);
+  });
+});


### PR DESCRIPTION
# Description

Fixes #706 

Phase banner now reflects option set in form config. If no option set in form config, the phase tag shows as set in ENV config. Finally, the phase tag defaults to 'BETA' for backwards compatibility (linked layout template bug means 'BETA' is always shown).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit tests added to test rendering of phase banner.

To manually test:

1. Create new form in designer
2. Check preview: phase banner should show 'BETA'
3. Edit form details and choose 'Alpha' for phase banner
4. Check preview: phase banner should show 'ALPHA'
5. Edit for and choose 'None' for phase banner
6. Check preview: phase banner should not be shown

Before PR's can be merged they will need to be tested by QA and approved where
applicable. To flag the change to QA assign **@XGovFormBuilder/qa** as one of the reviewers.

# Checklist:

- [x] My changes do not introduce any new linting errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md
