### PR TITLE
Fix: close menu flyouts on save

### DIFF
--- a/designer/client/components/Menu/Menu.tsx
+++ b/designer/client/components/Menu/Menu.tsx
@@ -80,25 +80,25 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
       </div>
       {formDetails.isVisible && (
         <Flyout title="Form Details" onHide={formDetails.hide}>
-          <FormDetails onCreate={() => formDetails.hide} />
+          <FormDetails onCreate={() => formDetails.hide()} />
         </Flyout>
       )}
 
       {page.isVisible && (
         <Flyout title="Add Page" onHide={page.hide}>
-          <PageCreate data={data} onCreate={() => page.hide} />
+          <PageCreate data={data} onCreate={() => page.hide()} />
         </Flyout>
       )}
 
       {link.isVisible && (
         <Flyout title={i18n("menu.links")} onHide={link.hide}>
-          <LinkCreate data={data} onCreate={() => link.hide} />
+          <LinkCreate data={data} onCreate={() => link.hide()} />
         </Flyout>
       )}
 
       {sections.isVisible && (
         <Flyout title="Edit Sections" onHide={sections.hide}>
-          <SectionsEdit data={data} onCreate={() => sections.hide} />
+          <SectionsEdit data={data} />
         </Flyout>
       )}
 
@@ -108,7 +108,7 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
           onHide={conditions.hide}
           width="large"
         >
-          <ConditionsEdit onCreate={() => conditions.hide} />
+          <ConditionsEdit />
         </Flyout>
       )}
 
@@ -123,13 +123,13 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
       )}
       {outputs.isVisible && (
         <Flyout title="Edit Outputs" onHide={outputs.hide} width="xlarge">
-          <OutputsEdit data={data} onCreate={outputs.hide} />
+          <OutputsEdit data={data} />
         </Flyout>
       )}
 
       {fees.isVisible && (
         <Flyout title="Edit Fees" onHide={fees.hide} width="xlarge">
-          <FeeEdit data={data} onEdit={() => fees.hide} />
+          <FeeEdit data={data} onEdit={() => fees.hide()} />
         </Flyout>
       )}
 
@@ -139,7 +139,10 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
           onHide={summaryBehaviour.hide}
           width="xlarge"
         >
-          <DeclarationEdit data={data} onCreate={() => summaryBehaviour.hide} />
+          <DeclarationEdit
+            data={data}
+            onCreate={() => summaryBehaviour.hide()}
+          />
         </Flyout>
       )}
 

--- a/designer/client/components/Menu/__tests__/Menu.jest.tsx
+++ b/designer/client/components/Menu/__tests__/Menu.jest.tsx
@@ -56,3 +56,14 @@ it("clicking on a summary tab shows different tab content", () => {
   expect(queryByTestId("tab-summary")).toBeNull();
   expect(queryByTestId("tab-model")).toBeNull();
 });
+
+it("flyouts close on Save", async () => {
+  const { getByText, queryByTestId } = customRender(<Menu />);
+
+  fireEvent.click(getByText("Summary behaviour"));
+  expect(queryByTestId("flyout-1")).toBeInTheDocument();
+
+  await fireEvent.click(getByText("Save"));
+  expect(dataValue.save).toHaveBeenCalledTimes(1);
+  expect(queryByTestId("flyout-1")).toBeNull();
+});

--- a/designer/client/declaration-edit.js
+++ b/designer/client/declaration-edit.js
@@ -13,7 +13,7 @@ class DeclarationEdit extends React.Component {
     this.onSubmit = this.onSubmit.bind(this);
   }
 
-  onSubmit = (e) => {
+  onSubmit = async (e) => {
     e.preventDefault();
     const form = e.target;
     const formData = new window.FormData(form);
@@ -24,13 +24,8 @@ class DeclarationEdit extends React.Component {
     copy.declaration = formData.get("declaration");
     copy.skipSummary = formData.get("skip-summary") === "on";
 
-    save(copy)
-      .then((data) => {
-        toggleShowState("showEditSummaryBehaviour");
-      })
-      .catch((err) => {
-        logger.error("DeclarationEdit", err);
-      });
+    const savedData = await save(copy);
+    this.props.onCreate({ data: savedData });
   };
 
   render() {

--- a/designer/client/declaration-edit.js
+++ b/designer/client/declaration-edit.js
@@ -24,8 +24,12 @@ class DeclarationEdit extends React.Component {
     copy.declaration = formData.get("declaration");
     copy.skipSummary = formData.get("skip-summary") === "on";
 
-    const savedData = await save(copy);
-    this.props.onCreate({ data: savedData });
+    try {
+      const savedData = await save(copy);
+      this.props.onCreate({ data: savedData });
+    } catch {
+      logger.error("DeclarationEdit", err);
+    }
   };
 
   render() {


### PR DESCRIPTION
# Description
Fixes #699 
Includes:
- Fixes onCreate calls in Menu component
- Remove onCreate prop from menu items which don't use it
- Slight edit to DeclarationEdit component so the save logic matches the other menu components

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Manually testing that the window closes on Save
- [ ] Some manual regression testing to make sure saves happen correctly
- [ ] Added automated test

# Checklist:

- [ ] My changes do not introduce any new linting errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and versioning
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased onto main and there are no code conflicts
- [ n/a ] I have checked deployments are working in all environments
- [ n/a ] I have updated the architecture diagrams as per Contribute.md
