### PR TITLE
Edit summary behaviour (declaration/skip) from the page rather than the menu

### DIFF
--- a/designer/client/components/DataPrettyPrint/DataPrettyPrint.tsx
+++ b/designer/client/components/DataPrettyPrint/DataPrettyPrint.tsx
@@ -22,17 +22,17 @@ export function DataPrettyPrint(props) {
   const model = {};
 
   pages.forEach((page) => {
-    page.components!.forEach((component) => {
+    page.components.forEach((component) => {
       if (component.name) {
         if (page.section) {
           const section = sections.find(
             (section) => section.name === page.section
           );
-          if (!model[section!.name]) {
-            model[section!.name] = {};
+          if (!model[section.name]) {
+            model[section.name] = {};
           }
 
-          model[section!.name][component.name] = `${component.type}`;
+          model[section.name][component.name] = `${component.type}`;
         } else {
           model[component.name] = `${component.type}`;
         }

--- a/designer/client/components/DataPrettyPrint/DataPrettyPrint.tsx
+++ b/designer/client/components/DataPrettyPrint/DataPrettyPrint.tsx
@@ -17,7 +17,7 @@ export function componentToString(component) {
 
 export function DataPrettyPrint(props) {
   const { data } = useContext(DataContext);
-  const { sections = [], pages = []} = data;
+  const { sections = [], pages = [] } = data;
 
   const model = {};
 
@@ -44,6 +44,5 @@ export function DataPrettyPrint(props) {
     <div>
       <pre>{JSON.stringify(model, null, 2)}</pre>
     </div>
-  ); 
-} 
-
+  );
+}

--- a/designer/client/components/DataPrettyPrint/DataPrettyPrint.tsx
+++ b/designer/client/components/DataPrettyPrint/DataPrettyPrint.tsx
@@ -1,5 +1,4 @@
-import React, { useContext } from "react";
-import { DataContext } from "../../context";
+import React from "react";
 
 const listTypes = [
   "SelectField",
@@ -16,23 +15,23 @@ export function componentToString(component) {
 }
 
 export function DataPrettyPrint(props) {
-  const { data } = useContext(DataContext);
+  const { data } = props;
   const { sections = [], pages = [] } = data;
 
   const model = {};
 
   pages.forEach((page) => {
-    page.components!.forEach((component) => {
+    page.components.forEach((component) => {
       if (component.name) {
         if (page.section) {
           const section = sections.find(
             (section) => section.name === page.section
           );
-          if (!model[section!.name]) {
-            model[section!.name] = {};
+          if (!model[section.name]) {
+            model[section.name] = {};
           }
 
-          model[section!.name][component.name] = `${component.type}`;
+          model[section.name][component.name] = `${component.type}`;
         } else {
           model[component.name] = `${component.type}`;
         }

--- a/designer/client/components/DataPrettyPrint/DataPrettyPrint.tsx
+++ b/designer/client/components/DataPrettyPrint/DataPrettyPrint.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useContext } from "react";
+import { DataContext } from "../../context";
 
 const listTypes = [
   "SelectField",
@@ -15,23 +16,23 @@ export function componentToString(component) {
 }
 
 export function DataPrettyPrint(props) {
-  const { data } = props;
+  const { data } = useContext(DataContext);
   const { sections = [], pages = [] } = data;
 
   const model = {};
 
   pages.forEach((page) => {
-    page.components.forEach((component) => {
+    page.components!.forEach((component) => {
       if (component.name) {
         if (page.section) {
           const section = sections.find(
             (section) => section.name === page.section
           );
-          if (!model[section.name]) {
-            model[section.name] = {};
+          if (!model[section!.name]) {
+            model[section!.name] = {};
           }
 
-          model[section.name][component.name] = `${component.type}`;
+          model[section!.name][component.name] = `${component.type}`;
         } else {
           model[component.name] = `${component.type}`;
         }

--- a/designer/client/components/DataPrettyPrint/DataPrettyPrint.tsx
+++ b/designer/client/components/DataPrettyPrint/DataPrettyPrint.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useContext } from "react";
+import { DataContext } from "../../context";
 
 const listTypes = [
   "SelectField",
@@ -15,23 +16,23 @@ export function componentToString(component) {
 }
 
 export function DataPrettyPrint(props) {
-  const { data } = props;
-  const { sections = [], pages = [] } = data;
+  const { data } = useContext(DataContext);
+  const { sections = [], pages = []} = data;
 
   const model = {};
 
   pages.forEach((page) => {
-    page.components.forEach((component) => {
+    page.components!.forEach((component) => {
       if (component.name) {
         if (page.section) {
           const section = sections.find(
             (section) => section.name === page.section
           );
-          if (!model[section.name]) {
-            model[section.name] = {};
+          if (!model[section!.name]) {
+            model[section!.name] = {};
           }
 
-          model[section.name][component.name] = `${component.type}`;
+          model[section!.name][component.name] = `${component.type}`;
         } else {
           model[component.name] = `${component.type}`;
         }
@@ -43,5 +44,6 @@ export function DataPrettyPrint(props) {
     <div>
       <pre>{JSON.stringify(model, null, 2)}</pre>
     </div>
-  );
-}
+  ); 
+} 
+

--- a/designer/client/components/Flyout/Flyout.tsx
+++ b/designer/client/components/Flyout/Flyout.tsx
@@ -7,16 +7,10 @@ import { i18n } from "../../i18n";
 import "./Flyout.scss";
 import { bool } from "aws-sdk/clients/signer";
 
-type Props = {
-  NEVER_UNMOUNTS: any;
-  onHide: (e?: any) => void;
-  width: string;
-  show: boolean;
-};
+type Props = {};
 
 export function useFlyoutEffect(props: Props) {
   const flyoutContext = useContext(FlyoutContext);
-  const { data } = useContext(DataContext);
   const [offset, setOffset] = useState(0);
   const [style, setStyle] = useState();
   const show = props.show ?? true;

--- a/designer/client/components/Flyout/Flyout.tsx
+++ b/designer/client/components/Flyout/Flyout.tsx
@@ -1,12 +1,23 @@
 import React, { useContext, useEffect, useLayoutEffect, useState } from "react";
 import FocusTrap from "focus-trap-react";
 import { FlyoutContext } from "../../context";
+import { DataContext } from "../../context";
 import { i18n } from "../../i18n";
 
 import "./Flyout.scss";
+import { bool } from "aws-sdk/clients/signer";
 
-export function useFlyoutEffect(props = {}) {
+
+type Props = {
+  NEVER_UNMOUNTS: any;
+  onHide: (e?: any) => void;
+  width: string;
+  show: boolean;
+};
+
+export function useFlyoutEffect(props: Props) {
   const flyoutContext = useContext(FlyoutContext);
+  const { data } = useContext(DataContext);
   const [offset, setOffset] = useState(0);
   const [style, setStyle] = useState();
   const show = props.show ?? true;

--- a/designer/client/components/Flyout/Flyout.tsx
+++ b/designer/client/components/Flyout/Flyout.tsx
@@ -7,7 +7,6 @@ import { i18n } from "../../i18n";
 import "./Flyout.scss";
 import { bool } from "aws-sdk/clients/signer";
 
-
 type Props = {
   NEVER_UNMOUNTS: any;
   onHide: (e?: any) => void;

--- a/designer/client/components/Menu/Menu.tsx
+++ b/designer/client/components/Menu/Menu.tsx
@@ -9,7 +9,6 @@ import { i18n } from "../../i18n";
 import { ListsEditorContextProvider } from "../../reducers/list/listsEditorReducer";
 import { ListContextProvider } from "../../reducers/listReducer";
 import { FeeEdit } from "../Fee/FeeEdit";
-import DeclarationEdit from "../../declaration-edit";
 import OutputsEdit from "../../outputs/outputs-edit";
 import { DataContext } from "../../context";
 import { DataPrettyPrint } from "../DataPrettyPrint/DataPrettyPrint";
@@ -34,7 +33,6 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
   const lists = useMenuItem();
   const outputs = useMenuItem();
   const fees = useMenuItem();
-  const summaryBehaviour = useMenuItem();
   const summary = useMenuItem();
 
   const { selectedTab, handleTabChange } = useTabs();
@@ -65,12 +63,6 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
         </button>
         <button data-testid="menu-fees" onClick={fees.show}>
           {i18n("menu.fees")}
-        </button>
-        <button
-          data-testid="menu-summary-behaviour"
-          onClick={summaryBehaviour.show}
-        >
-          {i18n("menu.summaryBehaviour")}
         </button>
         <button onClick={summary.show} data-testid="menu-summary">
           {i18n("menu.summary")}
@@ -129,16 +121,6 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
       {fees.isVisible && (
         <Flyout title="Edit Fees" onHide={fees.hide} width="xlarge">
           <FeeEdit onEdit={() => fees.hide()} />
-        </Flyout>
-      )}
-
-      {summaryBehaviour.isVisible && (
-        <Flyout
-          title="Edit Summary behaviour"
-          onHide={summaryBehaviour.hide}
-          width="xlarge"
-        >
-          <DeclarationEdit onCreate={() => summaryBehaviour.hide()} />
         </Flyout>
       )}
 

--- a/designer/client/components/Menu/Menu.tsx
+++ b/designer/client/components/Menu/Menu.tsx
@@ -86,19 +86,19 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
 
       {page.isVisible && (
         <Flyout title="Add Page" onHide={page.hide}>
-          <PageCreate data={data} onCreate={() => page.hide()} />
+          <PageCreate onCreate={() => page.hide()} />
         </Flyout>
       )}
 
       {link.isVisible && (
         <Flyout title={i18n("menu.links")} onHide={link.hide}>
-          <LinkCreate data={data} onCreate={() => link.hide()} />
+          <LinkCreate onCreate={() => link.hide()} />
         </Flyout>
       )}
 
       {sections.isVisible && (
         <Flyout title="Edit Sections" onHide={sections.hide}>
-          <SectionsEdit data={data} />
+          <SectionsEdit />
         </Flyout>
       )}
 
@@ -123,13 +123,13 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
       )}
       {outputs.isVisible && (
         <Flyout title="Edit Outputs" onHide={outputs.hide} width="xlarge">
-          <OutputsEdit data={data} />
+          <OutputsEdit/>
         </Flyout>
       )}
 
       {fees.isVisible && (
         <Flyout title="Edit Fees" onHide={fees.hide} width="xlarge">
-          <FeeEdit data={data} onEdit={() => fees.hide()} />
+          <FeeEdit onEdit={() => fees.hide()} />
         </Flyout>
       )}
 
@@ -140,7 +140,6 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
           width="xlarge"
         >
           <DeclarationEdit
-            data={data}
             onCreate={() => summaryBehaviour.hide()}
           />
         </Flyout>

--- a/designer/client/components/Menu/Menu.tsx
+++ b/designer/client/components/Menu/Menu.tsx
@@ -138,9 +138,7 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
           onHide={summaryBehaviour.hide}
           width="xlarge"
         >
-          <DeclarationEdit
-            onCreate={() => summaryBehaviour.hide()}
-          />
+          <DeclarationEdit onCreate={() => summaryBehaviour.hide()} />
         </Flyout>
       )}
 
@@ -211,4 +209,5 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
 
       <SubMenu id={id} updateDownloadedAt={updateDownloadedAt} />
     </nav>
-  )}
+  );
+}

--- a/designer/client/components/Menu/Menu.tsx
+++ b/designer/client/components/Menu/Menu.tsx
@@ -84,7 +84,7 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
 
       {page.isVisible && (
         <Flyout title="Add Page" onHide={page.hide}>
-          <PageCreate onCreate={() => page.hide()} />
+          <PageCreate data={data} onCreate={() => page.hide()} />
         </Flyout>
       )}
 

--- a/designer/client/components/Menu/Menu.tsx
+++ b/designer/client/components/Menu/Menu.tsx
@@ -84,7 +84,7 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
 
       {page.isVisible && (
         <Flyout title="Add Page" onHide={page.hide}>
-          <PageCreate data={data} onCreate={() => page.hide()} />
+          <PageCreate onCreate={() => page.hide()} />
         </Flyout>
       )}
 

--- a/designer/client/components/Menu/Menu.tsx
+++ b/designer/client/components/Menu/Menu.tsx
@@ -180,7 +180,7 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
               </ul>
               {selectedTab === Tabs.model && (
                 <section className="govuk-tabs__panel" data-testid="tab-model">
-                  <DataPrettyPrint data={data} />
+                  <DataPrettyPrint />
                 </section>
               )}
               {selectedTab === Tabs.json && (

--- a/designer/client/components/Menu/Menu.tsx
+++ b/designer/client/components/Menu/Menu.tsx
@@ -123,7 +123,7 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
       )}
       {outputs.isVisible && (
         <Flyout title="Edit Outputs" onHide={outputs.hide} width="xlarge">
-          <OutputsEdit/>
+          <OutputsEdit />
         </Flyout>
       )}
 
@@ -183,7 +183,7 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
               </ul>
               {selectedTab === Tabs.model && (
                 <section className="govuk-tabs__panel" data-testid="tab-model">
-                  <DataPrettyPrint data={data} />
+                  <DataPrettyPrint />
                 </section>
               )}
               {selectedTab === Tabs.json && (

--- a/designer/client/components/Menu/Menu.tsx
+++ b/designer/client/components/Menu/Menu.tsx
@@ -96,7 +96,7 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
 
       {sections.isVisible && (
         <Flyout title="Edit Sections" onHide={sections.hide}>
-          <SectionsEdit data={data} />
+          <SectionsEdit />
         </Flyout>
       )}
 

--- a/designer/client/components/Menu/Menu.tsx
+++ b/designer/client/components/Menu/Menu.tsx
@@ -63,7 +63,6 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
         <button data-testid="menu-outputs" onClick={outputs.show}>
           {i18n("menu.outputs")}
         </button>
-
         <button data-testid="menu-fees" onClick={fees.show}>
           {i18n("menu.fees")}
         </button>
@@ -73,7 +72,6 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
         >
           {i18n("menu.summaryBehaviour")}
         </button>
-
         <button onClick={summary.show} data-testid="menu-summary">
           {i18n("menu.summary")}
         </button>
@@ -121,6 +119,7 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
           </ListsEditorContextProvider>
         </Flyout>
       )}
+
       {outputs.isVisible && (
         <Flyout title="Edit Outputs" onHide={outputs.hide} width="xlarge">
           <OutputsEdit />
@@ -212,5 +211,4 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
 
       <SubMenu id={id} updateDownloadedAt={updateDownloadedAt} />
     </nav>
-  );
-}
+  )}

--- a/designer/client/components/Menu/Menu.tsx
+++ b/designer/client/components/Menu/Menu.tsx
@@ -96,7 +96,7 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
 
       {sections.isVisible && (
         <Flyout title="Edit Sections" onHide={sections.hide}>
-          <SectionsEdit />
+          <SectionsEdit data={data} />
         </Flyout>
       )}
 

--- a/designer/client/components/Menu/Menu.tsx
+++ b/designer/client/components/Menu/Menu.tsx
@@ -180,7 +180,7 @@ export default function Menu({ updateDownloadedAt, id }: Props) {
               </ul>
               {selectedTab === Tabs.model && (
                 <section className="govuk-tabs__panel" data-testid="tab-model">
-                  <DataPrettyPrint />
+                  <DataPrettyPrint data={data} />
                 </section>
               )}
               {selectedTab === Tabs.json && (

--- a/designer/client/components/Page/Page.tsx
+++ b/designer/client/components/Page/Page.tsx
@@ -43,6 +43,7 @@ export const Page = ({ page, previewUrl, id, layout }) => {
   const { data, save } = useContext(DataContext);
   const [isEditingPage, setIsEditingPage] = useState(false);
   const [isCreatingComponent, setIsCreatingComponent] = useState(false);
+  const [isEditingDeclaration, setIsEditingDeclaration] = useState(false);
 
   const onSortEnd = ({ oldIndex, newIndex }) => {
     const copy = { ...data };
@@ -52,7 +53,14 @@ export const Page = ({ page, previewUrl, id, layout }) => {
     save(copy);
   };
 
+  const onEditStart = () => {
+    setIsEditingPage(true);
+
+    if (page?.path === "/summary") setIsEditingDeclaration(true);
+  };
+
   const onEditEnd = () => {
+    setIsEditingDeclaration(false);
     setIsEditingPage(false);
   };
 
@@ -95,10 +103,7 @@ export const Page = ({ page, previewUrl, id, layout }) => {
       />
 
       <div className="page__actions">
-        <button
-          title={i18n("Edit page")}
-          onClick={(_e) => setIsEditingPage(true)}
-        >
+        <button title={i18n("Edit page")} onClick={(_e) => onEditStart()}>
           {i18n("Edit page")}
         </button>
         <button
@@ -119,7 +124,11 @@ export const Page = ({ page, previewUrl, id, layout }) => {
       </div>
       {isEditingPage && (
         <Flyout title="Edit Page" onHide={setIsEditingPage}>
-          <PageEdit page={page} onEdit={onEditEnd} />
+          <PageEdit
+            page={page}
+            onEdit={onEditEnd}
+            isEditingDeclaration={isEditingDeclaration}
+          />
         </Flyout>
       )}
 

--- a/designer/client/conditions/ConditionsEdit.tsx
+++ b/designer/client/conditions/ConditionsEdit.tsx
@@ -39,9 +39,7 @@ function useConditionsEditor() {
   };
 }
 
-type Props = {
-  path: string;
-};
+type Props = {};
 
 export function ConditionsEdit({ path }: Props) {
   const {

--- a/designer/client/declaration-edit.js
+++ b/designer/client/declaration-edit.js
@@ -1,10 +1,12 @@
 import React from "react";
 import Editor from "./editor";
 import { clone } from "@xgovformbuilder/model";
-
 import { DataContext } from "./context";
 import logger from "../client/plugins/logger";
 
+/**
+ * @deprecated Edit from summary page instead to add a declaration
+ */
 class DeclarationEdit extends React.Component {
   static contextType = DataContext;
 

--- a/designer/client/declaration-edit.js
+++ b/designer/client/declaration-edit.js
@@ -33,7 +33,7 @@ class DeclarationEdit extends React.Component {
   };
 
   render() {
-    const { data } = this.props;
+    const { data } = this.context;
     const { declaration, skipSummary } = data;
 
     return (

--- a/designer/client/declaration-edit.js
+++ b/designer/client/declaration-edit.js
@@ -17,8 +17,8 @@ class DeclarationEdit extends React.Component {
     e.preventDefault();
     const form = e.target;
     const formData = new window.FormData(form);
-    const { data, toggleShowState } = this.props;
-    const { save } = this.context;
+    const { toggleShowState } = this.props;
+    const { save, data } = this.context;
     const copy = clone(data);
 
     copy.declaration = formData.get("declaration");

--- a/designer/client/outputs/outputs-edit.tsx
+++ b/designer/client/outputs/outputs-edit.tsx
@@ -3,9 +3,7 @@ import randomId from "../randomId";
 import OutputEdit from "./output-edit";
 import { Output } from "./types";
 
-type Props = {
-  
-};
+type Props = {};
 
 type State = {
   showAddOutput: boolean;
@@ -44,7 +42,7 @@ class OutputsEdit extends React.Component<Props, State> {
   render() {
     const data = this.context;
     const { outputs } = data;
-    const { output, id, showAddOutput } = this.state; 
+    const { output, id, showAddOutput } = this.state;
 
     return (
       <div className="govuk-body">

--- a/designer/client/outputs/outputs-edit.tsx
+++ b/designer/client/outputs/outputs-edit.tsx
@@ -4,7 +4,6 @@ import OutputEdit from "./output-edit";
 import { Output } from "./types";
 
 type Props = {
-  data: any; // TODO: type
 };
 
 type State = {
@@ -42,9 +41,9 @@ class OutputsEdit extends React.Component<Props, State> {
   };
 
   render() {
-    const { data } = this.props;
+    const data = this.context;
     const { outputs } = data;
-    const { output, id, showAddOutput } = this.state;
+    const { output, id, showAddOutput } = this.state; 
 
     return (
       <div className="govuk-body">

--- a/designer/client/outputs/outputs-edit.tsx
+++ b/designer/client/outputs/outputs-edit.tsx
@@ -4,6 +4,7 @@ import OutputEdit from "./output-edit";
 import { Output } from "./types";
 
 type Props = {
+  
 };
 
 type State = {

--- a/designer/client/page-create.js
+++ b/designer/client/page-create.js
@@ -73,7 +73,7 @@ class PageCreate extends React.Component {
   };
 
   validate = (title, path) => {
-    const { data, i18n } = this.props;
+    const { data } = this.context;
     const titleErrors = validateTitle("page-title", title, i18n);
     const errors = { ...titleErrors };
     const alreadyExists = data.pages.find((page) => page.path === path);
@@ -102,7 +102,7 @@ class PageCreate extends React.Component {
   }
 
   findSectionWithName(name) {
-    const { data } = this.props;
+    const { data } = this.context;
     const { sections } = data;
     return sections.find((section) => section.name === name);
   }
@@ -171,7 +171,7 @@ class PageCreate extends React.Component {
   };
 
   render() {
-    const { data, i18n } = this.props;
+    const { data } = this.context;
     const { sections, pages } = data;
     const {
       pageType,
@@ -224,7 +224,7 @@ class PageCreate extends React.Component {
               onChange={this.onChangeLinkFrom}
             >
               <option />
-              {pages.map((page) => (
+              {pages?.map((page) => (
                 <option key={page.path} value={page.path}>
                   {page.path}
                 </option>
@@ -282,7 +282,7 @@ class PageCreate extends React.Component {
             <span className="govuk-hint">
               {i18n("addPage.sectionOption.helpText")}
             </span>
-            {sections.length > 0 && (
+            {sections?.length > 0 && (
               <select
                 className="govuk-select"
                 id="page-section"

--- a/designer/client/page-create.js
+++ b/designer/client/page-create.js
@@ -171,8 +171,7 @@ class PageCreate extends React.Component {
   };
 
   render() {
-    const { i18n } = this.props;
-    const { data } = this.context;
+    const { data, i18n } = this.props;
     const { sections, pages } = data;
     const {
       pageType,

--- a/designer/client/page-create.js
+++ b/designer/client/page-create.js
@@ -20,12 +20,14 @@ class PageCreate extends React.Component {
 
   constructor(props, context) {
     super(props, context);
-    const { page } = this.props;
+    const { data } = this.context;
+    const { pages } = data;
     this.state = {
+      pages: pages,
       path: "/",
-      controller: page?.controller ?? "",
-      title: page?.title,
-      section: page?.section ?? {},
+      controller: pages?.controller ?? "",
+      title: pages?.title,
+      section: pages?.section ?? {},
       isEditingSection: false,
       errors: {},
     };
@@ -73,10 +75,10 @@ class PageCreate extends React.Component {
   };
 
   validate = (title, path) => {
-    const { data, i18n } = this.props;
+    const { data, i18n } = this.context;
     const titleErrors = validateTitle("page-title", title, i18n);
     const errors = { ...titleErrors };
-    const alreadyExists = data.pages.find((page) => page.path === path);
+    const alreadyExists = this.state.pages.find((page) => page.path === path);
     if (alreadyExists) {
       errors.path = {
         href: "#page-path",
@@ -102,7 +104,7 @@ class PageCreate extends React.Component {
   }
 
   findSectionWithName(name) {
-    const { data } = this.props;
+    const { data } = this.context;
     const { sections } = data;
     return sections.find((section) => section.name === name);
   }
@@ -171,7 +173,7 @@ class PageCreate extends React.Component {
   };
 
   render() {
-    const { data, i18n } = this.props;
+    const { data } = this.context;
     const { sections, pages } = data;
     const {
       pageType,

--- a/designer/client/page-create.js
+++ b/designer/client/page-create.js
@@ -171,7 +171,8 @@ class PageCreate extends React.Component {
   };
 
   render() {
-    const { data, i18n } = this.props;
+    const { i18n } = this.props;
+    const { data } = this.context;
     const { sections, pages } = data;
     const {
       pageType,

--- a/designer/client/page-create.js
+++ b/designer/client/page-create.js
@@ -20,14 +20,12 @@ class PageCreate extends React.Component {
 
   constructor(props, context) {
     super(props, context);
-    const { data } = this.context;
-    const { pages } = data;
+    const { page } = this.props;
     this.state = {
-      pages: pages,
       path: "/",
-      controller: pages?.controller ?? "",
-      title: pages?.title,
-      section: pages?.section ?? {},
+      controller: page?.controller ?? "",
+      title: page?.title,
+      section: page?.section ?? {},
       isEditingSection: false,
       errors: {},
     };
@@ -75,10 +73,10 @@ class PageCreate extends React.Component {
   };
 
   validate = (title, path) => {
-    const { data, i18n } = this.context;
+    const { data, i18n } = this.props;
     const titleErrors = validateTitle("page-title", title, i18n);
     const errors = { ...titleErrors };
-    const alreadyExists = this.state.pages.find((page) => page.path === path);
+    const alreadyExists = data.pages.find((page) => page.path === path);
     if (alreadyExists) {
       errors.path = {
         href: "#page-path",
@@ -104,7 +102,7 @@ class PageCreate extends React.Component {
   }
 
   findSectionWithName(name) {
-    const { data } = this.context;
+    const { data } = this.props;
     const { sections } = data;
     return sections.find((section) => section.name === name);
   }
@@ -173,7 +171,7 @@ class PageCreate extends React.Component {
   };
 
   render() {
-    const { data } = this.context;
+    const { data, i18n } = this.props;
     const { sections, pages } = data;
     const {
       pageType,

--- a/designer/client/page-edit.js
+++ b/designer/client/page-edit.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Input } from "@govuk-jsx/input";
+import Editor from "./editor";
 import { clone } from "@xgovformbuilder/model";
 import randomId from "./randomId";
 
@@ -36,6 +37,8 @@ export class PageEdit extends React.Component {
 
   onSubmit = async (e) => {
     e.preventDefault();
+    const form = e.target;
+    const formData = new window.FormData(form);
     const { save, data } = this.context;
     const { title, path, section, controller } = this.state;
     const { page } = this.props;
@@ -56,6 +59,7 @@ export class PageEdit extends React.Component {
     }
 
     copyPage.title = title;
+    copy.declaration = formData.get("declaration");
     section ? (copyPage.section = section) : delete copyPage.section;
     controller
       ? (copyPage.controller = controller)
@@ -197,8 +201,8 @@ export class PageEdit extends React.Component {
   }
 
   render() {
-    const { i18n } = this.props;
-    const { data } = this.context;
+    const { isEditingDeclaration, i18n } = this.props;
+    const { declaration, data } = this.context;
     const { sections } = data;
     const {
       title,
@@ -308,6 +312,19 @@ export class PageEdit extends React.Component {
               </a>
             )}
           </div>
+          {isEditingDeclaration && (
+            <div className="govuk-form-group">
+              <label className="govuk-label" htmlFor="declaration">
+                Declaration
+              </label>
+              <span className="govuk-hint">
+                The declaration can include HTML and the `govuk-prose-scope` css
+                class is available. Use this on a wrapping element to apply
+                default govuk styles.
+              </span>
+              <Editor name="declaration" value={declaration} />
+            </div>
+          )}
           <button className="govuk-button" type="submit">
             {i18n("save")}
           </button>{" "}

--- a/designer/client/section/sections-edit.js
+++ b/designer/client/section/sections-edit.js
@@ -2,8 +2,10 @@ import React from "react";
 import SectionEdit from "./section-edit";
 import { RenderInPortal } from "../components/RenderInPortal";
 import { Flyout } from "../components/Flyout";
+import { DataContext } from "../context";
 
 class SectionsEdit extends React.Component {
+  static contextType = DataContext;
   state = {};
 
   onClickSection = (e, section) => {
@@ -17,6 +19,7 @@ class SectionsEdit extends React.Component {
   // TODO:- This is borrowed from page-edit.js. Needs refactor. (hooks hooks hooks)
   closeFlyout = (sectionName) => {
     const propSection = this.state.section ?? this.props.page?.section ?? {};
+
     this.setState({
       isEditingSection: false,
       section: sectionName
@@ -26,13 +29,13 @@ class SectionsEdit extends React.Component {
   };
 
   findSectionWithName(name) {
-    const { data } = this.props;
+    const { data } = this.context;
     const { sections } = data;
     return sections.find((section) => section.name === name);
   }
 
   render() {
-    const { data } = this.props;
+    const { data } = this.context;
     const { sections } = data;
     const { section, isEditingSection } = this.state;
 

--- a/designer/client/section/sections-edit.js
+++ b/designer/client/section/sections-edit.js
@@ -1,10 +1,12 @@
 import React from "react";
 import SectionEdit from "./section-edit";
 import { RenderInPortal } from "../components/RenderInPortal";
+import { DataContext } from "../context";
 import { Flyout } from "../components/Flyout";
 
 class SectionsEdit extends React.Component {
   state = {};
+  static contextType = DataContext;
 
   onClickSection = (e, section) => {
     e.preventDefault();
@@ -26,13 +28,14 @@ class SectionsEdit extends React.Component {
   };
 
   findSectionWithName(name) {
-    const { data } = this.props;
+    const data = this.context;
     const { sections } = data;
+
     return sections.find((section) => section.name === name);
   }
 
   render() {
-    const { data } = this.props;
+    const data = this.context;
     const { sections } = data;
     const { section, isEditingSection } = this.state;
 

--- a/designer/client/section/sections-edit.js
+++ b/designer/client/section/sections-edit.js
@@ -7,6 +7,7 @@ import { Flyout } from "../components/Flyout";
 class SectionsEdit extends React.Component {
   state = {};
   static contextType = DataContext;
+  
 
   onClickSection = (e, section) => {
     e.preventDefault();
@@ -35,7 +36,7 @@ class SectionsEdit extends React.Component {
   }
 
   render() {
-    const data = this.context;
+    const { data } = this.context;
     const { sections } = data;
     const { section, isEditingSection } = this.state;
 

--- a/designer/client/section/sections-edit.js
+++ b/designer/client/section/sections-edit.js
@@ -7,7 +7,6 @@ import { Flyout } from "../components/Flyout";
 class SectionsEdit extends React.Component {
   state = {};
   static contextType = DataContext;
-  
 
   onClickSection = (e, section) => {
     e.preventDefault();

--- a/designer/client/section/sections-edit.js
+++ b/designer/client/section/sections-edit.js
@@ -1,12 +1,10 @@
 import React from "react";
 import SectionEdit from "./section-edit";
 import { RenderInPortal } from "../components/RenderInPortal";
-import { DataContext } from "../context";
 import { Flyout } from "../components/Flyout";
 
 class SectionsEdit extends React.Component {
   state = {};
-  static contextType = DataContext;
 
   onClickSection = (e, section) => {
     e.preventDefault();
@@ -28,14 +26,13 @@ class SectionsEdit extends React.Component {
   };
 
   findSectionWithName(name) {
-    const data = this.context;
+    const { data } = this.props;
     const { sections } = data;
-
     return sections.find((section) => section.name === name);
   }
 
   render() {
-    const { data } = this.context;
+    const { data } = this.props;
     const { sections } = data;
     const { section, isEditingSection } = this.state;
 

--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -126,7 +126,7 @@ export type FormDefinition = {
   pages: Page[];
   conditions: ConditionRawData[];
   lists: List[];
-  sections: Section[];
+  sections?: Section[];
   startPage?: Page["path"] | undefined;
   name?: string | undefined;
   feedback?: Feedback;

--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -126,7 +126,7 @@ export type FormDefinition = {
   pages: Page[];
   conditions: ConditionRawData[];
   lists: List[];
-  sections?: Section[];
+  sections: Section[];
   startPage?: Page["path"] | undefined;
   name?: string | undefined;
   feedback?: Feedback;


### PR DESCRIPTION
# Description

Summary page behaviour previously was selected from the menu for skip summary and editing the declaration. Now skip summary has been deprecated and declaration can be edited from specifically clicking the summary page.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Some unit tests need to be changed first since they use the summary page menu item

# Checklist:

- [ ] My changes do not introduce any new linting errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and versioning
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md
