### PR TITLE
minor: Enable health-check to pass on PaaS platform (cloud foundry)

### DIFF
--- a/designer/server/createServer.ts
+++ b/designer/server/createServer.ts
@@ -14,6 +14,9 @@ import { configureYarPlugin } from "./plugins/session";
 const serverOptions = () => {
   return {
     port: process.env.PORT || 3000,
+    router: {
+      stripTrailingSlash: true,
+    },
     routes: {
       validate: {
         options: {

--- a/runner/src/server/index.ts
+++ b/runner/src/server/index.ts
@@ -42,6 +42,9 @@ const serverOptions = (): ServerOptions => {
   const serverOptions: ServerOptions = {
     debug: { request: [`${config.isDev}`] },
     port: config.port,
+    router: {
+      stripTrailingSlash: true,
+    },
     routes: {
       validate: {
         options: {


### PR DESCRIPTION
Update: server options to handle trailing slash

Update: runner to use port from environment if provided

# Description
It simply enabled route option to strip trailing slash and, adds OR condition in  reading PORT number in runner, which is already set exactly the same way in designer

Prior to these changes, health-check of docker container deployed in cloud foundry were  failing to start only because of health-check failure 


## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
We have build and deployed docker container with this code on PaaS platform, and it is no more crashing because of health-check failure

# Checklist:

- [ x] My changes do not introduce any new linting errors
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation and versioning
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] I have rebased onto main and there are no code conflicts
- [ x] I have checked deployments are working in all environments
- [ x] I have updated the architecture diagrams as per Contribute.md
