### PR TITLE
Enforce CSRF if production

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 ## contributions
 
-Issues and pull requests are welcome. Please check [CONTRIBUTING.md](./CONTRIBUTING.md) first! 
-
+Issues and pull requests are welcome. Please check [CONTRIBUTING.md](./CONTRIBUTING.md) first!
 
 This repository is a mono repo for
 
@@ -20,14 +19,22 @@ This is a (getting close to) zero-install yarn 2 workspaces repository. .yarnrc.
 Workspaces will deal with sym-linking the packages, so we do not have to manually run `yarn link`.
 It will also deal with hoisting the node_modules for any packages that are shared between the repos, thus decreasing any install times. Hopefully it all just works™️.
 
+Also see the individual repo README files for additional info:
+
+- [runner README](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/runner/README.md)
+- [designer README](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/designer/README.md)
+- [model README](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/model/README.md)
+
 ## Setup
 
 **Always run scripts from the root directory.**
 
 1. Make sure you are using node >=12. upto 14. `node --version`.
 2. Make sure you have yarn 1.22+ installed. You do not need to install yarn 2.4+, yarn will detect the yarn 2 binary within [.yarn](./.yarn) and that will be used.
-3. Run `$ yarn` command to install all dependencies in all workspaces.
-4. Run `$ yarn build` to build all workspaces (this is needed because dependencies can depend on each other).
+3. If using the designer:
+   - Note that the designer requires the runner to be running with the default `NODE_ENV=development` settings (see [runner/config/development.json](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/runner/config/development.json)) to enable posting and previewing of forms during design.
+4. Run `$ yarn` command to install all dependencies in all workspaces.
+5. Run `$ yarn build` to build all workspaces (this is needed because dependencies can depend on each other).
 
 As already mentioned, **always run scripts from the root directory.** because workspaces don't have scripts or packages you need to run from inside their folders and by running in the root directory yarn 2 can resolve the scripts/packages properly.
 
@@ -84,6 +91,7 @@ We're using GitHub actions to run our CI process. View [a visualisation of the w
 #### Versioning
 
 Version numbers will automatically increment based on commit messages and SemVer (Major.Minor.Patch). When merging, prepend your merge commit with the following:
+
 - `major:` or `breaking:` - for example, `breaking: removing feature X`. This will increment the MAJOR version - for example: 1.1.0 to 2.0.0
 - `minor:` or `feature:` - for example, `feature: new component`. This will increment the MINOR version - for example: 1.1.0 to 1.2.0
 - `patch:` or `fix:` - for example, `fix: url bug` - this will increment the PATCH version - for example: 1.0.0 to 1.0.1 (this will also happen by default)
@@ -111,6 +119,7 @@ To run the smoke tests locally, you start the containers up using the command
 ```
 docker-compose up --build
 ```
+
 Then smoke test can be executed using command
 
 ```
@@ -118,10 +127,11 @@ yarn smoke-tests/designer smoke-test-headless
 ```
 
 Pre-requite for running smoke test are:
- 1. Yarn 
- 2. JVM 
- 2. a browser like chrome
- 3. Node version 12+ upto 14
- 4. yarn install
- 
- More details are on [Smoke Tests](./smoke-tests/README.md)
+
+1.  Yarn
+2.  JVM
+3.  a browser like chrome
+4.  Node version 12+ upto 14
+5.  yarn install
+
+More details are on [Smoke Tests](./smoke-tests/README.md)

--- a/designer/client/pages/LandingPage/NewConfig.tsx
+++ b/designer/client/pages/LandingPage/NewConfig.tsx
@@ -92,18 +92,18 @@ export class NewConfig extends Component<Props, State> {
     });
   };
 
-  handleResponse = (response) => {
-    response.text().then((text) => {
-      if (!response.ok) {
+  handleResponse = async (res) => {
+    if (!res.ok) {
+      await res.text().then((text) => {
         return this.handleErrors({
           name: {
             href: "#formName",
             children: i18n(text),
           },
         });
-      }
-    });
-    return response.json();
+      });
+    }
+    return res.json();
   };
 
   onSubmit = async (event: MouseEvent<HTMLButtonElement>) => {
@@ -131,9 +131,7 @@ export class NewConfig extends Component<Props, State> {
           "Content-Type": "application/json",
         },
       })
-      .then((response) => {
-        return this.handleResponse(response);
-      });
+      .then((res) => this.handleResponse(res));
     this.props.history.push(`designer/${newResponse.id}`);
   };
 

--- a/designer/client/pages/LandingPage/NewConfig.tsx
+++ b/designer/client/pages/LandingPage/NewConfig.tsx
@@ -86,6 +86,26 @@ export class NewConfig extends Component<Props, State> {
     return { errors, hasErrors };
   };
 
+  handleErrors = (errors) => {
+    return this.setState({
+      errors,
+    });
+  };
+
+  handleResponse = (response) => {
+    response.text().then((text) => {
+      if (!response.ok) {
+        return this.handleErrors({
+          name: {
+            href: "#formName",
+            children: i18n(text),
+          },
+        });
+      }
+    });
+    return response.json();
+  };
+
   onSubmit = async (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
 
@@ -94,13 +114,9 @@ export class NewConfig extends Component<Props, State> {
     const { errors, hasErrors } = this.validate();
 
     if (hasErrors) {
-      return this.setState({
-        errors,
-      });
+      return this.handleErrors(errors);
     } else {
-      this.setState({
-        errors,
-      });
+      this.handleErrors(errors);
     }
 
     const newResponse = await window
@@ -115,7 +131,9 @@ export class NewConfig extends Component<Props, State> {
           "Content-Type": "application/json",
         },
       })
-      .then((res) => res.json());
+      .then((response) => {
+        return this.handleResponse(response);
+      });
     this.props.history.push(`designer/${newResponse.id}`);
   };
 

--- a/designer/server/lib/persistence/previewPersistenceService.ts
+++ b/designer/server/lib/persistence/previewPersistenceService.ts
@@ -23,8 +23,27 @@ export class PreviewPersistenceService implements PersistenceService {
   }
 
   async listAllConfigurations() {
-    const { payload } = await Wreck.get(`${config.publishUrl}/published`);
-    return JSON.parse(payload.toString());
+    try {
+      const { payload } = await Wreck.get(`${config.publishUrl}/published`);
+      return JSON.parse(payload.toString());
+    } catch (e) {
+      console.log(
+        "\x1b[36m%s\x1b[0m",
+        "\n**********" +
+          "\nERROR: Publishing and previewing forms is not possible currently, either because the runner is" +
+          "\nnot available at " +
+          config.publishUrl.toString() +
+          " or if it is running, previewMode may be set to false on it." +
+          "\n\nTo enable publishing and previewing of forms, ensure the runner is running in development mode " +
+          "\nby setting NODE_ENV=development in your environment and then re-starting the runner with: " +
+          "\n$>yarn runner start" +
+          "\n\nYou can alternatively create a custom environment by placing a custom myenvironment.json file" +
+          "\nin the runner/config folder. Note: enforceCsrf must be set to false " +
+          "\nand previewMode must be set to true on the runner for the designer to work" +
+          "\nSee runner/config/development.json for example dev defaults." +
+          "\n**********\n"
+      );
+    }
   }
 
   async getConfiguration(id: string) {

--- a/designer/server/plugins/routes/newConfig.ts
+++ b/designer/server/plugins/routes/newConfig.ts
@@ -56,7 +56,7 @@ export const registerNewFormWithRunner: ServerRoute = {
             "\nSee runner/config/development.json for example dev defaults." +
             "\n**********\n"
         );
-        // request.logger.error(e);
+        request.logger.error(e);
         return h
           .response(
             "Designer could not connect to runner instance. " +

--- a/designer/server/plugins/routes/newConfig.ts
+++ b/designer/server/plugins/routes/newConfig.ts
@@ -40,7 +40,31 @@ export const registerNewFormWithRunner: ServerRoute = {
           await publish(newName, copied);
         }
       } catch (e) {
-        request.logger.error(e);
+        console.log(
+          "\x1b[36m%s\x1b[0m",
+          "\n**********" +
+            "\nERROR: Publishing and previewing forms is not possible currently, either because the runner is" +
+            "\nnot available at " +
+            config.publishUrl.toString() +
+            " or if it is running, previewMode may be set to false on it." +
+            "\n\nTo enable publishing and previewing of forms, ensure the runner is running in development mode " +
+            "\nby setting NODE_ENV=development in your environment and then re-starting the runner with: " +
+            "\n$>yarn runner start" +
+            "\n\nYou can alternatively create a custom environment by placing a custom myenvironment.json file" +
+            "\nin the runner/config folder. Note: enforceCsrf must be set to false " +
+            "\nand previewMode must be set to true on the runner for the designer to work" +
+            "\nSee runner/config/development.json for example dev defaults." +
+            "\n**********\n"
+        );
+        // request.logger.error(e);
+        return h
+          .response(
+            "Designer could not connect to runner instance. " +
+              "Please confirm it is up and running, " +
+              "and in development mode. See docs for more details."
+          )
+          .type("application/json")
+          .code(400);
       }
 
       const response = {

--- a/runner/config/custom-environment-variables.json
+++ b/runner/config/custom-environment-variables.json
@@ -36,5 +36,7 @@
   "authClientSecret": "AUTH_CLIENT_SECRET",
   "authClientAuthUrl": "AUTH_CLIENT_AUTH_URL",
   "authClientTokenUrl": "AUTH_CLIENT_TOKEN_URL",
-  "authClientProfileUrl": "AUTH_CLIENT_PROFILE_URL"
+  "authClientProfileUrl": "AUTH_CLIENT_PROFILE_URL",
+  "previewMode": "PREVIEW_MODE",
+  "enforceCsrf": "ENFORCE_CSRF"
 }

--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -4,7 +4,6 @@ const { deferConfig } = require("config/defer");
 const dotEnv = require("dotenv");
 if (process.env.NODE_ENV !== "test") {
   dotEnv.config({ path: ".env" });
-  console.log(process.env);
 }
 
 module.exports = {

--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -4,6 +4,7 @@ const { deferConfig } = require("config/defer");
 const dotEnv = require("dotenv");
 if (process.env.NODE_ENV !== "test") {
   dotEnv.config({ path: ".env" });
+  console.log(process.env);
 }
 
 module.exports = {
@@ -20,7 +21,8 @@ module.exports = {
    */
   port: 3009,
   env: "development",
-  previewMode: true,
+  previewMode: false,
+  enforceCsrf: true,
   sandbox: true,
 
   /**

--- a/runner/config/development.json
+++ b/runner/config/development.json
@@ -1,0 +1,6 @@
+{
+  "isTest": true,
+  "previewMode": true,
+  "enforceCsrf": false,
+  "env": "development"
+}

--- a/runner/config/test.json
+++ b/runner/config/test.json
@@ -1,6 +1,8 @@
 {
   "safelist": ["webho.ok"],
   "isTest": true,
+  "previewMode": true,
+  "enforceCsrf": false,
   "initialisedSessionKey": "predictable-key",
   "env": "test"
 }

--- a/runner/package.json
+++ b/runner/package.json
@@ -7,7 +7,7 @@
     "check-forms": "yarn node bin/run/check",
     "watch": "babel --watch --extensions '.ts' src -d dist --copy-files -s inline",
     "start": "node dist/index.js",
-    "start:local": "NODE_ENV=development PREVIEW_MODE=true nodemon dist/index.js",
+    "start:local": "NODE_ENV=development nodemon dist/index.js",
     "dev": "concurrently 'yarn watch' 'yarn start:local'",
     "build": "yarn build:css && yarn babel-build && yarn run check-forms",
     "build:css": "yarn sass src/client/sass:public/build/stylesheets -s compressed -I . --no-source-map",

--- a/runner/src/server/index.ts
+++ b/runner/src/server/index.ts
@@ -156,7 +156,44 @@ async function createServer(routeConfig: RouteConfig) {
   await server.register(pluginErrorPages);
 
   if (!config.isTest) {
+    console.log(
+      "\x1b[36m%s\x1b[0m",
+      "**********" +
+        "\n**********" +
+        "\nServer is running in production mode." +
+        "\n-- env=" +
+        config.env.toString() +
+        "\n-- enforceCSRF=" +
+        config.enforceCsrf.toString() +
+        "\n-- previewMode=" +
+        config.previewMode.toString() +
+        "\n**********" +
+        "\n**********\n"
+    );
     await server.register(blipp);
+  } else {
+    console.log(
+      "\x1b[36m%s\x1b[0m",
+      "**********" +
+        "\n**********" +
+        "\nWARNING: Server is running in insecure development/test mode." +
+        "\n-- env=" +
+        config.env.toString() +
+        "\n-- enforceCSRF=" +
+        config.enforceCsrf.toString() +
+        "\n-- previewMode=" +
+        config.previewMode.toString() +
+        "\n\npreviewMode=true and enforceCsrf=false are both currently required" +
+        "\nto allow the runner to accept posts from the designer for the building" +
+        "\nand publishing of forms." +
+        "\n\nIn production deployments, please ensure that the NODE_ENV=production" +
+        "\nenvironment variable is set." +
+        "\n\nYou can also create custom environment configurations by placing" +
+        "\na myenvironment.json file in runner/config/ with your bespoke config vars" +
+        "\nor by setting individual vars in a .env file at runner/.env ." +
+        "\n**********" +
+        "\n**********\n"
+    );
   }
 
   server.state("cookies_policy", {

--- a/runner/src/server/index.ts
+++ b/runner/src/server/index.ts
@@ -163,7 +163,7 @@ async function createServer(routeConfig: RouteConfig) {
         "\nServer is running in production mode." +
         "\n-- env=" +
         config.env.toString() +
-        "\n-- enforceCSRF=" +
+        "\n-- enforceCsrf=" +
         config.enforceCsrf.toString() +
         "\n-- previewMode=" +
         config.previewMode.toString() +
@@ -179,7 +179,7 @@ async function createServer(routeConfig: RouteConfig) {
         "\nWARNING: Server is running in insecure development/test mode." +
         "\n-- env=" +
         config.env.toString() +
-        "\n-- enforceCSRF=" +
+        "\n-- enforceCsrf=" +
         config.enforceCsrf.toString() +
         "\n-- previewMode=" +
         config.previewMode.toString() +

--- a/runner/src/server/plugins/crumb.ts
+++ b/runner/src/server/plugins/crumb.ts
@@ -4,8 +4,8 @@ import { ServerRegisterPluginObject } from "@hapi/hapi";
 import { RouteConfig } from "../types";
 
 type Config = {
-  isDev: string | undefined;
-  previewMode: boolean;
+  isDev: boolean;
+  enforceCsrf: boolean;
 };
 
 export const configureCrumbPlugin = (
@@ -16,12 +16,10 @@ export const configureCrumbPlugin = (
     plugin: crumb,
     options: {
       logUnauthorized: true,
-      enforce: routeConfig
-        ? routeConfig.enforceCsrf || false
-        : !config.previewMode,
+      enforce: routeConfig?.enforceCsrf ?? config?.enforceCsrf,
       cookieOptions: {
         path: "/",
-        isSecure: !!config.isDev,
+        isSecure: !config.isDev,
         isHttpOnly: true,
         isSameSite: "Strict",
       },

--- a/runner/src/server/plugins/engine/plugin.ts
+++ b/runner/src/server/plugins/engine/plugin.ts
@@ -64,18 +64,19 @@ export const plugin = {
       });
     });
 
-    if (previewMode) {
-      /**
-       * The following endpoints are used from the designer for operating in 'preview' mode.
-       * I.E. Designs saved in the designer can be accessed in the runner for viewing.
-       * The designer also uses these endpoints as a persistence mechanism for storing and retrieving data
-       * for it's own purposes so if you're changing these endpoints you likely need to go and amend
-       * the designer too!
-       */
-      server.route({
-        method: "post",
-        path: "/publish",
-        handler: (request: HapiRequest, h: HapiResponseToolkit) => {
+    /**
+     * The following publish endpoints (/publish, /published/{id}, /published)
+     * are used from the designer for operating in 'preview' mode.
+     * I.E. Designs saved in the designer can be accessed in the runner for viewing.
+     * The designer also uses these endpoints as a persistence mechanism for storing and retrieving data
+     * for its own purposes so if you're changing these endpoints you likely need to go and amend
+     * the designer too!
+     */
+    server.route({
+      method: "post",
+      path: "/publish",
+      handler: (request: HapiRequest, h: HapiResponseToolkit) => {
+        if (previewMode) {
           const payload = request.payload as FormPayload;
           const { id, configuration } = payload;
 
@@ -88,13 +89,23 @@ export const plugin = {
             basePath: id,
           });
           return h.response({}).code(204);
-        },
-      });
+        } else {
+          console.log(
+            "This route is not accessible as config.previewMode is disabled. " +
+              "Please enable it in your environment config. See runner/config/default.js"
+          );
+          throw Boom.notFound(
+            "previewMode is disabled. Please enable it in your environment config."
+          );
+        }
+      },
+    });
 
-      server.route({
-        method: "get",
-        path: "/published/{id}",
-        handler: (request: HapiRequest, h: HapiResponseToolkit) => {
+    server.route({
+      method: "get",
+      path: "/published/{id}",
+      handler: (request: HapiRequest, h: HapiResponseToolkit) => {
+        if (previewMode) {
           const { id } = request.params;
           if (forms[id]) {
             const { values } = forms[id];
@@ -102,13 +113,23 @@ export const plugin = {
           } else {
             return h.response({}).code(204);
           }
-        },
-      });
+        } else {
+          console.log(
+            "This route is not accessible as config.previewMode is disabled. " +
+              "Please enable it in your environment config. See runner/config/default.js"
+          );
+          throw Boom.notFound(
+            "previewMode is disabled. Please enable it in your environment config."
+          );
+        }
+      },
+    });
 
-      server.route({
-        method: "get",
-        path: "/published",
-        handler: (_request: HapiRequest, h: HapiResponseToolkit) => {
+    server.route({
+      method: "get",
+      path: "/published",
+      handler: (_request: HapiRequest, h: HapiResponseToolkit) => {
+        if (previewMode) {
           return h
             .response(
               JSON.stringify(
@@ -124,9 +145,17 @@ export const plugin = {
               )
             )
             .code(200);
-        },
-      });
-    }
+        } else {
+          console.log(
+            "This route is not accessible as config.previewMode is disabled. " +
+              "Please enable it in your environment config. See runner/config/default.js"
+          );
+          throw Boom.notFound(
+            "previewMode is disabled. Please enable it in your environment config."
+          );
+        }
+      },
+    });
 
     server.route({
       method: "get",

--- a/runner/src/server/plugins/engine/plugin.ts
+++ b/runner/src/server/plugins/engine/plugin.ts
@@ -91,11 +91,17 @@ export const plugin = {
           return h.response({}).code(204);
         } else {
           console.log(
-            "This route is not accessible as config.previewMode is disabled. " +
-              "Please enable it in your environment config. See runner/config/default.js"
+            "\x1b[36m%s\x1b[0m",
+            "\n**********" +
+              "\nNOT FOUND: The /publish route is not accessible as config.previewMode is disabled. " +
+              "\nTo enable it, please switch to development mode by setting NODE_ENV=development" +
+              "\nin your environment, or create a custom environment config with PREVIEW_MODE=true" +
+              "\nand ENFORCE_CSRF=false. See runner/config/development.json for env defaults" +
+              "\n**********\n"
           );
           throw Boom.notFound(
-            "previewMode is disabled. Please enable it in your environment config."
+            "previewMode is disabled. To enable it, please switch to development mode" +
+              " by setting NODE_ENV=development in your environment"
           );
         }
       },
@@ -115,11 +121,17 @@ export const plugin = {
           }
         } else {
           console.log(
-            "This route is not accessible as config.previewMode is disabled. " +
-              "Please enable it in your environment config. See runner/config/default.js"
+            "\x1b[36m%s\x1b[0m",
+            "\n**********" +
+              "\nNOT FOUND: The /published/{id} route is not accessible as config.previewMode is disabled. " +
+              "\nTo enable it, please switch to development mode by setting NODE_ENV=development" +
+              "\nin your environment, or create a custom environment config with PREVIEW_MODE=true" +
+              "\nand ENFORCE_CSRF=false. See runner/config/development.json for env defaults" +
+              "\n**********\n"
           );
           throw Boom.notFound(
-            "previewMode is disabled. Please enable it in your environment config."
+            "previewMode is disabled. To enable it, please switch to development mode" +
+              " by setting NODE_ENV=development in your environment"
           );
         }
       },
@@ -147,11 +159,17 @@ export const plugin = {
             .code(200);
         } else {
           console.log(
-            "This route is not accessible as config.previewMode is disabled. " +
-              "Please enable it in your environment config. See runner/config/default.js"
+            "\x1b[36m%s\x1b[0m",
+            "\n**********" +
+              "\nNOT FOUND: The /published route is not accessible as config.previewMode is disabled. " +
+              "\nTo enable it, please switch to development mode by setting NODE_ENV=development" +
+              "\nin your environment, or create a custom environment config with PREVIEW_MODE=true" +
+              "\nand ENFORCE_CSRF=false. See runner/config/development.json for env defaults" +
+              "\n**********\n"
           );
           throw Boom.notFound(
-            "previewMode is disabled. Please enable it in your environment config."
+            "previewMode is disabled. To enable it, please switch to development mode" +
+              " by setting NODE_ENV=development in your environment"
           );
         }
       },

--- a/runner/src/server/utils/configSchema.ts
+++ b/runner/src/server/utils/configSchema.ts
@@ -40,6 +40,7 @@ export const configSchema = Joi.object({
   serviceName: Joi.string().optional(),
   documentUploadApiUrl: Joi.string(),
   previewMode: Joi.boolean().optional(),
+  enforceCsrf: Joi.boolean().optional(),
   sslKey: Joi.string().optional(),
   sslCert: Joi.string().optional(),
   sessionTimeout: Joi.number(),


### PR DESCRIPTION
# Description

- Enforce CSRF protection on runner when in production environment
- Enable toggling of CSRF protection on runner with ENFORCE_CSRF env variable
- Enable toggling of enforceCsrf and previewMode together, simply by switching NODE_ENV from production to development
- Added new console start-up messages to notify developer of runner NODE_ENV mode, and required settings.
- Added new on-page error to alert when using the designer, if the runner is unavailable or not in previewMode
- README files updated with notes on new default and environment variable settings.

This fixes an error that meant CSRF protection was not enforced on forms

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Locally with test and jest

# Checklist:

- [x] My changes do not introduce any new linting errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md
