### PR TITLE
Fix/769 link by dragging

### DIFF
--- a/designer/client/components/PageLinkage/PageLinkage.tsx
+++ b/designer/client/components/PageLinkage/PageLinkage.tsx
@@ -18,8 +18,7 @@ export function PageLinkage({ page, layout }) {
   };
 
   const handleDragStart = useCallback((event) => {
-    const { clientX: x, clientY } = event;
-    const y = clientY + window.pageYOffset;
+    const { pageX: x, pageY: y } = event;
 
     setIsDragging(true);
     setLineEnd({ x, y });
@@ -28,8 +27,7 @@ export function PageLinkage({ page, layout }) {
   }, []);
 
   const handleDrag = useCallback((event) => {
-    const { clientX: x, clientY } = event;
-    const y = clientY + window.pageYOffset;
+    const { pageX: x, pageY: y } = event;
 
     if (!x && !y) {
       // event might return 0 0 moved outside dom or drop occurs outside linkage

--- a/designer/client/components/PageLinkage/__tests__/PageLinkage.test.tsx
+++ b/designer/client/components/PageLinkage/__tests__/PageLinkage.test.tsx
@@ -143,10 +143,10 @@ suite("Page Linkage", () => {
     const line = svg.find("line").first();
 
     expect(line.props()).to.include({
-      x1: event.clientX,
-      y1: event.clientY + window.pageYOffset,
-      x2: event.clientX,
-      y2: event.clientY + window.pageYOffset,
+      x1: event.pageX,
+      y1: event.pageY,
+      x2: event.pageX,
+      y2: event.pageY,
     });
   });
 
@@ -159,21 +159,21 @@ suite("Page Linkage", () => {
     let line = svg.find("line").first();
 
     expect(line.props()).to.include({
-      x1: event.clientX,
-      y1: event.clientY + window.pageYOffset,
-      x2: event.clientX,
-      y2: event.clientY + window.pageYOffset,
+      x1: event.pageX,
+      y1: event.pageY,
+      x2: event.pageX,
+      y2: event.pageY,
     });
 
-    dragArea.prop("onDrag")({ clientX: 200, clientY: 200 });
+    dragArea.prop("onDrag")({ pageX: 200, pageY: 200 });
     svg = wrapper.find("RenderInPortal").first().children();
     line = svg.find("line").first();
 
     expect(line.props()).to.include({
-      x1: event.clientX,
-      y1: event.clientY + window.pageYOffset,
+      x1: event.pageX,
+      y1: event.pageY,
       x2: 200,
-      y2: 200 + window.pageYOffset,
+      y2: 200,
     });
   });
 


### PR DESCRIPTION
# Description
Fixes #769 
- Use pageX coordinate rather than clientX. This works because pageX is defined in relation to the page as a whole, whereas clientX is defined in relation to the browser window.
- Someone had previously fixed a similar issue in the Y axis by using `y = clientY + window.pageYOffset`. This is equivalent to using pageY, so I've replaced that too. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

Before PR's can be merged they will need to be tested by QA and approved where
applicable. To flag the change to QA assign **@XGovFormBuilder/qa** as one of the reviewers.

- [x] Manual test:
  - open a long form (e.g. Report a terrorist)
  - scroll to the right of the screen
  - drag from one page to another
  - verify that the arrow follows your mouse correctly
- [x] Updated automated tests to use the correct x and y values.

# Checklist:

- [x] My changes do not introduce any new linting errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation and versioning
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto main and there are no code conflicts
- [n/a] I have checked deployments are working in all environments
- [n/a] I have updated the architecture diagrams as per Contribute.md
