### PR TITLE
#784 Improve Component order dragging

### DIFF
--- a/designer/client/component.js
+++ b/designer/client/component.js
@@ -312,7 +312,6 @@ export function Component(props) {
   return (
     <div>
       <div className="component govuk-!-padding-2" onClick={toggleShowEditor}>
-        <DragHandle />
         <TagName />
       </div>
       {showEditor && (

--- a/designer/client/component.js
+++ b/designer/client/component.js
@@ -6,10 +6,6 @@ import ComponentEdit from "./ComponentEdit";
 import { ComponentContextProvider } from "./reducers/component/componentReducer";
 import { i18n } from "./i18n";
 
-const DragHandle = SortableHandle(() => (
-  <span className="drag-handle">&#9776;</span>
-));
-
 export const componentTypes = {
   TextField,
   TelephoneNumberField,

--- a/designer/client/components/Page/Page.tsx
+++ b/designer/client/components/Page/Page.tsx
@@ -86,7 +86,7 @@ export const Page = ({ page, previewUrl, id, layout }) => {
       <SortableList
         page={page}
         data={data}
-        pressDelay={200}
+        pressDelay={90}
         onSortEnd={onSortEnd}
         lockAxis="y"
         helperClass="dragging"

--- a/designer/client/components/Page/Page.tsx
+++ b/designer/client/components/Page/Page.tsx
@@ -91,7 +91,6 @@ export const Page = ({ page, previewUrl, id, layout }) => {
         lockAxis="y"
         helperClass="dragging"
         lockToContainerEdges
-        useDragHandle
       />
 
       <div className="page__actions">

--- a/smoke-tests/designer/wdio.conf.js
+++ b/smoke-tests/designer/wdio.conf.js
@@ -1,6 +1,6 @@
 const { hooks } = require("./support/hooks");
 const drivers = {
-  chrome: { version: "98.0.4758.102" }, // https://chromedriver.chromium.org/
+  chrome: { version: "100.0.4896.60" }, // https://chromedriver.chromium.org/
   firefox: { version: "0.29.1" }, // https://github.com/mozilla/geckodriver/releases
 };
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

- Removed the drag marker and made the whole component draggable. Decrease the press time to improve hit box click delay.
-*Issue*  Still slightly hit or miss. What i have noticed is that if your cursor is still moving, even only slightly, the drag wont register. I think this may be an issue with [react-sortable-hoc](https://github.com/clauderic/react-sortable-hoc) and not our app
[link to issue and recreation steps](https://github.com/XGovFormBuilder/digital-form-builder/issues/784)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

Before PR's can be merged they will need to be tested by QA and approved where
applicable. To flag the change to QA assign **@XGovFormBuilder/qa** as one of the reviewers.

- [ ] Create a component and changes its order position by dragging the whole component 

# Checklist:

- [x] My changes do not introduce any new linting errors
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased onto main and there are no code conflicts
- [x] I have checked deployments are working in all environments
