### PR TITLE
fix: components do not delete inorder

### DIFF
--- a/designer/client/ComponentEdit.js
+++ b/designer/client/ComponentEdit.js
@@ -76,7 +76,7 @@ export function ComponentEdit(props) {
     const copy = { ...data };
     const indexOfPage = copy.pages.findIndex((p) => p.path === page.path);
     const indexOfComponent = copy.pages[indexOfPage]?.components.findIndex(
-      (component) => component.name === selectedComponent.initialName
+      (component) => component.name === selectedComponent.name
     );
     copy.pages[indexOfPage].components.splice(indexOfComponent, 1);
     await save(copy);


### PR DESCRIPTION
# Description

Currently page components that are deleted from a page is done in post-order and not in-order. This change changes deletion to in-order [#758](https://github.com/XGovFormBuilder/digital-form-builder/issues/758)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran jest

# Checklist:

- [ ] My changes do not introduce any new linting errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and versioning
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md