### PR TITLE
feat: repeating page

### DIFF
--- a/docs/adr/0002-save-and-return.md
+++ b/docs/adr/0002-save-and-return.md
@@ -1,7 +1,7 @@
 # Save and return
 
 * Status: proposed
-* Deciders: FCDO / OS maintainers: [@jenbutongit](https://github.com/jen) [@superafroman](https://github.com/superafroman) [@alisalaman-cyb](https://github.com/alisalaman-cyb)
+* Deciders: FCDO / OS maintainers: [@jenbutongit](https://github.com/jenbutongit) [@superafroman](https://github.com/superafroman) [@alisalaman-cyb](https://github.com/alisalaman-cyb)
 * Date: 2022-02-02
 * Amended: 2022-02-21
 

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -153,6 +153,9 @@ interface DateFieldBase {
 // Text Fields
 export interface TextFieldComponent extends TextFieldBase {
   type: "TextField";
+  options: TextFieldBase["options"] & {
+    customValidationMessage?: string;
+  };
 }
 
 export interface EmailAddressFieldComponent extends TextFieldBase {

--- a/runner/config/production.json
+++ b/runner/config/production.json
@@ -1,0 +1,3 @@
+{
+  "env": "production"
+}

--- a/runner/config/production.json
+++ b/runner/config/production.json
@@ -1,3 +1,0 @@
-{
-  "env": "production"
-}

--- a/runner/src/client/sass/application.scss
+++ b/runner/src/client/sass/application.scss
@@ -61,3 +61,16 @@ $govuk-global-styles: true;
     background: transparent;
   }
 }
+
+.govuk-button {
+  &--add-another {
+    @extend .govuk-link;
+    border: none;
+    background-color: transparent;
+    display: block;
+    color: map-get($govuk-colours, "blue");
+    &:hover {
+      cursor: pointer;
+    }
+  }
+}

--- a/runner/src/server/plugins/engine/components/AutocompleteField.ts
+++ b/runner/src/server/plugins/engine/components/AutocompleteField.ts
@@ -14,7 +14,10 @@ export class AutocompleteField extends SelectField {
     const { name, items } = this;
     const value = state[name];
     if (Array.isArray(value)) {
-      return items.filter((item) => value.includes(item.value)).join(", ");
+      return items
+        .filter((item) => value.includes(item.value))
+        .map((item) => item.text)
+        .join(", ");
     }
     const item = items.find((item) => String(item.value) === String(value));
     return `${item?.text ?? ""}`;

--- a/runner/src/server/plugins/engine/components/AutocompleteField.ts
+++ b/runner/src/server/plugins/engine/components/AutocompleteField.ts
@@ -3,10 +3,20 @@ import { ListComponentsDef } from "@xgovformbuilder/model";
 import { SelectField } from "./SelectField";
 import { FormModel } from "../models";
 import { addClassOptionIfNone } from "./helpers";
+import { FormSubmissionState } from "server/plugins/engine/types";
 
 export class AutocompleteField extends SelectField {
   constructor(def: ListComponentsDef, model: FormModel) {
     super(def, model);
     addClassOptionIfNone(this.options, "govuk-input--width-20");
+  }
+  getDisplayStringFromState(state: FormSubmissionState): string {
+    const { name, items } = this;
+    const value = state[name];
+    if (Array.isArray(value)) {
+      return items.filter((item) => value.includes(item.value)).join(", ");
+    }
+    const item = items.find((item) => String(item.value) === String(value));
+    return `${item?.text ?? ""}`;
   }
 }

--- a/runner/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/runner/src/server/plugins/engine/components/ListFormComponent.ts
@@ -62,7 +62,6 @@ export class ListFormComponent extends FormComponent {
   getViewModel(formData: FormData, errors: FormSubmissionErrors) {
     const { name, items } = this;
     const viewModel = super.getViewModel(formData, errors);
-
     const viewModelItems: ListItem[] =
       items.map(({ text, value, description = "", condition }) => ({
         text: this.localisedString(text),

--- a/runner/src/server/plugins/engine/components/SelectField.ts
+++ b/runner/src/server/plugins/engine/components/SelectField.ts
@@ -15,4 +15,8 @@ export class SelectField extends ListFormComponent {
     }
     return viewModel;
   }
+
+  getDisplayStringFromState(state) {
+    return state[this.name]?.join(", ");
+  }
 }

--- a/runner/src/server/plugins/engine/components/SelectField.ts
+++ b/runner/src/server/plugins/engine/components/SelectField.ts
@@ -17,6 +17,10 @@ export class SelectField extends ListFormComponent {
   }
 
   getDisplayStringFromState(state) {
-    return state[this.name]?.join(", ");
+    const value = state[this.name];
+    if (Array.isArray(value)) {
+      return value.join(", ");
+    }
+    return value;
   }
 }

--- a/runner/src/server/plugins/engine/components/SelectField.ts
+++ b/runner/src/server/plugins/engine/components/SelectField.ts
@@ -15,12 +15,4 @@ export class SelectField extends ListFormComponent {
     }
     return viewModel;
   }
-
-  getDisplayStringFromState(state) {
-    const value = state[this.name];
-    if (Array.isArray(value)) {
-      return value.join(", ");
-    }
-    return value;
-  }
 }

--- a/runner/src/server/plugins/engine/components/TextField.ts
+++ b/runner/src/server/plugins/engine/components/TextField.ts
@@ -17,7 +17,7 @@ export class TextField extends FormComponent {
     this.options = options;
     this.schema = schema;
 
-    addClassOptionIfNone(this.options, "govuk-input--width-10");
+    addClassOptionIfNone(this.options, "govuk-input--width-20");
 
     let componentSchema = joi.string().required();
 
@@ -25,7 +25,7 @@ export class TextField extends FormComponent {
       componentSchema = componentSchema.optional().allow("").allow(null);
     }
 
-    componentSchema = componentSchema.label(def.title);
+    componentSchema = componentSchema.label(def.title ?? def.name);
 
     if (options.customValidationMessage) {
       componentSchema = componentSchema.label(options.customValidationMessage);

--- a/runner/src/server/plugins/engine/components/TextField.ts
+++ b/runner/src/server/plugins/engine/components/TextField.ts
@@ -42,9 +42,9 @@ export class TextField extends FormComponent {
     }
 
     if (options.customValidationMessage) {
-      componentSchema = componentSchema.message(
-        options.customValidationMessage
-      );
+      componentSchema = componentSchema.messages({
+        any: options.customValidationMessage,
+      });
     }
 
     this.formSchema = componentSchema;

--- a/runner/src/server/plugins/engine/components/TextField.ts
+++ b/runner/src/server/plugins/engine/components/TextField.ts
@@ -20,7 +20,6 @@ export class TextField extends FormComponent {
     addClassOptionIfNone(this.options, "govuk-input--width-20");
 
     let componentSchema = joi.string().required();
-
     if (options.required === false) {
       componentSchema = componentSchema.optional().allow("").allow(null);
     }
@@ -30,7 +29,9 @@ export class TextField extends FormComponent {
     );
 
     if (options.customValidationMessage) {
-      componentSchema = componentSchema.label(options.customValidationMessage);
+      componentSchema = componentSchema.rule({
+        message: options.customValidationMessage,
+      });
     }
 
     if (schema.max) {

--- a/runner/src/server/plugins/engine/components/TextField.ts
+++ b/runner/src/server/plugins/engine/components/TextField.ts
@@ -28,12 +28,6 @@ export class TextField extends FormComponent {
       def.title.en ?? def.title ?? def.name
     );
 
-    if (options.customValidationMessage) {
-      componentSchema = componentSchema.rule({
-        message: options.customValidationMessage,
-      });
-    }
-
     if (schema.max) {
       componentSchema = componentSchema.max(schema.max);
     }
@@ -45,6 +39,12 @@ export class TextField extends FormComponent {
     if (schema.regex) {
       const pattern = new RegExp(schema.regex);
       componentSchema.pattern(pattern);
+    }
+
+    if (options.customValidationMessage) {
+      componentSchema = componentSchema.message(
+        options.customValidationMessage
+      );
     }
 
     this.formSchema = componentSchema;

--- a/runner/src/server/plugins/engine/components/TextField.ts
+++ b/runner/src/server/plugins/engine/components/TextField.ts
@@ -25,7 +25,9 @@ export class TextField extends FormComponent {
       componentSchema = componentSchema.optional().allow("").allow(null);
     }
 
-    componentSchema = componentSchema.label(def.title ?? def.name);
+    componentSchema = componentSchema.label(
+      def.title.en ?? def.title ?? def.name
+    );
 
     if (options.customValidationMessage) {
       componentSchema = componentSchema.label(options.customValidationMessage);

--- a/runner/src/server/plugins/engine/models/FormModel.ts
+++ b/runner/src/server/plugins/engine/models/FormModel.ts
@@ -120,7 +120,7 @@ export class FormModel {
     // from the individual pages/sections
     let schema = joi.object().required();
     // @ts-ignore
-    [undefined].concat(this.sections).forEach((section) => {
+    [undefined, ...this.sections].forEach((section) => {
       const sectionPages = relevantPages.filter(
         (page) => page.section === section
       );

--- a/runner/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/runner/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -402,6 +402,7 @@ function Item(
 ) {
   const isRepeatable = !!page.repeatField;
 
+  //TODO:- deprecate in favour of section based and/or repeatingFieldPageController
   if (isRepeatable && Array.isArray(sectionState)) {
     return sectionState.map((state, i) => {
       const collated = Object.values(state).reduce(

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -1,9 +1,6 @@
 import { merge, reach } from "@hapi/hoek";
 import * as querystring from "querystring";
-import {
-  messages,
-  validationOptions,
-} from "server/plugins/engine/pageControllers/validationOptions";
+import { validationOptions } from "server/plugins/engine/pageControllers/validationOptions";
 
 import { feedbackReturnInfoKey, proceed, redirectTo } from "../helpers";
 import { ComponentCollection } from "../components/ComponentCollection";
@@ -73,9 +70,9 @@ export class PageControllerBase {
     this.repeatField = pageDef.repeatField;
 
     // Resolve section
-    this.section =
-      pageDef.section &&
-      model.sections.find((section) => section.name === pageDef.section);
+    this.section = model.sections?.find(
+      (section) => section.name === pageDef.section
+    );
 
     // Components collection
     const components = new ComponentCollection(pageDef.components, model);
@@ -486,9 +483,140 @@ export class PageControllerBase {
       }
 
       await cacheService.mergeState(request, { progress });
+
       viewModel.backLink = progress[progress.length - 2];
       return h.view(this.viewName, viewModel);
     };
+  }
+
+  /**
+   * deals with parsing errors and saving answers to state
+   */
+  async handlePostRequest(
+    request: HapiRequest,
+    h: HapiResponseToolkit,
+    mergeOptions: {
+      nullOverride?: boolean;
+      arrayMerge?: boolean;
+      /**
+       * if you wish to modify the value just before it is added to the user's session (i.e. after validation and error parsing), use the modifyUpdate method.
+       * pass in a function, that takes in the update value. Make sure that this returns the modified value.
+       */
+      modifyUpdate?: <T>(value: T) => any;
+    } = {}
+  ) {
+    const { cacheService } = request.services([]);
+    const hasFilesizeError = request.payload === null;
+    const preHandlerErrors = request.pre.errors;
+    const payload = (request.payload || {}) as FormData;
+    const formResult: any = this.validateForm(payload);
+    const state = await cacheService.getState(request);
+    const originalFilenames = (state || {}).originalFilenames || {};
+    const fileFields = this.getViewModel(formResult)
+      .components.filter((component) => component.type === "FileUploadField")
+      .map((component) => component.model);
+    const progress = state.progress || [];
+    const { num } = request.query;
+
+    // TODO:- Refactor this into a validation method
+    if (hasFilesizeError) {
+      const reformattedErrors = fileFields.map((field) => {
+        return {
+          path: field.name,
+          href: `#${field.name}`,
+          name: field.name,
+          text: "The selected file must be smaller than 5MB",
+        };
+      });
+
+      formResult.errors = Object.is(formResult.errors, null)
+        ? { titleText: "Fix the following errors" }
+        : formResult.errors;
+      formResult.errors.errorList = reformattedErrors;
+    }
+
+    /**
+     * other file related errors.. assuming file fields will be on their own page. This will replace all other errors from the page if not..
+     */
+    if (preHandlerErrors) {
+      const reformattedErrors: any[] = [];
+      preHandlerErrors.forEach((error) => {
+        const reformatted = error;
+        const fieldMeta = fileFields.find((field) => field.id === error.name);
+
+        if (typeof reformatted.text === "string") {
+          /**
+           * if it's not a string it's probably going to be a stack trace.. don't want to show that to the user. A problem for another day.
+           */
+          reformatted.text = reformatted.text.replace(
+            /%s/,
+            fieldMeta?.label?.text.trim() ?? "the file"
+          );
+          reformattedErrors.push(reformatted);
+        }
+      });
+
+      formResult.errors = Object.is(formResult.errors, null)
+        ? { titleText: "Fix the following errors" }
+        : formResult.errors;
+      formResult.errors.errorList = reformattedErrors;
+    }
+
+    Object.entries(payload).forEach(([key, value]) => {
+      if (value && value === (originalFilenames[key] || {}).location) {
+        payload[key] = originalFilenames[key].originalFilename;
+      }
+    });
+
+    /**
+     * If there are any errors, render the page with the parsed errors
+     */
+    if (formResult.errors) {
+      //TODO:- refactor to match POST REDIRECT GET pattern.
+
+      return this.renderWithErrors(
+        request,
+        h,
+        payload,
+        num,
+        progress,
+        formResult.errors
+      );
+    }
+
+    const newState = this.getStateFromValidForm(formResult.value);
+    const stateResult = this.validateState(newState);
+    if (stateResult.errors) {
+      return this.renderWithErrors(
+        request,
+        h,
+        payload,
+        num,
+        progress,
+        stateResult.errors
+      );
+    }
+
+    let update = this.getPartialMergeState(stateResult.value);
+    if (this.repeatField) {
+      const updateValue = { [this.path]: update[this.section.name] };
+      const sectionState = state[this.section.name];
+      if (!sectionState) {
+        update = { [this.section.name]: [updateValue] };
+      } else if (!sectionState[num - 1]) {
+        sectionState.push(updateValue);
+        update = { [this.section.name]: sectionState };
+      } else {
+        sectionState[num - 1] = merge(sectionState[num - 1] ?? {}, updateValue);
+        update = { [this.section.name]: sectionState };
+      }
+    }
+
+    const { nullOverride, arrayMerge, modifyUpdate } = mergeOptions;
+    if (modifyUpdate) {
+      update = modifyUpdate(update);
+    }
+    await cacheService.mergeState(request, update, nullOverride, arrayMerge);
   }
 
   /**
@@ -496,117 +624,13 @@ export class PageControllerBase {
    */
   makePostRouteHandler() {
     return async (request: HapiRequest, h: HapiResponseToolkit) => {
+      const response = await this.handlePostRequest(request, h);
+      if (response?.source?.context?.errors) {
+        return response;
+      }
       const { cacheService } = request.services([]);
-      const hasFilesizeError = request.payload === null;
-      const preHandlerErrors = request.pre.errors;
-      const payload = (request.payload || {}) as FormData;
-      const formResult: any = this.validateForm(payload);
-      const state = await cacheService.getState(request);
-      const originalFilenames = (state || {}).originalFilenames || {};
-      const fileFields = this.getViewModel(formResult)
-        .components.filter((component) => component.type === "FileUploadField")
-        .map((component) => component.model);
-      const progress = state.progress || [];
-      const { num } = request.query;
+      const savedState = cacheService.getState(request);
 
-      // TODO:- Refactor this into a validation method
-      if (hasFilesizeError) {
-        const reformattedErrors = fileFields.map((field) => {
-          return {
-            path: field.name,
-            href: `#${field.name}`,
-            name: field.name,
-            text: "The selected file must be smaller than 5MB",
-          };
-        });
-
-        formResult.errors = Object.is(formResult.errors, null)
-          ? { titleText: "Fix the following errors" }
-          : formResult.errors;
-        formResult.errors.errorList = reformattedErrors;
-      }
-
-      /**
-       * other file related errors.. assuming file fields will be on their own page. This will replace all other errors from the page if not..
-       */
-      if (preHandlerErrors) {
-        const reformattedErrors: any[] = [];
-        preHandlerErrors.forEach((error) => {
-          const reformatted = error;
-          const fieldMeta = fileFields.find((field) => field.id === error.name);
-
-          if (typeof reformatted.text === "string") {
-            /**
-             * if it's not a string it's probably going to be a stack trace.. don't want to show that to the user. A problem for another day.
-             */
-            reformatted.text = reformatted.text.replace(
-              /%s/,
-              fieldMeta?.label?.text.trim() ?? "the file"
-            );
-            reformattedErrors.push(reformatted);
-          }
-        });
-
-        formResult.errors = Object.is(formResult.errors, null)
-          ? { titleText: "Fix the following errors" }
-          : formResult.errors;
-        formResult.errors.errorList = reformattedErrors;
-      }
-
-      Object.entries(payload).forEach(([key, value]) => {
-        if (value && value === (originalFilenames[key] || {}).location) {
-          payload[key] = originalFilenames[key].originalFilename;
-        }
-      });
-
-      /**
-       * If there are any errors, render the page with the parsed errors
-       */
-      if (formResult.errors) {
-        return this.renderWithErrors(
-          request,
-          h,
-          payload,
-          num,
-          progress,
-          formResult.errors
-        );
-      }
-
-      const newState = this.getStateFromValidForm(formResult.value);
-      const stateResult = this.validateState(newState);
-
-      if (stateResult.errors) {
-        return this.renderWithErrors(
-          request,
-          h,
-          payload,
-          num,
-          progress,
-          stateResult.errors
-        );
-      }
-
-      let update = this.getPartialMergeState(stateResult.value);
-      if (this.repeatField) {
-        const updateValue = { [this.path]: update[this.section.name] };
-        const sectionState = state[this.section.name];
-        if (!sectionState) {
-          update = { [this.section.name]: [updateValue] };
-        } else if (!sectionState[num - 1]) {
-          sectionState.push(updateValue);
-          update = { [this.section.name]: sectionState };
-        } else {
-          sectionState[num - 1] = merge(
-            sectionState[num - 1] ?? {},
-            updateValue
-          );
-          update = { [this.section.name]: sectionState };
-        }
-      }
-      const savedState = await cacheService.mergeState(request, update);
-
-      //Calculate our relevantState, which will filter out previously input answers that are no longer relevant to this user journey
       //This is required to ensure we don't navigate to an incorrect page based on stale state values
       let relevantState = this.getConditionEvaluationContext(
         this.model,
@@ -674,6 +698,9 @@ export class PageControllerBase {
     return this.model.pages.find((page) => page.path === path);
   }
 
+  /**
+   * TODO:- proceed is interfering with subclasses
+   */
   proceed(request: HapiRequest, h: HapiResponseToolkit, state) {
     return proceed(request, h, this.getNext(state));
   }

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -629,8 +629,7 @@ export class PageControllerBase {
         return response;
       }
       const { cacheService } = request.services([]);
-      const savedState = cacheService.getState(request);
-
+      const savedState = await cacheService.getState(request);
       //This is required to ensure we don't navigate to an incorrect page based on stale state values
       let relevantState = this.getConditionEvaluationContext(
         this.model,

--- a/runner/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.ts
@@ -1,0 +1,152 @@
+import { HapiRequest, HapiResponseToolkit } from "server/types";
+import { PageController } from "./PageController";
+import { FormModel } from "server/plugins/engine/models";
+import { RepeatingSummaryPageController } from "./RepeatingSummaryPageController";
+import { ComponentDef } from "@xgovformbuilder/model";
+import { FormComponent } from "../components";
+
+import joi from "joi";
+import { reach } from "hoek";
+
+const contentTypes: Array<ComponentDef["type"]> = [
+  "Para",
+  "Details",
+  "Html",
+  "InsetText",
+];
+
+function isInputType(component) {
+  return !contentTypes.includes(component.type);
+}
+
+export class RepeatingFieldPageController extends PageController {
+  summary: RepeatingSummaryPageController;
+  pageTitle = "repeating";
+  inputComponent: FormComponent;
+  isRepeatingFieldPageController = true;
+  constructor(model: FormModel, pageDef: any) {
+    super(model, pageDef);
+    const inputComponent = this.components?.items?.find(isInputType);
+    if (!inputComponent) {
+      throw Error(
+        "RepeatingFieldPageController initialisation failed, no input component (non-content) was found"
+      );
+    }
+    this.inputComponent = inputComponent as FormComponent;
+
+    this.summary = new RepeatingSummaryPageController(
+      model,
+      pageDef,
+      this.inputComponent
+    );
+    this.summary.getPartialState = this.getPartialState;
+    this.summary.nextIndex = this.nextIndex;
+  }
+
+  get stateSchema() {
+    const name = this.inputComponent.name;
+    const parentSchema = super.stateSchema.fork([name], (schema) => {
+      if (schema.type !== "array") {
+        return joi.array().items(schema).single().empty(null).default([]);
+      }
+      return schema;
+    });
+    super.stateSchema = parentSchema;
+    return parentSchema;
+  }
+
+  makeGetRouteHandler() {
+    return async (request: HapiRequest, h: HapiResponseToolkit) => {
+      const { query } = request;
+      const { removeAtIndex, view, returnUrl } = query;
+
+      if (view === "summary" || returnUrl) {
+        return this.summary.getRouteHandler(request, h);
+      }
+      if (view ?? false) {
+        const response = await super.makeGetRouteHandler()(request, h);
+
+        const { cacheService } = request.services([]);
+        const state = await cacheService.getState(request);
+        const partialState = this.getPartialState(state, view);
+        response.source.context.components &&= response.source.context.components.map(
+          (component) => {
+            const { model } = component;
+            model.value = partialState;
+            model.items &&= model.items.filter(
+              (item) => !state[model.name]?.includes(item.value)
+            );
+            return {
+              ...component,
+              model,
+            };
+          }
+        );
+
+        return response;
+      }
+
+      if (removeAtIndex ?? false) {
+        const { cacheService } = request.services([]);
+        let state = await cacheService.getState(request);
+        const key = this.inputComponent.name;
+        const answers = state[key];
+        answers?.splice(removeAtIndex, 1);
+        state = await cacheService.mergeState(request, { [key]: answers });
+        if (state[key]?.length < 1) {
+          return h.redirect("?view=0");
+        }
+        return h.redirect(`?view=summary`);
+      }
+
+      return super.makeGetRouteHandler()(request, h);
+    };
+  }
+
+  makePostRouteHandler() {
+    return async (request: HapiRequest, h: HapiResponseToolkit) => {
+      const { query } = request;
+
+      if (query.view === "summary") {
+        return this.summary.postRouteHandler(request, h);
+      }
+
+      const modifyUpdate = (update) => {
+        const key = this.inputComponent.name;
+        const value = update[key];
+        const wrappedValue = !Array.isArray(value) ? [value] : value;
+        return {
+          [key]: [...new Set(wrappedValue)],
+        };
+      };
+
+      const response = await this.handlePostRequest(request, h, {
+        arrayMerge: true,
+        modifyUpdate,
+      });
+
+      if (response?.source?.context?.errors) {
+        return response;
+      }
+
+      return h.redirect(`/${this.model.basePath}${this.path}?view=summary`);
+    };
+  }
+
+  getPartialState(state, atIndex?: number) {
+    const keyName = this.inputComponent.name;
+    const sectionName = this.pageDef.sectionName ?? "";
+    const path = [sectionName, keyName].filter(Boolean).join(".");
+    const partial = reach(state, path);
+    if (atIndex ?? false) {
+      return partial[atIndex!];
+    }
+
+    return partial;
+  }
+
+  nextIndex(state) {
+    const partial = this.getPartialState(state) ?? [];
+    return partial.length;
+  }
+}

--- a/runner/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.ts
@@ -21,7 +21,6 @@ function isInputType(component) {
 
 export class RepeatingFieldPageController extends PageController {
   summary: RepeatingSummaryPageController;
-  pageTitle = "repeating";
   inputComponent: FormComponent;
   isRepeatingFieldPageController = true;
   constructor(model: FormModel, pageDef: any) {

--- a/runner/src/server/plugins/engine/pageControllers/RepeatingSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RepeatingSummaryPageController.ts
@@ -78,13 +78,17 @@ export class RepeatingSummaryPageController extends PageController {
   getViewModel(formData) {
     const baseViewModel = super.getViewModel(formData);
     const { progress, ...answers } = formData;
-
     const [key, values] = Object.entries(answers)[0];
     const componentDef = this.pageDef.components.find(
       (component) => component.name === key
     );
     const { title = "" } = componentDef;
-
+    let listValueToText = this.model.lists
+      .find((list) => list.name === componentDef.list)
+      ?.items?.reduce((prev, curr) => {
+        return { ...prev, [`${curr.value}`]: curr.text };
+      }, {});
+    console.log("values", values);
     const rows = values?.map((value, i) => {
       const titleWithIteration = `${title} ${i + 1}`;
       return {
@@ -92,7 +96,7 @@ export class RepeatingSummaryPageController extends PageController {
           text: titleWithIteration,
         },
         value: {
-          text: value,
+          text: listValueToText?.[value] ?? value,
         },
         actions: {
           items: [

--- a/runner/src/server/plugins/engine/pageControllers/RepeatingSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RepeatingSummaryPageController.ts
@@ -45,7 +45,6 @@ export class RepeatingSummaryPageController extends PageController {
       await cacheService.mergeState(request, { progress });
 
       const viewModel = this.getViewModel(state);
-      console.log("vm ", state, viewModel);
       return h.view("repeating-summary", viewModel);
     };
   }
@@ -55,7 +54,6 @@ export class RepeatingSummaryPageController extends PageController {
       (component) => component.name === key
     );
 
-    console.log("value!!", value);
     const { title } = componentDef;
     const titleWithIteration = `${title} ${iteration + 1}`;
     return {

--- a/runner/src/server/plugins/engine/pageControllers/RepeatingSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RepeatingSummaryPageController.ts
@@ -1,0 +1,134 @@
+import { PageController } from "server/plugins/engine/pageControllers/PageController";
+import {
+  HapiRequest,
+  HapiResponseToolkit,
+  HapiLifecycleMethod,
+} from "server/types";
+import { RepeatingFieldPageController } from "./RepeatingFieldPageController";
+
+export class RepeatingSummaryPageController extends PageController {
+  private getRoute!: HapiLifecycleMethod;
+  private postRoute!: HapiLifecycleMethod;
+  nextIndex!: RepeatingFieldPageController["nextIndex"];
+  getPartialState!: RepeatingFieldPageController["getPartialState"];
+
+  inputComponent;
+
+  constructor(model, pageDef, inputComponent) {
+    super(model, pageDef);
+    this.inputComponent = inputComponent;
+  }
+
+  get getRouteHandler() {
+    this.getRoute ??= this.makeGetRouteHandler();
+    return this.getRoute;
+  }
+
+  get postRouteHandler() {
+    this.postRoute ??= this.makePostRouteHandler();
+    return this.postRoute;
+  }
+
+  /**
+   * The controller which is used when Page["controller"] is defined as "./pages/summary.js"
+   */
+
+  /**
+   * Returns an async function. This is called in plugin.ts when there is a GET request at `/{id}/{path*}`,
+   */
+  makeGetRouteHandler() {
+    return async (request: HapiRequest, h: HapiResponseToolkit) => {
+      const { cacheService } = request.services([]);
+      const state = await cacheService.getState(request);
+      const { progress = [] } = state;
+      progress?.push(`/${this.model.basePath}${this.path}?view=summary`);
+      await cacheService.mergeState(request, { progress });
+
+      const viewModel = this.getViewModel(state);
+      return h.view("repeating-summary", viewModel);
+    };
+  }
+
+  entryToViewModelRow = ([key, value], iteration) => {
+    const componentDef = this.pageDef.components.filter(
+      (component) => component.name === key
+    );
+
+    const { title } = componentDef;
+    const titleWithIteration = `${title} ${iteration + 1}`;
+    return {
+      key: {
+        text: titleWithIteration,
+      },
+      value: {
+        text: value,
+      },
+      actions: {
+        items: [
+          {
+            href: `?view=${iteration}`,
+            text: "change",
+            visuallyHiddenText: titleWithIteration,
+          },
+        ],
+      },
+    };
+  };
+
+  getViewModel(formData) {
+    const baseViewModel = super.getViewModel(formData);
+    const { progress, ...answers } = formData;
+
+    const [key, values] = Object.entries(answers)[0];
+    const componentDef = this.pageDef.components.find(
+      (component) => component.name === key
+    );
+    const { title = "" } = componentDef;
+
+    const rows = values?.map((value, i) => {
+      const titleWithIteration = `${title} ${i + 1}`;
+      return {
+        key: {
+          text: titleWithIteration,
+        },
+        value: {
+          text: value,
+        },
+        actions: {
+          items: [
+            {
+              href: `?removeAtIndex=${i}`,
+              text: "Remove",
+              visuallyHiddenText: titleWithIteration,
+            },
+          ],
+        },
+      };
+    });
+
+    return {
+      ...baseViewModel,
+      details: { rows },
+    };
+  }
+
+  /**
+   * Returns an async function. This is called in plugin.ts when there is a POST request at `/{id}/{path*}`.
+   * If a form is incomplete, a user will be redirected to the start page.
+   */
+  makePostRouteHandler() {
+    return async (request: HapiRequest, h: HapiResponseToolkit) => {
+      const { cacheService } = request.services([]);
+      const state = await cacheService.getState(request);
+
+      if (request.payload?.next === "increment") {
+        const nextIndex = this.nextIndex(state);
+        return h.redirect(
+          `/${this.model.basePath}${this.path}?view=${nextIndex}`
+        );
+      }
+
+      return h.redirect(this.getNext(request.payload));
+    };
+  }
+}

--- a/runner/src/server/plugins/engine/pageControllers/RepeatingSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RepeatingSummaryPageController.ts
@@ -45,6 +45,7 @@ export class RepeatingSummaryPageController extends PageController {
       await cacheService.mergeState(request, { progress });
 
       const viewModel = this.getViewModel(state);
+      console.log("vm ", state, viewModel);
       return h.view("repeating-summary", viewModel);
     };
   }
@@ -54,6 +55,7 @@ export class RepeatingSummaryPageController extends PageController {
       (component) => component.name === key
     );
 
+    console.log("value!!", value);
     const { title } = componentDef;
     const titleWithIteration = `${title} ${iteration + 1}`;
     return {
@@ -83,12 +85,11 @@ export class RepeatingSummaryPageController extends PageController {
       (component) => component.name === key
     );
     const { title = "" } = componentDef;
-    let listValueToText = this.model.lists
+    const listValueToText = this.model.lists
       .find((list) => list.name === componentDef.list)
       ?.items?.reduce((prev, curr) => {
         return { ...prev, [`${curr.value}`]: curr.text };
       }, {});
-    console.log("values", values);
     const rows = values?.map((value, i) => {
       const titleWithIteration = `${title} ${i + 1}`;
       return {

--- a/runner/src/server/plugins/engine/pageControllers/helpers.ts
+++ b/runner/src/server/plugins/engine/pageControllers/helpers.ts
@@ -7,6 +7,7 @@ import { StartDatePageController } from "./StartDatePageController";
 import { StartPageController } from "./StartPageController";
 import { SummaryPageController } from "./SummaryPageController";
 import { PageControllerBase } from "./PageControllerBase";
+import { RepeatingFieldPageController } from "./RepeatingFieldPageController";
 import { Page } from "@xgovformbuilder/model";
 
 const PageControllers = {
@@ -17,6 +18,7 @@ const PageControllers = {
   StartPageController,
   SummaryPageController,
   PageControllerBase,
+  RepeatingFieldPageController,
 };
 
 export const controllerNameFromPath = (filePath: string) => {
@@ -33,5 +35,5 @@ export const getPageController = (nameOrPath: Page["controller"]) => {
     ? controllerNameFromPath(nameOrPath)
     : nameOrPath;
 
-  return PageControllers[controllerName];
+  return PageControllers[controllerName ?? "PageControllerBase"];
 };

--- a/runner/src/server/plugins/engine/plugin.ts
+++ b/runner/src/server/plugins/engine/plugin.ts
@@ -262,12 +262,7 @@ export const plugin = {
           multipart: { output: "stream" },
           maxBytes: uploadService.fileSizeLimit,
           failAction: async (request: any, h: HapiResponseToolkit) => {
-            if (
-              request.server.plugins.crumb &&
-              request.server.plugins.crumb.generate
-            ) {
-              request.server.plugins.crumb.generate(request, h);
-            }
+            request.server?.plugins?.crumb?.generate?.(request, h);
             return h.continue;
           },
         },

--- a/runner/src/server/plugins/initialiseSession/initialiseSession.ts
+++ b/runner/src/server/plugins/initialiseSession/initialiseSession.ts
@@ -9,7 +9,6 @@ import path from "path";
 import { WebhookSchema } from "server/schemas/types";
 import Jwt from "@hapi/jwt";
 import { SpecialPages } from "@xgovformbuilder/model";
-import config from "src/server/config";
 
 type ConfirmationPage = SpecialPages["confirmationPage"];
 

--- a/runner/src/server/services/cacheService.ts
+++ b/runner/src/server/services/cacheService.ts
@@ -11,7 +11,7 @@ import {
   DecodedSessionToken,
   InitialiseSessionOptions,
 } from "server/plugins/initialiseSession/types";
-import { WebhookSchema } from "../schemas/webhookSchema";
+import { WebhookSchema } from "../schemas/types";
 
 const {
   redisHost,

--- a/runner/src/server/services/uploadService.ts
+++ b/runner/src/server/services/uploadService.ts
@@ -95,7 +95,7 @@ export class UploadService {
   async handleUploadRequest(request: HapiRequest, h: HapiResponseToolkit) {
     const { cacheService } = request.services([]);
     const state = await cacheService.getState(request);
-    const originalFilenames = (state || {}).originalFilenames || {};
+    const originalFilenames = state?.originalFilenames ?? {};
 
     let files: [string, any][] = [];
 

--- a/runner/src/server/types.ts
+++ b/runner/src/server/types.ts
@@ -1,5 +1,11 @@
 import yar from "@hapi/yar";
-import { Request, ResponseToolkit, Server, ResponseObject } from "@hapi/hapi";
+import {
+  Request,
+  ResponseToolkit,
+  Server,
+  ResponseObject,
+  Lifecycle,
+} from "@hapi/hapi";
 import { Logger } from "pino";
 
 import { RateOptions } from "./plugins/rateLimit";
@@ -68,5 +74,6 @@ declare module "@hapi/hapi" {
 
 export type HapiRequest = Request;
 export type HapiResponseToolkit = ResponseToolkit;
+export type HapiLifecycleMethod = Lifecycle.Method;
 export type HapiServer = Server;
 export type HapiResponseObject = ResponseObject;

--- a/runner/src/server/views/repeating-summary.html
+++ b/runner/src/server/views/repeating-summary.html
@@ -1,0 +1,21 @@
+{% from "partials/summary-detail.html" import summaryDetail %}
+{% from "summary-list/macro.njk" import govukSummaryList -%}
+
+
+{% extends 'layout.html' %}
+
+{% block content %}
+  <div class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+        {{ govukSummaryList(details) }}
+        <form action="?view=summary"  method="post" enctype="multipart/form-data">
+          <button name="next" value="increment" class="govuk-body govuk-button--add-another">Add another</button>
+          <button name="next" value="continue" class="govuk-button">Continue</button>
+        </form>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+

--- a/runner/test/cases/server/plugins/engine/components/TextField.test.ts
+++ b/runner/test/cases/server/plugins/engine/components/TextField.test.ts
@@ -20,7 +20,7 @@ suite("TextField", () => {
       title: "What's your first name?",
       options: {
         autocomplete: "given-name",
-      }
+      },
     };
 
     const formModel = {
@@ -47,55 +47,48 @@ suite("TextField", () => {
       expect(component.formSchema.validate({}).error).to.exist();
     });
 
-
-    it("regex should be in the correct format", () => {
-      const component = TextComponent({ schema: { regex: "[]" } });
-
-      const schema = component.formSchema.describe();
-      const object = JSON.parse(JSON.stringify(schema.rules))[1] ?? { args: { regex: null } };
-      const regex = object.args.regex ?? '/^[^"\\/\\#;]*$/';
-
-      expect(regex.length).to.be.at.least(5);
-      expect(regex.substring(1, 2)).to.be.equal('^');
-      expect(regex.substring(regex.length - 2, regex.length - 1)).to.be.equal('$');
-    });
-
     it("should match pattern for regex", () => {
       let component = TextComponent({ schema: { regex: "[abc]*" } });
 
-      expect(component.formSchema.validate("ab", { messages })).
-        to.be.equal({ value: 'ab' });
+      expect(component.formSchema.validate("ab", { messages })).to.be.equal({
+        value: "ab",
+      });
 
       component = TextComponent({ schema: { regex: null } });
 
-      expect(component.formSchema.validate("*", { messages })).
-        to.be.equal({ value: '*' });
+      expect(component.formSchema.validate("*", { messages })).to.be.equal({
+        value: "*",
+      });
 
       component = TextComponent({ schema: { regex: undefined } });
 
-      expect(component.formSchema.validate("/", { messages })).
-        to.be.equal({ value: '/' });
+      expect(component.formSchema.validate("/", { messages })).to.be.equal({
+        value: "/",
+      });
 
       component = TextComponent({ schema: { regex: "" } });
 
-      expect(component.formSchema.validate("", { messages })).
-        to.not.be.equal({ value: "" });
+      expect(component.formSchema.validate("", { messages })).to.not.be.equal({
+        value: "",
+      });
 
-      component = TextComponent({ schema: { regex: "[A-Z]{1,2}[0-9]{1,2} ?[0-9][A-Z]{2}" } });
+      component = TextComponent({
+        schema: { regex: "[A-Z]{1,2}[0-9]{1,2} ?[0-9][A-Z]{2}" },
+      });
 
-      expect(component.formSchema.validate("AJ98 7AX", { messages })).
-        to.be.equal({ value: "AJ98 7AX" });
+      expect(
+        component.formSchema.validate("AJ98 7AX", { messages })
+      ).to.be.equal({ value: "AJ98 7AX" });
     });
 
     function TextComponent(properties) {
       return new TextField(
         {
           ...componentDefinition,
-          ...properties
+          ...properties,
         },
         formModel
       );
     }
-
   });
 });

--- a/smoke-tests/designer/wdio.conf.js
+++ b/smoke-tests/designer/wdio.conf.js
@@ -1,6 +1,6 @@
 const { hooks } = require("./support/hooks");
 const drivers = {
-  chrome: { version: "100.0.4896.60" }, // https://chromedriver.chromium.org/
+  chrome: { version: "102.0.5005.61" }, // https://chromedriver.chromium.org/
   firefox: { version: "0.29.1" }, // https://github.com/mozilla/geckodriver/releases
 };
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

- Add RepeatingFieldPageController and RepeatingSummaryPageController
  - `RepeatingFieldPageController` 
  - modifies the stateSchema to allow multiple answers (i.e. array) for one page. 
  - GET (makeGetRouteHandler) 
    - `?view=summary` - renders the summary page. 
    - `?view=number` - renders the question page at index `number`. 
    - if the question is list based, remove the items from the list 
  - POST (makePostRouteHandler+ 
    - redirects to ?view=summary if successful. otherwise rerenders the page with errors (TODO: implement Post Redirect Get pattern globally, currently POST requests are rendering views) 
- added a hook to PageControllerBase to be able to modify the state before it gets committed to the state.
- fix textField validation

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

Before PR's can be merged they will need to be tested by QA and approved where
applicable. To flag the change to QA assign **@XGovFormBuilder/qa** as one of the reviewers.

- manual 

