### PR TITLE
Feat/repeating-summary-on-same-page

### DIFF
--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -1,6 +1,8 @@
 import { ConditionRawData } from ".";
 import { ComponentDef } from "../components/types";
 
+type Toggleable<T> = boolean | T;
+
 export interface Next {
   path: string;
   condition?: string;
@@ -18,10 +20,13 @@ export interface Page {
 
 export interface RepeatingFieldPage extends Page {
   controller: "RepeatingFieldPageController";
-  options?: {
+  options: {
     summaryDisplayMode?: {
       samePage?: boolean;
       separatePage?: boolean;
+    };
+    customText?: {
+      separatePageTitle?: string;
     };
   };
 }
@@ -98,8 +103,6 @@ export type Output = {
   type: OutputType;
   outputConfiguration: OutputConfiguration;
 };
-
-type Toggleable<T> = boolean | T;
 
 export type ConfirmationPage = {
   customText: {

--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -16,6 +16,16 @@ export interface Page {
   next?: { path: string; condition?: string }[];
 }
 
+export interface RepeatingFieldPage extends Page {
+  controller: "RepeatingFieldPageController";
+  options?: {
+    summaryDisplayMode?: {
+      samePage?: boolean;
+      separatePage?: boolean;
+    };
+  };
+}
+
 export interface Section {
   name: string;
   title: string;
@@ -123,7 +133,7 @@ export type Fee = {
  * `FormDefinition` is a typescript representation of `Schema`
  */
 export type FormDefinition = {
-  pages: Page[];
+  pages: Array<Page | RepeatingFieldPage>;
   conditions: ConditionRawData[];
   lists: List[];
   sections: Section[];

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -111,6 +111,7 @@ const pageSchema = joi.object().keys({
   components: joi.array().items(componentSchema),
   next: joi.array().items(nextSchema),
   repeatField: joi.string().optional(),
+  options: joi.object().optional(),
 });
 
 const toggleableString = joi.alternatives().try(joi.boolean(), joi.string());

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -133,7 +133,7 @@ export class PageControllerBase {
       }
 
       label.isPageHeading = true;
-      label.classes = "govuk-label--xl";
+      label.classes = "govuk-label--l";
       pageTitle = pageTitle || label.text;
       showTitle = false;
     }

--- a/runner/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.ts
@@ -2,7 +2,7 @@ import { HapiRequest, HapiResponseToolkit } from "server/types";
 import { PageController } from "./PageController";
 import { FormModel } from "server/plugins/engine/models";
 import { RepeatingSummaryPageController } from "./RepeatingSummaryPageController";
-import { ComponentDef } from "@xgovformbuilder/model";
+import { ComponentDef, RepeatingFieldPage } from "@xgovformbuilder/model";
 import { FormComponent } from "../components";
 
 import joi from "joi";
@@ -19,11 +19,19 @@ function isInputType(component) {
   return !contentTypes.includes(component.type);
 }
 
+const DEFAULT_OPTIONS = {
+  summaryDisplayMode: {
+    samePage: false,
+    separatePage: true,
+  },
+};
+
 export class RepeatingFieldPageController extends PageController {
   summary: RepeatingSummaryPageController;
   inputComponent: FormComponent;
   isRepeatingFieldPageController = true;
-  constructor(model: FormModel, pageDef: any) {
+  options: RepeatingFieldPage["options"];
+  constructor(model: FormModel, pageDef: RepeatingFieldPage) {
     super(model, pageDef);
     const inputComponent = this.components?.items?.find(isInputType);
     if (!inputComponent) {
@@ -31,6 +39,9 @@ export class RepeatingFieldPageController extends PageController {
         "RepeatingFieldPageController initialisation failed, no input component (non-content) was found"
       );
     }
+    this.options = pageDef?.options ?? DEFAULT_OPTIONS;
+    this.options.summaryDisplayMode ??= DEFAULT_OPTIONS.summaryDisplayMode;
+
     this.inputComponent = inputComponent as FormComponent;
 
     this.summary = new RepeatingSummaryPageController(

--- a/runner/src/server/plugins/engine/pageControllers/RepeatingSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RepeatingSummaryPageController.ts
@@ -11,6 +11,7 @@ export class RepeatingSummaryPageController extends PageController {
   nextIndex!: RepeatingFieldPageController["nextIndex"];
   getPartialState!: RepeatingFieldPageController["getPartialState"];
   options!: RepeatingFieldPageController["options"];
+  removeAtIndex!: RepeatingFieldPageController["removeAtIndex"];
 
   inputComponent;
 
@@ -39,6 +40,12 @@ export class RepeatingSummaryPageController extends PageController {
   makeGetRouteHandler() {
     return async (request: HapiRequest, h: HapiResponseToolkit) => {
       const { cacheService } = request.services([]);
+
+      const { removeAtIndex } = request.query;
+      if (removeAtIndex ?? false) {
+        return this.removeAtIndex(request, h);
+      }
+
       const state = await cacheService.getState(request);
       const { progress = [] } = state;
       progress?.push(`/${this.model.basePath}${this.path}?view=summary`);
@@ -79,7 +86,7 @@ export class RepeatingSummaryPageController extends PageController {
   getViewModel(formData) {
     const baseViewModel = super.getViewModel(formData);
     const answers = this.getPartialState(formData);
-    const rows = this.getRowsFromAnswers(answers);
+    const rows = this.getRowsFromAnswers(answers, "summary");
 
     return {
       ...baseViewModel,
@@ -88,7 +95,7 @@ export class RepeatingSummaryPageController extends PageController {
     };
   }
 
-  getRowsFromAnswers(answers) {
+  getRowsFromAnswers(answers, view = false) {
     const { title = "" } = this.inputComponent;
     const listValueToText = this.inputComponent.list?.items?.reduce(
       (prev, curr) => ({ ...prev, [curr.value]: curr.text }),
@@ -107,7 +114,7 @@ export class RepeatingSummaryPageController extends PageController {
         actions: {
           items: [
             {
-              href: `?removeAtIndex=${i}`,
+              href: `?removeAtIndex=${i}${view ? `&view=${view}` : ``}`,
               text: "Remove",
               visuallyHiddenText: titleWithIteration,
             },

--- a/runner/src/server/plugins/engine/pageControllers/RepeatingSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RepeatingSummaryPageController.ts
@@ -10,6 +10,7 @@ export class RepeatingSummaryPageController extends PageController {
   private postRoute!: HapiLifecycleMethod;
   nextIndex!: RepeatingFieldPageController["nextIndex"];
   getPartialState!: RepeatingFieldPageController["getPartialState"];
+  options!: RepeatingFieldPageController["options"];
 
   inputComponent;
 
@@ -44,6 +45,7 @@ export class RepeatingSummaryPageController extends PageController {
       await cacheService.mergeState(request, { progress });
 
       const viewModel = this.getViewModel(state);
+
       return h.view("repeating-summary", viewModel);
     };
   }
@@ -77,13 +79,23 @@ export class RepeatingSummaryPageController extends PageController {
   getViewModel(formData) {
     const baseViewModel = super.getViewModel(formData);
     const answers = this.getPartialState(formData);
+    const rows = this.getRowsFromAnswers(answers);
+
+    return {
+      ...baseViewModel,
+      customText: this.options.customText,
+      details: { rows },
+    };
+  }
+
+  getRowsFromAnswers(answers) {
     const { title = "" } = this.inputComponent;
     const listValueToText = this.inputComponent.list?.items?.reduce(
       (prev, curr) => ({ ...prev, [curr.value]: curr.text }),
       {}
     );
 
-    const rows = answers?.map((value, i) => {
+    return answers?.map((value, i) => {
       const titleWithIteration = `${title} ${i + 1}`;
       return {
         key: {
@@ -103,11 +115,6 @@ export class RepeatingSummaryPageController extends PageController {
         },
       };
     });
-
-    return {
-      ...baseViewModel,
-      details: { rows },
-    };
   }
 
   /**

--- a/runner/src/server/plugins/engine/views/partials/form.html
+++ b/runner/src/server/plugins/engine/views/partials/form.html
@@ -1,12 +1,31 @@
 {% from "button/macro.njk" import govukButton %}
+{% from "summary-list/macro.njk" import govukSummaryList -%}
+
 <form method="post" enctype="multipart/form-data" autocomplete="on">
   <input type="hidden" name="crumb" value="{{crumb}}"/>
   {{ componentList(components) }}
+
+  {% if page.isRepeatingFieldPageController and details %}
+    {{ govukButton({
+      attributes: { id: "add-another"},
+      classes: "govuk-button govuk-button--secondary",
+      text: "Add to list"
+      })
+    }}
+    {{ govukSummaryList(details) }}
+  {% endif %}
+
   {% if not (components[0].type == "FlashCard") %}
     {% if isStartPage %}
       {{ govukButton({ attributes: { id: "submit" }, text: "Start now", isStartButton: true }) }}
     {% else %}
-      {{ govukButton({ attributes: { id: "submit" }, text: "Continue" }) }}
+      {% if page.isRepeatingFieldPageController %}
+        {% if details.rows.length %}
+          {{ govukButton({ attributes: { id: "submit", formaction: "?view=summary" }, text: "Continue", name: "next", value: "continue"}) }}
+        {% endif %}
+      {% else %}
+        {{ govukButton({ attributes: { id: "submit" }, text: "Continue" }) }}
+      {% endif %}
     {% endif %}
   {% endif %}
 </form>

--- a/runner/src/server/plugins/engine/views/partials/form.html
+++ b/runner/src/server/plugins/engine/views/partials/form.html
@@ -19,9 +19,9 @@
     {% if isStartPage %}
       {{ govukButton({ attributes: { id: "submit" }, text: "Start now", isStartButton: true }) }}
     {% else %}
-      {% if page.isRepeatingFieldPageController %}
+      {% if page.isRepeatingFieldPageController and page.isSamePageDisplayMode %}
         {% if details.rows.length %}
-          {{ govukButton({ attributes: { id: "submit", formaction: "?view=summary" }, text: "Continue", name: "next", value: "continue"}) }}
+          {{ govukButton({ attributes: { id: "submit" }, text: "Continue", name: "next", value: "continue"}) }}
         {% endif %}
       {% else %}
         {{ govukButton({ attributes: { id: "submit" }, text: "Continue" }) }}

--- a/runner/src/server/plugins/engine/views/partials/heading.html
+++ b/runner/src/server/plugins/engine/views/partials/heading.html
@@ -1,8 +1,8 @@
 {% if sectionTitle and (sectionTitle !== pageTitle) %}
-  <h2 class="govuk-caption-xl govuk-!-margin-top-0" id="section-title">{{sectionTitle}}</h2>
+  <h2 class="govuk-caption-l govuk-!-margin-top-0" id="section-title">{{sectionTitle}}</h2>
 {% endif %}
 {% if showTitle %}
-  <h1 class="govuk-heading-xl">
+  <h1 class="govuk-heading-l">
     {{pageTitle}}
   </h1>
 {% endif %}

--- a/runner/src/server/views/404.html
+++ b/runner/src/server/views/404.html
@@ -5,7 +5,7 @@
     <div class="govuk-main-wrapper">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-xl">Page not found</h1>
+          <h1 class="govuk-heading-l">Page not found</h1>
           <p class="govuk-body">We have reported this to the team that manages the service and they will fix it as soon as possible.</p>
           <p class="govuk-body">Contact us if you need to speak to someone.</p>
           <p class="govuk-body">Telephone:

--- a/runner/src/server/views/500.html
+++ b/runner/src/server/views/500.html
@@ -5,7 +5,7 @@
     <div class="govuk-main-wrapper">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+          <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
           <p class="govuk-body">Contact your closest consulate.</p>
         </div>
       </div>

--- a/runner/src/server/views/help/accessibility-statement.html
+++ b/runner/src/server/views/help/accessibility-statement.html
@@ -9,7 +9,7 @@
     <div class="govuk-main-wrapper ">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-                <h1 class="govuk-heading-xl">Accessibility Statement</h1>
+                <h1 class="govuk-heading-l">Accessibility Statement</h1>
                 <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eget volutpat tortor. Duis placerat ornare ipsum, eget molestie arcu tincidunt eget. Nam luctus arcu eu pulvinar mattis. Sed lobortis venenatis quam vel semper. Nunc lacinia augue eu nisl placerat, quis dignissim diam rutrum. Vestibulum sed leo pellentesque, gravida nibh at, consequat purus. Proin ultrices, arcu ac cursus accumsan, tellus mauris tincidunt erat, quis pellentesque sapien tortor sit amet erat.</p>
             </div>
         </div>

--- a/runner/src/server/views/help/cookies.html
+++ b/runner/src/server/views/help/cookies.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">Cookies on {{ serviceName }}</h1>
+        <h1 class="govuk-heading-l">Cookies on {{ serviceName }}</h1>
         <p class="govuk-body">Cookies are files saved on your phone, tablet or computer when you visit a website.</p>
         <p class="govuk-body">We use cookies to remember information you've entered when applying to prove your eligibility.</p>
 

--- a/runner/src/server/views/help/privacy.html
+++ b/runner/src/server/views/help/privacy.html
@@ -8,7 +8,7 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">How we use your data (Privacy Notice)</h1>
+      <h1 class="govuk-heading-l">How we use your data (Privacy Notice)</h1>
     </div>
   </div>
 </div>

--- a/runner/src/server/views/help/terms-and-conditions.html
+++ b/runner/src/server/views/help/terms-and-conditions.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">Terms and conditions</h1>
+        <h1 class="govuk-heading-l">Terms and conditions</h1>
         <p class="govuk-body">By using this digital service you agree to our <a rel=noopener
                 href="https://www.gov.uk/government/publications/foreign-and-commonwealth-office-privacy-notice-consular-services-in-the-uk-and-at-british-embassies-high-commissions-and-consulates-overseas/foreign-and-commonwealth-office-privacy-notice-consular-services-in-the-uk-and-missions-overseas">
             privacy policy</a> and to these terms and conditions. Read them carefully.

--- a/runner/src/server/views/layout.html
+++ b/runner/src/server/views/layout.html
@@ -138,7 +138,7 @@
 
 
 {% block content %}
-  <h1 class="govuk-heading-xl">Default page template</h1>
+  <h1 class="govuk-heading-l">Default page template</h1>
 {% endblock %}
 
 

--- a/runner/src/server/views/repeating-summary.html
+++ b/runner/src/server/views/repeating-summary.html
@@ -8,7 +8,7 @@
   <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+        <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
         {{ govukSummaryList(details) }}
         <form action="?view=summary"  method="post" enctype="multipart/form-data">
           <button name="next" value="increment" class="govuk-body govuk-button--add-another">Add another</button>

--- a/runner/src/server/views/repeating-summary.html
+++ b/runner/src/server/views/repeating-summary.html
@@ -1,18 +1,23 @@
 {% from "partials/summary-detail.html" import summaryDetail %}
 {% from "summary-list/macro.njk" import govukSummaryList -%}
-
+{% from "button/macro.njk" import govukButton %}
 
 {% extends 'layout.html' %}
+
 
 {% block content %}
   <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+        <h1 class="govuk-heading-l">{{customText.separatePageTitle or pageTitle }}</h1>
         {{ govukSummaryList(details) }}
         <form action="?view=summary"  method="post" enctype="multipart/form-data">
-          <button name="next" value="increment" class="govuk-body govuk-button--add-another">Add another</button>
-          <button name="next" value="continue" class="govuk-button">Continue</button>
+          <div class="govuk-button-group">
+            <button name="next" value="continue" class="govuk-button">Continue</button>
+            <button name="next" value="increment" class="govuk-button govuk-button--secondary">
+              Add another
+            </button>
+          </div>
         </form>
       </div>
     </div>

--- a/runner/src/server/views/summary.html
+++ b/runner/src/server/views/summary.html
@@ -6,7 +6,7 @@
   <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+        <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
         {% if callback and callback.message %}
         <div class="govuk-inset-text">
           {{callback.message}}

--- a/runner/src/server/views/timeout.html
+++ b/runner/src/server/views/timeout.html
@@ -9,7 +9,7 @@
   <div class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">Your application has timed out</h1>
+        <h1 class="govuk-heading-l">Your application has timed out</h1>
         <p class="govuk-body">
           We have reset your application because you did not do anything for {{ sessionTimeout / 60000 }} minutes. We did this
           to keep your information secure.


### PR DESCRIPTION
related to #850 

This change adds support for same page and separate page summaries (or both). `RepeatingFieldPageController`s now support an options object. This is an example of the page declaration:

<details>
 <summary>Page declaration</summary>
  
```.json
    {
      "path": "/which-languages-do-you-provide-a-service-in",
      "title": "Which languages do you provide a service in?",
      "controller": "RepeatingFieldPageController",
      "options": {
        "summaryDisplayMode": {
          "samePage":false,
          "separatePage": true
        },
        "customText": {
          "separatePageTitle": "You have selected these languages"
        }
      },
      "components": [
        {
          "name": "languagesProvided",
          "options": {
            "hideTitle": true
          },
          "list": "languages",
          "type": "AutocompleteField",
          "title": "Language",
          "hint": "List any languages you interpret or translate (apart from English)",
          "schema": {}
        }
      ],
      "next": [
        {
          "path": "/name"
        }
      ]
    }
```
</details>



### options:
```.json
      "options": {
        "summaryDisplayMode": {
          "samePage":false,
          "separatePage": true
        },
        "customText": {
          "separatePageTitle": "You have selected these languages"
        }
      },
```

### `summaryDisplayMode.samePage`: `boolean`
If `samePage` is set to `true`, a list of previous answers will be presented to the user.

<details>
 <summary>Video</summary>
https://user-images.githubusercontent.com/22080510/179397491-e92d700b-9956-4c7d-b89b-e03beec2a945.mov
</details>

### `summaryDisplayMode.separatePage`: `boolean`
If `seperatePage` is set to `true`, a list of previous answers will be presented to the user on a different page.

#### You may customise the title by providing `options.customText.seperatePageTitle`.

<details>
 <summary>Video (with <code>summaryDisplayMode.samePage`</code> is <code>`false`</code>) </summary>

  https://user-images.githubusercontent.com/22080510/179397625-d2a22a22-f584-40db-9caa-0a0eb767bf0d.mov
</details>

<details>
 <summary>Video (with <code>summaryDisplayMode.samePage`</code> is <code>`true`</code>) </summary>

  https://user-images.githubusercontent.com/22080510/179397625-d2a22a22-f584-40db-9caa-0a0eb767bf0d.mov
</details>







