### PR TITLE
bumped typescript version in model & linebreaks preserved for change …

### DIFF
--- a/model/package.json
+++ b/model/package.json
@@ -61,7 +61,7 @@
     "nunjucks": "3.2.1",
     "path": "0.12.7",
     "ts-jest": "^26.4.4",
-    "typescript": "^4.0.3",
+    "typescript": "^4.1.3",
     "wreck": "14.2.0"
   }
 }

--- a/runner/package.json
+++ b/runner/package.json
@@ -126,7 +126,7 @@
     "nodemon": "^2.0.6",
     "sass": "^1.49.9",
     "sinon": "^13.0.1",
-    "typescript": "^4.0.3"
+    "typescript": "^4.1.3"
   },
   "lighthouse": {
     "requiredScores": {

--- a/runner/src/server/views/summary.html
+++ b/runner/src/server/views/summary.html
@@ -9,7 +9,7 @@
         <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
         {% if callback and callback.message %}
         <div class="govuk-inset-text">
-          {{callback.message}}
+          {{ callback.message | striptags(true) | escape | nl2br }}
         </div>
         {% endif %}
         {% for detail in details %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4906,7 +4906,7 @@ __metadata:
     nunjucks: 3.2.1
     path: 0.12.7
     ts-jest: ^26.4.4
-    typescript: ^4.0.3
+    typescript: ^4.1.3
     wreck: 14.2.0
   languageName: unknown
   linkType: soft
@@ -5002,7 +5002,7 @@ __metadata:
     schmervice: ^1.6.0
     sinon: ^13.0.1
     tmp: ^0.2.1
-    typescript: ^4.0.3
+    typescript: ^4.1.3
     url-parse: ^1.5.10
     uuid: ^8.3.2
     yar: 9.1.0
@@ -21282,7 +21282,7 @@ typescript@^3.6.4:
   languageName: node
   linkType: hard
 
-"typescript@^4.0.3, typescript@^4.1.3":
+typescript@^4.1.3:
   version: 4.1.3
   resolution: "typescript@npm:4.1.3"
   bin:
@@ -21302,7 +21302,7 @@ typescript@^3.6.4:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.0.3#~builtin<compat/typescript>, typescript@patch:typescript@^4.1.3#~builtin<compat/typescript>":
+"typescript@patch:typescript@^4.1.3#~builtin<compat/typescript>":
   version: 4.1.3
   resolution: "typescript@patch:typescript@npm%3A4.1.3#~builtin<compat/typescript>::version=4.1.3&hash=f456af"
   bin:


### PR DESCRIPTION
…message in summary page

# Description

 - Linebreaks preserved in summary page when accessing from the initiate session URL
 - Bumped typescript version in model package.json

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [ ] Call initiate session endpoint including linebreaks (\r\n) in the change message.  Access the URL and the line breaks should be preserved when viewing the message on the summary page

# Checklist:

- [ ] My changes do not introduce any new linting errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and versioning
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased onto main and there are no code conflicts
- [ ] I have checked deployments are working in all environments
- [ ] I have updated the architecture diagrams as per Contribute.md
