### PR TITLE
fix: add condition for if header.referrer can't be found

### DIFF
--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -153,11 +153,8 @@ export class SummaryPageController extends PageController {
             "declarationError",
             "You must declare to be able to submit this application"
           );
-          return redirectTo(
-            request,
-            h,
-            `${request.headers.referer}#declaration`
-          );
+          const url = request.headers.referer ?? request.path;
+          return redirectTo(request, h, `${url}#declaration`);
         }
         summaryViewModel.addDeclarationAsQuestion();
       }


### PR DESCRIPTION
# Description

The purpose of this PR is super specific. If there is a summary page with a declaration at the bottom of it, there are cases where the `request.headers. referer ` does not exist (like if the user has an ad blocker). In those cases if a user ignore the tickbox and submits the form, they get an error.

This fix addresses that so that the user is redirected to the page with an error message.

<img width="1009" alt="Screenshot 2022-11-10 at 18 42 45" src="https://user-images.githubusercontent.com/1377253/201179799-7cc23034-25d1-4d6f-ad26-14ffd760392d.png">
