### PR TITLE
fix: add paymentSessionTimeout

### DIFF
--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -67,6 +67,7 @@ module.exports = {
    */
   sessionTimeout: 20 * minute,
   confirmationSessionTimeout: 20 * minute,
+  paymentSessionTimeout: 90 * minute, // GOV.UK Pay sessions are 90 minutes. It is possible a user takes longer than 20 minutes to complete a payment.
   // sessionCookiePassword: "",
   // redisHost: "http://localhost",
   // redisPort: 6379,

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -163,6 +163,12 @@ export class SummaryPageController extends PageController {
         outputs: summaryViewModel.outputs,
         userCompletedSummary: true,
       });
+
+      request.logger.info(
+        ["Webhook data", "before send", request.yar.id],
+        JSON.stringify(summaryViewModel.validatedWebhookData)
+      );
+
       await cacheService.mergeState(request, {
         webhookData: summaryViewModel.validatedWebhookData,
       });

--- a/runner/src/server/services/cacheService.ts
+++ b/runner/src/server/services/cacheService.ts
@@ -58,8 +58,8 @@ export class CacheService {
     hoek.merge(state, value, nullOverride, arrayMerge);
     if (!!state.pay) {
       this.logger.info(
-        ["cacheService"],
-        `Pay state detected for ${request.yar.id} setting session TTL to ${paymentSessionTimeout}.`
+        ["cacheService", request.yar.id],
+        `Pay state detected setting session TTL to ${paymentSessionTimeout}.`
       );
       ttl = paymentSessionTimeout;
     }

--- a/runner/src/server/services/cacheService.ts
+++ b/runner/src/server/services/cacheService.ts
@@ -59,7 +59,7 @@ export class CacheService {
     if (!!state.pay) {
       this.logger.info(
         ["cacheService"],
-        `Pay state detected, setting session TTL to ${paymentSessionTimeout}.`
+        `Pay state detected for ${request.yar.id} setting session TTL to ${paymentSessionTimeout}.`
       );
       ttl = paymentSessionTimeout;
     }

--- a/runner/src/server/services/cacheService.ts
+++ b/runner/src/server/services/cacheService.ts
@@ -21,6 +21,7 @@ const {
   isSandbox,
   sessionTimeout,
   confirmationSessionTimeout,
+  paymentSessionTimeout,
 } = config;
 const partition = "cache";
 
@@ -53,8 +54,16 @@ export class CacheService {
   ) {
     const key = this.Key(request);
     const state = await this.getState(request);
+    let ttl = sessionTimeout;
     hoek.merge(state, value, nullOverride, arrayMerge);
-    await this.cache.set(key, state, sessionTimeout);
+    if (!!state.pay) {
+      this.logger.info(
+        ["cacheService"],
+        `Pay state detected, setting session TTL to ${paymentSessionTimeout}.`
+      );
+      ttl = paymentSessionTimeout;
+    }
+    await this.cache.set(key, state, ttl);
     return this.cache.get(key);
   }
 


### PR DESCRIPTION


# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

- If a pay property is detected in the state object, set the TTL to 90 minutes
  - gov.uk pay session is 90 minutes. It is possible that a user takes longer to pay than 20 minutes, but by that time their session would have died. 
- Add logging of webhook data before redirecting to pay or /status

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

