### PR TITLE
Bug/nested conditions

### DIFF
--- a/designer/client/conditions/SelectConditions.tsx
+++ b/designer/client/conditions/SelectConditions.tsx
@@ -85,6 +85,7 @@ class SelectConditions extends React.Component<Props, State> {
     const stringConditions = conditions.filter(
       (condition) => typeof condition.value === "string"
     );
+    // nested conditions have their own data structure, so need to be considered separately
     const nestedConditions = conditions.filter((condition) =>
       condition.value.conditions
         .map((innerCondition) => innerCondition.hasOwnProperty("conditionName"))
@@ -97,8 +98,6 @@ class SelectConditions extends React.Component<Props, State> {
           (nestedCondition) => nestedCondition.name === condition.name
         )
     );
-
-    console.log("fields: ", fields);
 
     fields.forEach((field) => {
       this.handleStringConditions(
@@ -167,7 +166,7 @@ class SelectConditions extends React.Component<Props, State> {
     );
     var a = "";
   }
-
+  // loops through nested conditions, checking the referenced condition against the current field
   handleNestedConditions(
     nestedConditions: ConditionData[],
     fieldName: string,


### PR DESCRIPTION
# Description
Related to #998. The SelectCondition component wasn't checking for nested conditions and was only checking against the field name of the condition. Given the data structure of nested conditions, this was causing an error as there is no reference to the field when referencing another condition.

- Added new method to handle nested conditions
## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?
- [X] Followed steps to reproduce issue in #998, nested condition is selectable with no error.
# Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
