### PR TITLE
#1018 issues with conditions in sections

### DIFF
--- a/designer/client/conditions/InlineConditions.tsx
+++ b/designer/client/conditions/InlineConditions.tsx
@@ -13,6 +13,7 @@ import {
   allInputs,
   findList,
   inputsAccessibleAt,
+  removeCondition,
   updateCondition,
 } from "../data";
 import randomId from "../randomId";
@@ -169,6 +170,18 @@ export class InlineConditions extends React.Component<Props, State> {
     }
   };
 
+  onClickDelete = async (event: MouseEvent<HTMLAnchorElement>) => {
+    event?.preventDefault();
+    const { data, save } = this.context;
+    const { cancelCallback, conditionsChange, condition } = this.props;
+
+    const updatedData = removeCondition(data, condition.name);
+    await save(updatedData);
+    if (cancelCallback) {
+      cancelCallback(event);
+    }
+  };
+
   saveCondition = (condition) => {
     this.setState({
       conditions: this.state.conditions.add(condition),
@@ -212,12 +225,8 @@ export class InlineConditions extends React.Component<Props, State> {
   };
 
   render() {
-    const {
-      conditions,
-      editView,
-      conditionString,
-      validationErrors,
-    } = this.state;
+    const { conditions, editView, conditionString, validationErrors } =
+      this.state;
     const hasConditions = conditions.hasConditions;
 
     const nameError = validationErrors.filter(
@@ -316,14 +325,26 @@ export class InlineConditions extends React.Component<Props, State> {
             />
             <div className="govuk-form-group">
               {hasConditions && (
-                <a
-                  href="#"
-                  id="save-inline-conditions"
-                  className="govuk-button"
-                  onClick={this.onClickSave}
-                >
-                  {i18n("save")}
-                </a>
+                <>
+                  <a
+                    href="#"
+                    id="save-inline-conditions"
+                    className="govuk-button"
+                    onClick={this.onClickSave}
+                  >
+                    {i18n("save")}
+                  </a>
+                  {this.props.condition && (
+                    <a
+                      href="#"
+                      id="delete-inline-conditions"
+                      className="govuk-button"
+                      onClick={this.onClickDelete}
+                    >
+                      {i18n("delete")}
+                    </a>
+                  )}
+                </>
               )}
               <a
                 href="#"

--- a/designer/client/conditions/InlineConditions.tsx
+++ b/designer/client/conditions/InlineConditions.tsx
@@ -325,7 +325,7 @@ export class InlineConditions extends React.Component<Props, State> {
               fields={this.state.fields}
               saveCallback={this.saveCondition}
             />
-            <div className="govuk-form-group">
+            <div className="govuk-button-group">
               {hasConditions && (
                 <>
                   <a
@@ -340,7 +340,7 @@ export class InlineConditions extends React.Component<Props, State> {
                     <a
                       href="#"
                       id="delete-inline-conditions"
-                      className="govuk-button"
+                      className="govuk-button govuk-button--warning"
                       onClick={this.onClickDelete}
                     >
                       {i18n("delete")}

--- a/designer/client/conditions/InlineConditions.tsx
+++ b/designer/client/conditions/InlineConditions.tsx
@@ -148,8 +148,6 @@ export class InlineConditions extends React.Component<Props, State> {
       return;
     }
 
-    const copy = { ...data };
-
     if (condition) {
       const updatedData = updateCondition(data, condition.name, conditions);
       await save(updatedData);
@@ -173,7 +171,7 @@ export class InlineConditions extends React.Component<Props, State> {
   onClickDelete = async (event: MouseEvent<HTMLAnchorElement>) => {
     event?.preventDefault();
     const { data, save } = this.context;
-    const { cancelCallback, conditionsChange, condition } = this.props;
+    const { cancelCallback, condition } = this.props;
 
     const updatedData = removeCondition(data, condition.name);
     await save(updatedData);
@@ -225,8 +223,12 @@ export class InlineConditions extends React.Component<Props, State> {
   };
 
   render() {
-    const { conditions, editView, conditionString, validationErrors } =
-      this.state;
+    const {
+      conditions,
+      editView,
+      conditionString,
+      validationErrors,
+    } = this.state;
     const hasConditions = conditions.hasConditions;
 
     const nameError = validationErrors.filter(

--- a/designer/client/conditions/SelectConditions.tsx
+++ b/designer/client/conditions/SelectConditions.tsx
@@ -18,6 +18,7 @@ import {
   isDuplicateCondition,
   hasConditionName,
   getFieldNameSubstring,
+  conditionsByType,
 } from "./select-condition-helpers";
 interface Props {
   path: string;
@@ -33,13 +34,15 @@ interface State {
   fields: any;
 }
 
+type ConditionObject = {
+  name: string;
+  conditions: Condition[];
+};
+
 export type ConditionData = {
   name: string;
   displayName: string;
-  value: {
-    name: string;
-    conditions: Condition[];
-  };
+  value: string | ConditionObject;
 };
 
 class SelectConditions extends React.Component<Props, State> {
@@ -89,23 +92,7 @@ class SelectConditions extends React.Component<Props, State> {
     const fields: any = Object.values(this.fieldsForPath(path));
     const { conditions = [] } = data;
     let conditionsForPath: any[] = [];
-    const conditionsByTypeMap = conditions.reduce(
-      (conditionsByType, currentValue) => {
-        if (typeof currentValue.value === "string") {
-          conditionsByType.string.push(currentValue);
-        } else if (!!hasNestedCondition(currentValue)) {
-          conditionsByType.nested.push(currentValue);
-        } else if (isObjectCondition(currentValue)) {
-          conditionsByType.object.push(currentValue);
-        }
-        return conditionsByType;
-      },
-      {
-        string: [],
-        nested: [],
-        object: [],
-      }
-    );
+    const conditionsByTypeMap = conditionsByType(conditions);
 
     fields.forEach((field) => {
       this.handleStringConditions(
@@ -134,7 +121,7 @@ class SelectConditions extends React.Component<Props, State> {
     conditionsForPath: any[]
   ) {
     objectConditions.forEach((condition) => {
-      condition.value.conditions.forEach((innerCondition) => {
+      condition.value.conditions?.forEach((innerCondition) => {
         this.checkAndAddCondition(
           condition,
           fieldName,

--- a/designer/client/conditions/SelectConditions.tsx
+++ b/designer/client/conditions/SelectConditions.tsx
@@ -166,7 +166,6 @@ class SelectConditions extends React.Component<Props, State> {
         conditionsForPath
       )
     );
-    var a = "";
   }
   // loops through nested conditions, checking the referenced condition against the current field
   handleNestedConditions(

--- a/designer/client/conditions/SelectConditions.tsx
+++ b/designer/client/conditions/SelectConditions.tsx
@@ -85,6 +85,7 @@ class SelectConditions extends React.Component<Props, State> {
     const stringConditions = conditions.filter(
       (condition) => typeof condition.value === "string"
     );
+    // nested conditions have their own data structure, so need to be considered separately
     const nestedConditions = conditions.filter((condition) =>
       condition.value.conditions
         .map((innerCondition) => innerCondition.hasOwnProperty("conditionName"))
@@ -97,8 +98,6 @@ class SelectConditions extends React.Component<Props, State> {
           (nestedCondition) => nestedCondition.name === condition.name
         )
     );
-
-    console.log("fields: ", fields);
 
     fields.forEach((field) => {
       this.handleStringConditions(
@@ -167,7 +166,7 @@ class SelectConditions extends React.Component<Props, State> {
     );
     var a = "";
   }
-
+  // loops through nested conditions, checking the referenced condition against the current field
   handleNestedConditions(
     nestedConditions: ConditionData[],
     fieldName: string,

--- a/designer/client/conditions/SelectConditions.tsx
+++ b/designer/client/conditions/SelectConditions.tsx
@@ -88,7 +88,7 @@ class SelectConditions extends React.Component<Props, State> {
     // nested conditions have their own data structure, so need to be considered separately
     const nestedConditions = conditions.filter(
       (condition) =>
-        typeof condition.value === "string" &&
+        typeof condition.value !== "string" &&
         condition.value.conditions
           .map((innerCondition) =>
             innerCondition.hasOwnProperty("conditionName")

--- a/designer/client/conditions/SelectConditions.tsx
+++ b/designer/client/conditions/SelectConditions.tsx
@@ -86,10 +86,14 @@ class SelectConditions extends React.Component<Props, State> {
       (condition) => typeof condition.value === "string"
     );
     // nested conditions have their own data structure, so need to be considered separately
-    const nestedConditions = conditions.filter((condition) =>
-      condition.value.conditions
-        .map((innerCondition) => innerCondition.hasOwnProperty("conditionName"))
-        .includes(true)
+    const nestedConditions = conditions.filter(
+      (condition) =>
+        typeof condition.value === "string" &&
+        condition.value.conditions
+          .map((innerCondition) =>
+            innerCondition.hasOwnProperty("conditionName")
+          )
+          .includes(true)
     );
     const objectConditions = conditions.filter(
       (condition) =>

--- a/designer/client/conditions/SelectConditions.tsx
+++ b/designer/client/conditions/SelectConditions.tsx
@@ -126,7 +126,9 @@ class SelectConditions extends React.Component<Props, State> {
         this.checkAndAddCondition(
           condition,
           fieldName,
-          innerCondition.field.name,
+          innerCondition.field.name.substring(
+            innerCondition.field.name.indexOf(".") + 1
+          ),
           conditionsForPath
         );
       });
@@ -186,7 +188,9 @@ class SelectConditions extends React.Component<Props, State> {
           this.checkAndAddCondition(
             condition,
             fieldName,
-            innerCondition.field.name,
+            innerCondition.field.name.substring(
+              innerCondition.field.name.indexOf(".") + 1
+            ),
             conditionsForPath
           );
         }

--- a/designer/client/conditions/SelectConditions.tsx
+++ b/designer/client/conditions/SelectConditions.tsx
@@ -17,7 +17,7 @@ import {
   isObjectCondition,
   isDuplicateCondition,
   hasConditionName,
-  getFieldNameSubstring
+  getFieldNameSubstring,
 } from "./select-condition-helpers";
 interface Props {
   path: string;

--- a/designer/client/conditions/SelectConditions.tsx
+++ b/designer/client/conditions/SelectConditions.tsx
@@ -16,7 +16,8 @@ import {
   hasNestedCondition,
   isObjectCondition,
   isDuplicateCondition,
-  hasConditionName, getFieldNameSubstring
+  hasConditionName,
+  getFieldNameSubstring
 } from "./select-condition-helpers";
 interface Props {
   path: string;

--- a/designer/client/conditions/SelectConditions.tsx
+++ b/designer/client/conditions/SelectConditions.tsx
@@ -89,33 +89,37 @@ class SelectConditions extends React.Component<Props, State> {
     const fields: any = Object.values(this.fieldsForPath(path));
     const { conditions = [] } = data;
     let conditionsForPath: any[] = [];
-    const [
-      stringConditions,
-      nestedConditions,
-      objectConditions,
-    ] = conditions.reduce(
-      (res, condition) => {
-        if (condition.value === "string") {
-          res[0].push(condition);
-        } else if (!!hasNestedCondition(condition)) {
-          res[1].push(condition);
-        } else if (isObjectCondition(condition)) {
-          res[2].push(condition);
+    const conditionsByTypeMap = conditions.reduce(
+      (conditionsByType, currentValue) => {
+        if (typeof currentValue.value === "string") {
+          conditionsByType.string.push(currentValue);
+        } else if (!!hasNestedCondition(currentValue)) {
+          conditionsByType.nested.push(currentValue);
+        } else if (isObjectCondition(currentValue)) {
+          conditionsByType.object.push(currentValue);
         }
-        return res;
+        return conditionsByType;
       },
-      [[], [], []]
+      {
+        string: [],
+        nested: [],
+        object: [],
+      }
     );
 
     fields.forEach((field) => {
       this.handleStringConditions(
-        stringConditions,
+        conditionsByTypeMap.string,
         field.name,
         conditionsForPath
       );
-      this.handleConditions(objectConditions, field.name, conditionsForPath);
+      this.handleConditions(
+        conditionsByTypeMap.object,
+        field.name,
+        conditionsForPath
+      );
       this.handleNestedConditions(
-        nestedConditions,
+        conditionsByTypeMap.nested,
         field.name,
         conditionsForPath
       );

--- a/designer/client/conditions/__tests__/conditionsByType.jest.ts
+++ b/designer/client/conditions/__tests__/conditionsByType.jest.ts
@@ -1,0 +1,55 @@
+import { conditionsByType } from "./../select-condition-helpers";
+
+const stringCondition = {
+  name: "likesScrambledEggs",
+  displayName: "Likes scrambled eggs",
+  value: "likeScrambled == true",
+};
+
+const objectCondition = {
+  name: "likesFriedEggsCond",
+  displayName: "Likes fried eggs",
+  value: {
+    name: "likesFriedEggs",
+    conditions: [
+      {
+        value: {
+          name: "likesFried",
+          displayName: "Do you like fried eggs?",
+          field: {
+            name: "likesFried",
+            type: "string",
+            display: "Do you like fried eggs?",
+          },
+          operator: "is",
+          type: "Value",
+          value: "true",
+          display: "true",
+        },
+      },
+    ],
+  },
+};
+
+const nestedCondition = {
+  name: "likesFriedAndScrambledEggs",
+  displayName: "Favourite egg is fried and scrambled",
+  value: {
+    conditions: [
+      {
+        conditionName: "likesScrambledEggs",
+        conditionDisplayName: "likes scrambled eggs",
+      },
+      { coordinator: "and", ...objectCondition },
+    ],
+  },
+};
+
+test("conditionsByType", () => {
+  const conditions = [stringCondition, objectCondition, nestedCondition];
+  expect(conditionsByType(conditions)).toEqual({
+    string: [stringCondition],
+    nested: [nestedCondition],
+    object: [objectCondition],
+  });
+});

--- a/designer/client/conditions/select-condition-helpers.ts
+++ b/designer/client/conditions/select-condition-helpers.ts
@@ -1,0 +1,29 @@
+import { ConditionData } from "./SelectConditions";
+
+// return whether the current condition has an object value
+export const isObjectCondition = (condition: ConditionData) => {
+  return typeof condition.value !== "string";
+};
+
+// return whether the current condition value has the conditionName property
+export const hasConditionName = (condition: any) => {
+  return !!condition?.conditionName;
+};
+
+// return whether the current condition has a nested condition as a value
+export const hasNestedCondition = (condition: ConditionData) => {
+  return condition.value.conditions?.find?.(hasConditionName);
+};
+
+// return whether the current condition is already in the supplied condition array
+export const isDuplicateCondition = (
+  conditions: any[],
+  conditionName: string
+) => {
+  return !!conditions.find((condition) => condition.name === conditionName);
+};
+
+// return the substring of the field name from the combined section and field name
+export const getFieldNameSubstring = (sectionFieldName: string) => {
+  return sectionFieldName.substring(sectionFieldName.indexOf("."));
+};

--- a/designer/client/conditions/select-condition-helpers.ts
+++ b/designer/client/conditions/select-condition-helpers.ts
@@ -1,21 +1,24 @@
 import { ConditionData } from "./SelectConditions";
 
-// return whether the current condition has an object value
 export const isObjectCondition = (condition: ConditionData) => {
   return typeof condition.value !== "string";
 };
 
-// return whether the current condition value has the conditionName property
+export const isStringCondition = (condition: ConditionData) => {
+  return typeof condition.value === "string";
+};
+
 export const hasConditionName = (condition: any) => {
   return !!condition?.conditionName;
 };
 
-// return whether the current condition has a nested condition as a value
 export const hasNestedCondition = (condition: ConditionData) => {
+  if (typeof condition.value === "string") {
+    return false;
+  }
   return condition.value.conditions?.find?.(hasConditionName) ?? false;
 };
 
-// return whether the current condition is already in the supplied condition array
 export const isDuplicateCondition = (
   conditions: any[],
   conditionName: string
@@ -23,7 +26,32 @@ export const isDuplicateCondition = (
   return !!conditions.find((condition) => condition.name === conditionName);
 };
 
-// return the substring of the field name from the combined section and field name
 export const getFieldNameSubstring = (sectionFieldName: string) => {
   return sectionFieldName.substring(sectionFieldName.indexOf("."));
+};
+
+export function conditionsByType(conditions: ConditionData[]) {
+  return conditions.reduce(
+    (conditionsByType, currentValue) => {
+      if (isStringCondition(currentValue)) {
+        conditionsByType.string.push(currentValue);
+      } else if (!!hasNestedCondition(currentValue)) {
+        conditionsByType.nested.push(currentValue);
+      } else if (isObjectCondition(currentValue)) {
+        conditionsByType.object.push(currentValue);
+      }
+      return conditionsByType;
+    },
+    {
+      string: [],
+      nested: [],
+      object: [],
+    } as ConditionByTypeMap
+  );
+}
+
+type ConditionByTypeMap = {
+  string: ConditionData[];
+  nested: ConditionData[];
+  object: ConditionData[];
 };

--- a/designer/client/conditions/select-condition-helpers.ts
+++ b/designer/client/conditions/select-condition-helpers.ts
@@ -12,7 +12,7 @@ export const hasConditionName = (condition: any) => {
 
 // return whether the current condition has a nested condition as a value
 export const hasNestedCondition = (condition: ConditionData) => {
-  return condition.value.conditions?.find?.(hasConditionName);
+  return condition.value.conditions?.find?.(hasConditionName) ?? false;
 };
 
 // return whether the current condition is already in the supplied condition array


### PR DESCRIPTION
# Description

Conditions which relied on fields that sat within sections weren't showing in the list of conditions to add to links. This meant that if a condition was defined inline that the value of the condition on. the link was an empty class, since the dropdown list still had no values after the condition was created.

- Related to #1018, update SelectConditions component to strip the section prefix from the field name on the condition, so that these conditions were still being registered
- Added delete button to conditions for ease of use, as during testing noticed it was quite annoying that I could add loads of conditions but couldn't delete them

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Followed steps to reproduce on #1018 
- [X] create condition using field in section, click add page, link to page after field in form, condition should show
- [X] add page and link to page inside section with field on it, define new condition using field on page, save condition, condition should appear in list

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
