### PR TITLE
Added the ability to pass through conditional lists to a GOVnotify template

### DIFF
--- a/designer/client/data/types.ts
+++ b/designer/client/data/types.ts
@@ -16,6 +16,8 @@ export const isNotContentType = (
     "Details",
     "Html",
     "InsetText",
+    "List",
+    "FlashCard",
   ];
   return !contentTypes.find((type) => `${type}` === `${obj.type}`);
 };

--- a/designer/client/list/ListEdit.tsx
+++ b/designer/client/list/ListEdit.tsx
@@ -151,7 +151,12 @@ export function ListEdit() {
           {i18n("list.item.add")}
         </a>
         <>
-          <button className="govuk-button" type="submit" onClick={handleSubmit}>
+          <button
+            data-testid="save-list"
+            className="govuk-button"
+            type="submit"
+            onClick={handleSubmit}
+          >
             {i18n("save")}
           </button>
           <a

--- a/designer/client/list/ListItemEdit.tsx
+++ b/designer/client/list/ListItemEdit.tsx
@@ -103,7 +103,12 @@ export function ListItemEdit() {
         </select>
         <hr />
         <div className={"govuk-form-group"}>
-          <button className="govuk-button" type="submit" onClick={handleSubmit}>
+          <button
+            data-testid="save-list-item"
+            className="govuk-button"
+            type="submit"
+            onClick={handleSubmit}
+          >
             {i18n("save")}
           </button>
         </div>

--- a/designer/client/outputs/__tests__/output-edit.jest.tsx
+++ b/designer/client/outputs/__tests__/output-edit.jest.tsx
@@ -29,6 +29,7 @@ describe("OutputEdit", () => {
       ],
       outputs: [],
       conditions: [],
+      lists: [],
     };
   });
 

--- a/designer/client/outputs/notify-edit-items.tsx
+++ b/designer/client/outputs/notify-edit-items.tsx
@@ -99,7 +99,12 @@ class NotifyItems extends React.Component<Props, State> {
               Notify template key
             </th>
             <th className="govuk-table__header" scope="col">
-              <a className="pull-right" href="#" onClick={this.onClickAddItem}>
+              <a
+                data-testid="add-notify-personalisation"
+                className="pull-right"
+                href="#"
+                onClick={this.onClickAddItem}
+              >
                 Add
               </a>
             </th>

--- a/designer/client/outputs/notify-edit.tsx
+++ b/designer/client/outputs/notify-edit.tsx
@@ -33,7 +33,7 @@ class NotifyEdit extends Component<Props, State> {
 
   render() {
     const { data, output, onEdit, errors } = this.props;
-    const { conditions } = data;
+    const { conditions, lists } = data;
     const outputConfiguration = (typeof output.outputConfiguration === "object"
       ? output.outputConfiguration
       : {
@@ -49,6 +49,10 @@ class NotifyEdit extends Component<Props, State> {
       ...conditions.map((condition) => ({
         name: condition.name,
         display: condition.displayName,
+      })),
+      ...lists.map((list) => ({
+        name: list.name,
+        display: list.title,
       })),
       ...this.usableKeys,
     ];

--- a/designer/client/outputs/notify-edit.tsx
+++ b/designer/client/outputs/notify-edit.tsx
@@ -52,7 +52,7 @@ class NotifyEdit extends Component<Props, State> {
       })),
       ...lists.map((list) => ({
         name: list.name,
-        display: list.title,
+        display: `${list.title} (List)`,
       })),
       ...this.usableKeys,
     ];

--- a/designer/client/outputs/outputs-edit.tsx
+++ b/designer/client/outputs/outputs-edit.tsx
@@ -68,7 +68,11 @@ class OutputsEdit extends React.Component<Props, State> {
                 ))}
                 <li>
                   <hr />
-                  <a href="#" onClick={this.onClickAddOutput}>
+                  <a
+                    data-testid="add-output"
+                    href="#"
+                    onClick={this.onClickAddOutput}
+                  >
                     Add output
                   </a>
                 </li>

--- a/e2e/cypress/e2e/designer/notifyOutput.feature
+++ b/e2e/cypress/e2e/designer/notifyOutput.feature
@@ -11,6 +11,6 @@ Feature: Notify output allows lists
   Scenario: Create GOVNotify output
     When I open Outputs
     * I choose Add output
-    * I use the GOVnotify output type
+    * I use the GOVUK notify output type
     * I add a personalisation
     Then "New list (List)" should appear in the Description dropdown

--- a/e2e/cypress/e2e/designer/notifyOutput.feature
+++ b/e2e/cypress/e2e/designer/notifyOutput.feature
@@ -4,18 +4,12 @@ Feature: Notify output allows lists
   So that I can send emails to customers using values from the form submission
 
   Background:
-    Given I am on the new configuration page
-    And I enter the form name "editing-links"
-    When I submit the form with the button title "Next"
+    Given the form "notifyOutput" exists
+    When I am viewing the designer at "/app/designer/notifyOutput"
+    Then The list "New list" should exist
 
   Scenario: Create GOVNotify output
-    When I open the lists menu
-    And Add a new list with 3 list items
-      | itemText | itemValue |
-      | Item 1   | Item 1    |
-      | Item 2   | Item 2    |
-      | Item 3   | Item 3    |
-    * I open Outputs
+    When I open Outputs
     * I choose Add output
     * I use the GOVnotify output type
     * I add a personalisation

--- a/e2e/cypress/e2e/designer/notifyOutput.feature
+++ b/e2e/cypress/e2e/designer/notifyOutput.feature
@@ -1,0 +1,22 @@
+Feature: Notify output allows lists
+  As a user
+  I want to add a notify output
+  So that I can send emails to customers using values from the form submission
+
+  Background:
+    Given I am on the new configuration page
+    And I enter the form name "editing-links"
+    When I submit the form with the button title "Next"
+
+  Scenario: Create GOVNotify output
+    When I open the lists menu
+    And Add a new list with 3 list items
+      | itemText | itemValue |
+      | Item 1   | Item 1    |
+      | Item 2   | Item 2    |
+      | Item 3   | Item 3    |
+    * I open Outputs
+    * I choose Add output
+    * I use the GOVnotify output type
+    * I add a personalisation
+    Then "New list (List)" should appear in the Description dropdown

--- a/e2e/cypress/e2e/designer/notifyOutput.js
+++ b/e2e/cypress/e2e/designer/notifyOutput.js
@@ -14,7 +14,7 @@ When("I choose Add output", () => {
   cy.findByTestId("add-output").click();
 });
 
-When("I use the GOVnotify output type", () => {
+When("I use the GOVUK notify output type", () => {
   cy.findByLabelText("Output type").select("Email via GOVUK Notify");
 });
 

--- a/e2e/cypress/e2e/designer/notifyOutput.js
+++ b/e2e/cypress/e2e/designer/notifyOutput.js
@@ -1,20 +1,8 @@
 import { When, Then } from "@badeball/cypress-cucumber-preprocessor";
 
-When("I open the lists menu", () => {
+Then("The list {string} should exist", (listName) => {
   cy.findByTestId("menu-lists").click();
-});
-
-When("Add a new list with 3 list items", (table) => {
-  cy.findByTestId("add-list").click();
-  cy.findByLabelText("List title").type("New list");
-  const items = table.hashes();
-  items.forEach((item) => {
-    cy.findByTestId("add-list-item").click();
-    cy.findByLabelText("Item text").type(item.itemText);
-    cy.findByLabelText("Value").type(item.itemValue);
-    cy.findByTestId("save-list-item").click();
-  });
-  cy.findByTestId("save-list").click();
+  cy.findAllByTestId("edit-list").findByText(listName);
   cy.findByText("Close").click();
 });
 

--- a/e2e/cypress/e2e/designer/notifyOutput.js
+++ b/e2e/cypress/e2e/designer/notifyOutput.js
@@ -1,0 +1,39 @@
+import { When, Then } from "@badeball/cypress-cucumber-preprocessor";
+
+When("I open the lists menu", () => {
+  cy.findByTestId("menu-lists").click();
+});
+
+When("Add a new list with 3 list items", (table) => {
+  cy.findByTestId("add-list").click();
+  cy.findByLabelText("List title").type("New list");
+  const items = table.hashes();
+  items.forEach((item) => {
+    cy.findByTestId("add-list-item").click();
+    cy.findByLabelText("Item text").type(item.itemText);
+    cy.findByLabelText("Value").type(item.itemValue);
+    cy.findByTestId("save-list-item").click();
+  });
+  cy.findByTestId("save-list").click();
+  cy.findByText("Close").click();
+});
+
+When("I open Outputs", () => {
+  cy.findByTestId("menu-outputs").click();
+});
+
+When("I choose Add output", () => {
+  cy.findByTestId("add-output").click();
+});
+
+When("I use the GOVnotify output type", () => {
+  cy.findByLabelText("Output type").select("Email via GOVUK Notify");
+});
+
+When("I add a personalisation", () => {
+  cy.findByTestId("add-notify-personalisation").click();
+});
+
+Then("{string} should appear in the Description dropdown", (string) => {
+  cy.contains('[id="link-source"] option', string);
+});

--- a/e2e/cypress/fixtures/notifyOutput.json
+++ b/e2e/cypress/fixtures/notifyOutput.json
@@ -1,0 +1,105 @@
+{
+  "metadata": {},
+  "startPage": "/first-page",
+  "pages": [
+    {
+      "title": "First page",
+      "path": "/first-page",
+      "components": [
+        {
+          "name": "SWJtVi",
+          "options": {},
+          "type": "YesNoField",
+          "title": "Should item 1 be shown?"
+        },
+        {
+          "name": "dxWjPr",
+          "options": {},
+          "type": "YesNoField",
+          "title": "Should item 2 be shown?"
+        },
+        {
+          "name": "TZOHRn",
+          "options": {},
+          "type": "EmailAddressField",
+          "title": "Email address"
+        }
+      ],
+      "next": [{ "path": "/summary" }]
+    },
+    {
+      "title": "Summary",
+      "path": "/summary",
+      "controller": "./pages/summary.js",
+      "components": []
+    }
+  ],
+  "lists": [
+    {
+      "title": "New list",
+      "name": "wVUZJW",
+      "type": "string",
+      "items": [
+        { "text": "Item 1", "value": "Item 1", "condition": "KAOicj" },
+        { "text": "Item 2", "value": "Item 2", "condition": "vzzqjG" },
+        { "text": "Item 3", "value": "Item 3" }
+      ]
+    }
+  ],
+  "sections": [],
+  "conditions": [
+    {
+      "displayName": "Item 1 should be shown",
+      "name": "KAOicj",
+      "value": {
+        "name": "Item 1 should be shown",
+        "conditions": [
+          {
+            "field": {
+              "name": "SWJtVi",
+              "type": "YesNoField",
+              "display": "Should item 1 be shown?"
+            },
+            "operator": "is",
+            "value": { "type": "Value", "value": "true", "display": "true" }
+          }
+        ]
+      }
+    },
+    {
+      "displayName": "Item 2 should be shown",
+      "name": "vzzqjG",
+      "value": {
+        "name": "Item 2 should be shown",
+        "conditions": [
+          {
+            "field": {
+              "name": "dxWjPr",
+              "type": "YesNoField",
+              "display": "Should item 2 be shown?"
+            },
+            "operator": "is",
+            "value": { "type": "Value", "value": "true", "display": "true" }
+          }
+        ]
+      }
+    }
+  ],
+  "fees": [],
+  "outputs": [
+    {
+      "name": "iykabp",
+      "title": "test",
+      "type": "notify",
+      "outputConfiguration": {
+        "personalisation": ["wVUZJW"],
+        "templateId": "test",
+        "apiKey": "test",
+        "emailField": "TZOHRn",
+        "addReferencesToPersonalisation": false
+      }
+    }
+  ],
+  "version": 2,
+  "skipSummary": false
+}

--- a/e2e/cypress/support/step_definitions/designer/i_am_viewing_the_designer.js
+++ b/e2e/cypress/support/step_definitions/designer/i_am_viewing_the_designer.js
@@ -1,5 +1,5 @@
 import { Given } from "@badeball/cypress-cucumber-preprocessor";
 
 Given("I am viewing the designer at {string}", (path) => {
-  cy.visit(`${Cypress.env.DESIGNER_PATH}${path}`);
+  cy.visit(`${Cypress.env("DESIGNER_URL")}${path}`);
 });

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -337,7 +337,9 @@ export type ContentComponentsDef =
   | ParaComponent
   | DetailsComponent
   | HtmlComponent
-  | InsetTextComponent;
+  | InsetTextComponent
+  | ListComponent
+  | FlashCardComponent;
 
 // Components that render Lists
 export type ListComponentsDef =

--- a/runner/src/server/plugins/engine/models/submission/__tests__/NotifyModel.test.json
+++ b/runner/src/server/plugins/engine/models/submission/__tests__/NotifyModel.test.json
@@ -1,0 +1,105 @@
+{
+  "metadata": {},
+  "startPage": "/first-page",
+  "pages": [
+    {
+      "title": "First page",
+      "path": "/first-page",
+      "components": [
+        {
+          "name": "SWJtVi",
+          "options": {},
+          "type": "YesNoField",
+          "title": "Should item 1 be shown?"
+        },
+        {
+          "name": "dxWjPr",
+          "options": {},
+          "type": "YesNoField",
+          "title": "Should item 2 be shown?"
+        },
+        {
+          "name": "TZOHRn",
+          "options": {},
+          "type": "EmailAddressField",
+          "title": "Email address"
+        }
+      ],
+      "next": [{ "path": "/summary" }]
+    },
+    {
+      "title": "Summary",
+      "path": "/summary",
+      "controller": "./pages/summary.js",
+      "components": []
+    }
+  ],
+  "lists": [
+    {
+      "title": "New list",
+      "name": "wVUZJW",
+      "type": "string",
+      "items": [
+        { "text": "Item 1", "value": "Item 1", "condition": "KAOicj" },
+        { "text": "Item 2", "value": "Item 2", "condition": "vzzqjG" },
+        { "text": "Item 3", "value": "Item 3" }
+      ]
+    }
+  ],
+  "sections": [],
+  "conditions": [
+    {
+      "displayName": "Item 1 should be shown",
+      "name": "KAOicj",
+      "value": {
+        "name": "Item 1 should be shown",
+        "conditions": [
+          {
+            "field": {
+              "name": "SWJtVi",
+              "type": "YesNoField",
+              "display": "Should item 1 be shown?"
+            },
+            "operator": "is",
+            "value": { "type": "Value", "value": "true", "display": "true" }
+          }
+        ]
+      }
+    },
+    {
+      "displayName": "Item 2 should be shown",
+      "name": "vzzqjG",
+      "value": {
+        "name": "Item 2 should be shown",
+        "conditions": [
+          {
+            "field": {
+              "name": "dxWjPr",
+              "type": "YesNoField",
+              "display": "Should item 2 be shown?"
+            },
+            "operator": "is",
+            "value": { "type": "Value", "value": "true", "display": "true" }
+          }
+        ]
+      }
+    }
+  ],
+  "fees": [],
+  "outputs": [
+    {
+      "name": "iykabp",
+      "title": "test",
+      "type": "notify",
+      "outputConfiguration": {
+        "personalisation": ["wVUZJW"],
+        "templateId": "test",
+        "apiKey": "test",
+        "emailField": "TZOHRn",
+        "addReferencesToPersonalisation": false
+      }
+    }
+  ],
+  "version": 2,
+  "skipSummary": false
+}

--- a/runner/src/server/plugins/engine/models/submission/__tests__/NotifyModel.test.ts
+++ b/runner/src/server/plugins/engine/models/submission/__tests__/NotifyModel.test.ts
@@ -21,7 +21,7 @@ const testFormSubmission = (state: FormSubmissionState) => {
   return NotifyModel(form, notifyOutputConfiguration, state);
 };
 
-suite.only("NotifyModel", () => {
+suite("NotifyModel", () => {
   test("returns correct personalisation when a list is passed in and both conditions are satisfied", () => {
     const state: FormSubmissionState = {
       SWJtVi: true,

--- a/runner/src/server/plugins/engine/models/submission/__tests__/NotifyModel.test.ts
+++ b/runner/src/server/plugins/engine/models/submission/__tests__/NotifyModel.test.ts
@@ -1,0 +1,58 @@
+import { NotifyModel } from "../NotifyModel";
+import * as Code from "@hapi/code";
+import * as Lab from "@hapi/lab";
+const { expect } = Code;
+const lab = Lab.script();
+exports.lab = lab;
+const { suite, test } = lab;
+import json from "./NotifyModel.test.json";
+import { FormModel } from "server/plugins/engine/models";
+import { FormSubmissionState } from "server/plugins/engine/types";
+
+const testFormSubmission = (state: FormSubmissionState) => {
+  const notifyOutputConfiguration = {
+    apiKey: "test",
+    templateId: "test",
+    emailField: "TZOHRn",
+    personalisation: ["wVUZJW"],
+  };
+
+  const form = new FormModel(json, {});
+  return NotifyModel(form, notifyOutputConfiguration, state);
+};
+
+suite.only("NotifyModel", () => {
+  test("returns correct personalisation when a list is passed in and both conditions are satisfied", () => {
+    const state: FormSubmissionState = {
+      SWJtVi: true,
+      dxWjPr: true,
+      TZOHRn: "test@test.com",
+    };
+    const model = testFormSubmission(state);
+    expect(model.personalisation["wVUZJW"]).to.equal(
+      `* Item 1\n* Item 2\n* Item 3\n`
+    );
+  });
+  test("returns correct personalisation when a list is passed in and the second condition is satisfied", () => {
+    const state: FormSubmissionState = {
+      SWJtVi: true,
+      dxWjPr: false,
+      TZOHRn: "test@test.com",
+    };
+
+    const model = testFormSubmission(state);
+
+    expect(model.personalisation["wVUZJW"]).to.equal(`* Item 1\n* Item 3\n`);
+  });
+  test("returns correct personalisation when a list is passed in and no conditions are satisfied", () => {
+    const state: FormSubmissionState = {
+      SWJtVi: false,
+      dxWjPr: false,
+      TZOHRn: "test@test.com",
+    };
+
+    const model = testFormSubmission(state);
+
+    expect(model.personalisation["wVUZJW"]).to.equal(`* Item 3\n`);
+  });
+});


### PR DESCRIPTION
# Description

During work on a form we realised that in some scenarios there may be large conditional lists that need to be shown to the user. Currently, this logic can be recreated in the GOVnotify template by passing through all of the conditions and duplicating the list's conditional logic in the template. However, for larger lists, this could become quite cumbersome.

As a solution to this, conditional lists could be passed into the GOVnotify template by transforming the list into a notify-formatted string.

- Added a `parseListAsNotifyTemplate` function and `checkItemIsValid` function to the notify model to allow the processing of lists
- updated designer type data file so that list components and flash card component are filtered out of the govnotify variable list
- updated components data model to reflect that list and flash card components are content components as well as list components
- updated notify-edit component to include lists as variable choices in govnotify output template

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Create a new form
- [X] Give the first page two yes/no components and an email component
- [X] Create two conditions, one condition that is true if the first answer is yes, and another condition that is true if the second answer is yes
- [X] Create a list with 3 items, one with condition one, one with condition two, and one with no condition
- [X] Create a GOVnotify template which prints the list and uses the email component as the email
- [X] Submit the form with yes answered for both questions, an email should be sent with all 3 list items printed in it in a bulleted list
- [X] Submit the form with no answered for both questions, an email should be sent with only the third list item printed in it in a bulleted list
- [X] Submit the form with yes answered for question one, an email should be sent. with the first and third list item printed in it in a bulleted list

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
