### PR TITLE
Feat: allowing static emails for to address on notify output

### DIFF
--- a/designer/client/outputs/notify-edit.tsx
+++ b/designer/client/outputs/notify-edit.tsx
@@ -9,7 +9,9 @@ import classNames from "classnames";
 import { i18n } from "../i18n";
 import { allInputs } from "../data/component/inputs";
 
-type State = {};
+type State = {
+  emailFieldValue: string;
+};
 
 type Props = {
   data: any; // TODO: type
@@ -25,11 +27,38 @@ class NotifyEdit extends Component<Props, State> {
     super(props);
     const { data } = this.props;
 
-    this.usableKeys = allInputs(data).map((input) => ({
-      name: input.propertyPath || "",
-      display: input.title || "",
-    }));
+    this.usableKeys = allInputs(data)
+      .filter((input) => input.type === "EmailAddressField")
+      .map((input) => ({
+        name: input.propertyPath || "",
+        display: input.title || "",
+      }));
+    console.log(this.props.output.outputConfiguration);
+    this.state = {
+      emailFieldValue: this.props.output.outputConfiguration?.emailField ?? "",
+    };
   }
+
+  isEmailFieldStatic = () => {
+    if (
+      this.usableKeys.find((field) => this.state.emailFieldValue === field.name)
+    ) {
+      return false;
+    }
+    return true;
+  };
+  changeEmailFieldType = (event: React.MouseEvent) => {
+    event.preventDefault();
+    if (this.isEmailFieldStatic()) {
+      this.setState({
+        emailFieldValue: this.usableKeys[0]?.name ?? "",
+      });
+    } else {
+      this.setState({
+        emailFieldValue: "",
+      });
+    }
+  };
 
   render() {
     const { data, output, onEdit, errors } = this.props;
@@ -93,27 +122,64 @@ class NotifyEdit extends Component<Props, State> {
             "govuk-form-group--error": errors?.email,
           })}
         >
-          <label className="govuk-label" htmlFor="email-field">
+          <label className="govuk-label govuk-label--s" htmlFor="email-field">
             Email field
           </label>
           {errors?.email && (
             <ErrorMessage>{errors?.email.children}</ErrorMessage>
           )}
-          <select
-            className={classNames({
-              "govuk-select": true,
-              "govuk-input--error": errors?.email,
-            })}
-            id="email-field"
-            name="email-field"
-            defaultValue={emailField}
-          >
-            {this.usableKeys.map((value, i) => (
-              <option key={`${value.name}-${i}`} value={value.name}>
-                {value.display ?? value.name}
-              </option>
-            ))}
-          </select>
+          {!this.isEmailFieldStatic() ? (
+            <>
+              <select
+                className={classNames({
+                  "govuk-select": true,
+                  "govuk-!-width-three-quarters": true,
+                  "govuk-input--error": errors?.email,
+                  "govuk-!-margin-right-2": true,
+                })}
+                id="email-field"
+                name="email-field"
+                defaultValue={emailField}
+              >
+                {this.usableKeys.map((value, i) => (
+                  <option key={`${value.name}-${i}`} value={value.name}>
+                    {value.display ?? value.name}
+                  </option>
+                ))}
+              </select>
+              <a
+                role={"button"}
+                href={"#"}
+                onClick={(e) => this.changeEmailFieldType(e)}
+              >
+                Or enter an email address
+              </a>
+            </>
+          ) : (
+            <>
+              <input
+                className={classNames({
+                  "govuk-input": true,
+                  "govuk-!-width-three-quarters": this.usableKeys.length > 0,
+                  "govuk-input--error": errors?.email,
+                  "govuk-!-margin-right-2": true,
+                })}
+                id={"email-field"}
+                name={"email-field"}
+                type={"email"}
+                defaultValue={emailField}
+              />
+              {this.usableKeys.length > 0 && (
+                <a
+                  role={"button"}
+                  href={"#"}
+                  onClick={(e) => this.changeEmailFieldType(e)}
+                >
+                  Or choose a field
+                </a>
+              )}
+            </>
+          )}
         </div>
         <NotifyEditItems
           items={personalisation}

--- a/designer/client/outputs/outputs-edit.tsx
+++ b/designer/client/outputs/outputs-edit.tsx
@@ -61,7 +61,11 @@ class OutputsEdit extends React.Component<Props, State> {
               <ul className="govuk-list">
                 {(outputs || []).map((output) => (
                   <li key={output.name}>
-                    <a href="#" onClick={(e) => this.onClickOutput(e, output)}>
+                    <a
+                      role={"button"}
+                      href="#"
+                      onClick={(e) => this.onClickOutput(e, output)}
+                    >
                       {output.title || output.name}
                     </a>
                   </li>

--- a/e2e/cypress/e2e/designer/notifyOutput.feature
+++ b/e2e/cypress/e2e/designer/notifyOutput.feature
@@ -6,11 +6,26 @@ Feature: Notify output allows lists
   Background:
     Given the form "notifyOutput" exists
     When I am viewing the designer at "/app/designer/notifyOutput"
-    Then The list "New list" should exist
-
-  Scenario: Create GOVNotify output
-    When I open Outputs
+    * The list "New list" exists
+    * I open Outputs
     * I choose Add output
-    * I use the GOVUK notify output type
-    * I add a personalisation
+    * I choose the GOVUK notify output type
+    Then The the GOVUK notify output type should be selected
+
+  Scenario: Check lists appear in the peronalisation dropdown
+    When I add a personalisation
     Then "New list (List)" should appear in the Description dropdown
+
+  Scenario: Check that static values can be used for the emailAddress field
+    When I enter "test@test.com" for the email address
+    * I input values for the title, template ID and api key
+    * I save the output
+    Then The output should save with the value "test@test.com"
+
+  Scenario: Check that dynamic values can be used for the email address field
+    When I click the button "Or choose a field"
+    * I choose the email address field "TZOHRn"
+    * I input values for the title, template ID and api key
+    * I save the output
+    Then The output should save with the value "TZOHRn"
+

--- a/e2e/cypress/e2e/designer/notifyOutput.js
+++ b/e2e/cypress/e2e/designer/notifyOutput.js
@@ -1,6 +1,5 @@
 import { When, Then } from "@badeball/cypress-cucumber-preprocessor";
-
-Then("The list {string} should exist", (listName) => {
+Then("The list {string} exists", (listName) => {
   cy.findByTestId("menu-lists").click();
   cy.findAllByTestId("edit-list").findByText(listName);
   cy.findByText("Close").click();
@@ -14,8 +13,12 @@ When("I choose Add output", () => {
   cy.findByTestId("add-output").click();
 });
 
-When("I use the GOVUK notify output type", () => {
+When("I choose the GOVUK notify output type", () => {
   cy.findByLabelText("Output type").select("Email via GOVUK Notify");
+});
+
+Then("The the GOVUK notify output type should be selected", () => {
+  cy.findByLabelText("Output type").should("have.value", "notify");
 });
 
 When("I add a personalisation", () => {
@@ -24,4 +27,31 @@ When("I add a personalisation", () => {
 
 Then("{string} should appear in the Description dropdown", (string) => {
   cy.contains('[id="link-source"] option', string);
+});
+
+When("I enter {string} for the email address", (string) => {
+  cy.findByLabelText("Email field").type(string);
+});
+
+When("I input values for the title, template ID and api key", () => {
+  cy.findByLabelText("Title").type("New output");
+  cy.findByLabelText("Template ID").type("Template-ID");
+  cy.findByLabelText("API Key").type("API-key");
+});
+
+When("I save the output", () => {
+  cy.findByRole("button", { name: "Save" }).click();
+});
+
+Then("The output should save with the value {string}", (string) => {
+  cy.findAllByRole("button").contains("New output").click();
+  cy.findByLabelText("Email field").should("have.value", string);
+});
+
+When("I click the button {string}", (string) => {
+  cy.findAllByRole("button").contains(string).click();
+});
+
+When("I choose the email address field {string}", (string) => {
+  cy.findByLabelText("Email field").select(string);
 });

--- a/runner/src/server/plugins/engine/models/submission/NotifyModel.ts
+++ b/runner/src/server/plugins/engine/models/submission/NotifyModel.ts
@@ -103,7 +103,7 @@ export function NotifyModel(
   return {
     templateId: templateId,
     personalisation,
-    emailAddress: reach(state, emailField) as string,
+    emailAddress: (reach(state, emailField) as string) ?? emailField,
     apiKey: apiKey,
     addReferencesToPersonalisation,
     ...(emailReplyToId && { emailReplyToId }),

--- a/runner/src/server/plugins/engine/models/submission/__tests__/NotifyModel.test.ts
+++ b/runner/src/server/plugins/engine/models/submission/__tests__/NotifyModel.test.ts
@@ -9,11 +9,14 @@ import json from "./NotifyModel.test.json";
 import { FormModel } from "server/plugins/engine/models";
 import { FormSubmissionState } from "server/plugins/engine/types";
 
-const testFormSubmission = (state: FormSubmissionState) => {
+const testFormSubmission = (
+  state: FormSubmissionState,
+  emailField = "TZOHRn"
+) => {
   const notifyOutputConfiguration = {
     apiKey: "test",
     templateId: "test",
-    emailField: "TZOHRn",
+    emailField: emailField,
     personalisation: ["wVUZJW"],
   };
 
@@ -21,7 +24,7 @@ const testFormSubmission = (state: FormSubmissionState) => {
   return NotifyModel(form, notifyOutputConfiguration, state);
 };
 
-suite("NotifyModel", () => {
+suite.only("NotifyModel", () => {
   test("returns correct personalisation when a list is passed in and both conditions are satisfied", () => {
     const state: FormSubmissionState = {
       SWJtVi: true,
@@ -54,5 +57,27 @@ suite("NotifyModel", () => {
     const model = testFormSubmission(state);
 
     expect(model.personalisation["wVUZJW"]).to.equal(`* Item 3\n`);
+  });
+  test("returns correct email address when a dynamic value is used", () => {
+    const state: FormSubmissionState = {
+      SWJtVi: false,
+      dxWjPr: false,
+      TZOHRn: "test@test.com",
+    };
+
+    const model = testFormSubmission(state);
+
+    expect(model.emailAddress).to.equal("test@test.com");
+  });
+  test("returns correct email address when a static value is used", () => {
+    const state: FormSubmissionState = {
+      SWJtVi: false,
+      dxWjPr: false,
+      TZOHRn: "test@test.com",
+    };
+
+    const model = testFormSubmission(state, "test2@test2.com");
+
+    expect(model.emailAddress).to.equal("test2@test2.com");
   });
 });


### PR DESCRIPTION
# Description

As explained in #1068 , in some cases it might be necessary to be able to have a custom template with custom personalisation, but sent to a static email address e.g. for easier data entry for staff when a straight api to a CRM system isn't possible

- Updated the designer notify output to have a link button next to the email field to change the field to and from a text input to a select list
- Updated the notify output in the runner to accurately process static email addresses

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] notifyOutput e2e test to test the functionality of the designer changes
- [X] notifyModel unit test to test the functionality of the runner

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
