### PR TITLE
fix: lists passed to GOVnotify work with no list items shown

### DIFF
--- a/runner/src/server/plugins/engine/models/submission/NotifyModel.ts
+++ b/runner/src/server/plugins/engine/models/submission/NotifyModel.ts
@@ -19,13 +19,10 @@ const parseListAsNotifyTemplate = (
   model: FormModel,
   state: FormSubmissionState
 ) => {
-  return (
-    "" +
-    list.items
-      .filter((item) => checkItemIsValid(model, state, item.condition))
-      .map((item) => `* ${item.value}\n`)
-      .join("")
-  );
+  return `${list.items
+    .filter((item) => checkItemIsValid(model, state, item.condition))
+    .map((item) => `* ${item.value}\n`)
+    .join("")}`;
 };
 
 const checkItemIsValid = (

--- a/runner/src/server/plugins/engine/models/submission/NotifyModel.ts
+++ b/runner/src/server/plugins/engine/models/submission/NotifyModel.ts
@@ -19,10 +19,13 @@ const parseListAsNotifyTemplate = (
   model: FormModel,
   state: FormSubmissionState
 ) => {
-  return list.items
-    .filter((item) => checkItemIsValid(model, state, item.condition))
-    .map((item) => `* ${item.value}\n`)
-    .join("");
+  return (
+    "" +
+    list.items
+      .filter((item) => checkItemIsValid(model, state, item.condition))
+      .map((item) => `* ${item.value}\n`)
+      .join("")
+  );
 };
 
 const checkItemIsValid = (

--- a/runner/src/server/plugins/engine/models/submission/__tests__/NotifyModel.test.json
+++ b/runner/src/server/plugins/engine/models/submission/__tests__/NotifyModel.test.json
@@ -41,8 +41,7 @@
       "type": "string",
       "items": [
         { "text": "Item 1", "value": "Item 1", "condition": "KAOicj" },
-        { "text": "Item 2", "value": "Item 2", "condition": "vzzqjG" },
-        { "text": "Item 3", "value": "Item 3" }
+        { "text": "Item 2", "value": "Item 2", "condition": "vzzqjG" }
       ]
     }
   ],

--- a/runner/src/server/plugins/engine/models/submission/__tests__/NotifyModel.test.ts
+++ b/runner/src/server/plugins/engine/models/submission/__tests__/NotifyModel.test.ts
@@ -29,9 +29,7 @@ suite("NotifyModel", () => {
       TZOHRn: "test@test.com",
     };
     const model = testFormSubmission(state);
-    expect(model.personalisation["wVUZJW"]).to.equal(
-      `* Item 1\n* Item 2\n* Item 3\n`
-    );
+    expect(model.personalisation["wVUZJW"]).to.equal(`* Item 1\n* Item 2\n`);
   });
   test("returns correct personalisation when a list is passed in and the second condition is satisfied", () => {
     const state: FormSubmissionState = {
@@ -42,9 +40,9 @@ suite("NotifyModel", () => {
 
     const model = testFormSubmission(state);
 
-    expect(model.personalisation["wVUZJW"]).to.equal(`* Item 1\n* Item 3\n`);
+    expect(model.personalisation["wVUZJW"]).to.equal(`* Item 1\n`);
   });
-  test("returns correct personalisation when a list is passed in and no conditions are satisfied", () => {
+  test("returns an empty string when a list is passed in and no conditions are satisfied", () => {
     const state: FormSubmissionState = {
       SWJtVi: false,
       dxWjPr: false,
@@ -53,6 +51,6 @@ suite("NotifyModel", () => {
 
     const model = testFormSubmission(state);
 
-    expect(model.personalisation["wVUZJW"]).to.equal(`* Item 3\n`);
+    expect(model.personalisation["wVUZJW"]).to.equal("");
   });
 });


### PR DESCRIPTION
# Description

Fix of #1079 . The list that is parsed in the notifyModel is now appended to an empty string so that if no list items are shown, an empty string is passed to the personalisation.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [X] Amended GOVNotify test so that it checks that an empty string is passed back if no conditions are satisfied
- [X] Tested manually with the steps to reproduce mentioned in #1079 

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
