### PR TITLE
feat: allow payReturnUrl to be overridden. 

### DIFF
--- a/model/src/schema/__tests__/schema.test.ts
+++ b/model/src/schema/__tests__/schema.test.ts
@@ -2,28 +2,105 @@
 
 import { Schema } from "../schema";
 
-describe("Form schema", () => {
-  test("allows feedback URL to be an empty string when feedbackForm is false", () => {
-    const goodConfiguration = {
-      metadata: {},
-      startPage: "/first-page",
-      pages: [],
-      lists: [],
-      sections: [],
-      conditions: [],
-      fees: [],
-      outputs: [],
-      version: 2,
-      skipSummary: false,
-      name: "Schema fix 3",
-      feedback: { feedbackForm: false, url: "" },
-      phaseBanner: {},
+const baseConfiguration = {
+  metadata: {},
+  startPage: "/first-page",
+  pages: [],
+  lists: [],
+  sections: [],
+  conditions: [],
+  fees: [],
+  outputs: [],
+  version: 2,
+  skipSummary: false,
+  phaseBanner: {},
+};
+
+test("allows feedback URL to be an empty string when feedbackForm is false", () => {
+  const goodConfiguration = {
+    ...baseConfiguration,
+    feedbackForm: false,
+    url: "",
+    name: "Schema fix 3",
+  };
+
+  const { value, error } = Schema.validate(goodConfiguration, {
+    abortEarly: false,
+  });
+
+  expect(error).toEqual(undefined);
+});
+
+describe("payment configuration", () => {
+  test("top level payment configurations (payApiKey, paymentReferenceFormat, payReturnUrl) are valid", () => {
+    const configuration = {
+      ...baseConfiguration,
+      paymentReferenceFormat: "EGGS-",
     };
 
-    const { value, error } = Schema.validate(goodConfiguration, {
+    const { error } = Schema.validate(configuration, {
       abortEarly: false,
     });
 
     expect(error).toEqual(undefined);
+  });
+
+  test("feeOptions object creates itself from top level configurations if present", () => {
+    const configuration = {
+      ...baseConfiguration,
+      paymentReferenceFormat: "EGGS-",
+      payApiKey: "ab-cd",
+    };
+
+    const { value } = Schema.validate(configuration, {
+      abortEarly: false,
+    });
+
+    expect(value.paymentReferenceFormat).toEqual("EGGS-");
+    expect(value.payApiKey).toEqual("ab-cd");
+
+    expect(value.feeOptions).toEqual({
+      paymentReferenceFormat: "EGGS-",
+      payApiKey: "ab-cd",
+    });
+  });
+
+  test("values can be configured via feeOptions", () => {
+    const configuration = {
+      ...baseConfiguration,
+      feeOptions: {
+        paymentReferenceFormat: "EGGS-",
+        payReturnUrl: "https://my.egg.service.scramble",
+      },
+    };
+
+    const { value } = Schema.validate(configuration, {
+      abortEarly: false,
+    });
+
+    expect(value.feeOptions).toEqual({
+      paymentReferenceFormat: "EGGS-",
+      payReturnUrl: "https://my.egg.service.scramble",
+    });
+  });
+
+  test("feeOptions are not overwritten by top level configuration", () => {
+    const configuration = {
+      ...baseConfiguration,
+      paymentReferenceFormat: "FRIED-",
+      feeOptions: {
+        paymentReferenceFormat: "EGGS-",
+        payReturnUrl: "https://my.egg.service.scramble",
+      },
+    };
+
+    const { value } = Schema.validate(configuration, {
+      abortEarly: false,
+    });
+
+    expect(value.feeOptions).toEqual({
+      paymentReferenceFormat: "EGGS-",
+      payReturnUrl: "https://my.egg.service.scramble",
+    });
   });
 });

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -228,6 +228,20 @@ const phaseBannerSchema = joi.object().keys({
   phase: joi.string().valid("alpha", "beta"),
 });
 
+const feeOptionSchema = joi
+  .object()
+  .keys({
+    payApiKey: [joi.string().allow("").optional(), multiApiKeySchema],
+    paymentReferenceFormat: [joi.string().optional()],
+    payReturnUrl: joi.string().optional(),
+  })
+  .default(({ payApiKey, paymentReferenceFormat }) => {
+    return {
+      ...(payApiKey && { payApiKey }),
+      ...(paymentReferenceFormat && { paymentReferenceFormat }),
+    };
+  });
+
 export const Schema = joi
   .object()
   .required()
@@ -249,6 +263,7 @@ export const Schema = joi
     version: joi.number().default(CURRENT_VERSION),
     phaseBanner: phaseBannerSchema,
     specialPages: specialPagesSchema.optional(),
+    feeOptions: feeOptionSchema,
   });
 
 /**
@@ -258,4 +273,7 @@ export const Schema = joi
  *      options as 'values' rather than referencing a data list
  *  2 - Reverse v1. Values populating radio, checkboxes, select, autocomplete are defined in Lists only.
  *  TODO:- merge fees and paymentReferenceFormat
+ *  2 - 2023-05-04 `feeOptions` has been introduced. paymentReferenceFormat and payApiKey can be configured in top level or feeOptions. feeOptions will take precedent.
+ *      if feeOptions are empty, it will pull values from the top level keys.
+ *      WARN: Fee/GOV.UK pay configurations (apart from fees) should no longer be stored in the top level, always within feeOptions.
  **/

--- a/runner/src/server/plugins/engine/models/FormModel.ts
+++ b/runner/src/server/plugins/engine/models/FormModel.ts
@@ -50,6 +50,11 @@ export class FormModel {
   pages: any;
   startPage: any;
 
+  feeOptions?: {
+    paymentReferenceFormat?: string;
+    payReturnUrl?: string;
+  };
+
   constructor(def, options) {
     const result = Schema.validate(def, { abortEarly: false });
 
@@ -102,6 +107,8 @@ export class FormModel {
     // @ts-ignore
     this.pages = def.pages.map((pageDef) => this.makePage(pageDef));
     this.startPage = this.pages.find((page) => page.path === def.startPage);
+
+    this.feeOptions = def.feeOptions;
   }
 
   /**

--- a/runner/src/server/plugins/engine/models/submission/FeesModel.ts
+++ b/runner/src/server/plugins/engine/models/submission/FeesModel.ts
@@ -61,7 +61,10 @@ export function FeesModel(
       details,
       total: 0,
       prefixes: [],
-      referenceFormat: model.def.paymentReferenceFormat ?? "",
+      referenceFormat:
+        model.feeOptions?.paymentReferenceFormat ??
+        model.def.paymentReferenceFormat ??
+        "",
     }
   );
 }

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -183,10 +183,17 @@ export class SummaryPageController extends PageController {
         return redirectTo(request, h, `/${request.params.id}/status`);
       }
 
+      const payReturnUrl =
+        this.model.feeOptions?.payReturnUrl ?? config.payReturnUrl;
+
+      request.logger.info(
+        `payReturnUrl has been configured to ${payReturnUrl}`
+      );
+
       // user must pay for service
       const description = payService.descriptionFromFees(summaryViewModel.fees);
       const url = new URL(
-        `${config.payReturnUrl}/${request.params.id}/status`
+        `${payReturnUrl}/${request.params.id}/status`
       ).toString();
       const res = await payService.payRequest(
         summaryViewModel.fees,
@@ -201,7 +208,7 @@ export class SummaryPageController extends PageController {
           reference: res.reference,
           self: res._links.self.href,
           returnUrl: new URL(
-            `${config.payReturnUrl}/${request.params.id}/status`
+            `${payReturnUrl}/${request.params.id}/status`
           ).toString(),
           meta: {
             amount: summaryViewModel.fees.total,


### PR DESCRIPTION
allow payReturnUrl to be overridden and constructs feeOptions from top level options

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

- Allow payReturnUrl to be configured per form. It overrides env variables.
  - This is useful for when you have multiple forms which are similar, however need to be served on separate URLs. You will still need to set up an Ingress controller, however after a payment has completed, you can redirect to the correct subdomain.  
- The schema has been changed to allow `feeOptions` 
  - it accepts the keys `payApiKey`, `paymentReferenceFormat` and `payReturnUrl`, e.g. 
  ```
   {
     "name": "Test form",
     "pages": [],
     "fees": [],
     "feeOptions": {
       "payApiKey": "AB-CD",
       "payReferenceFormat": "FCDO-",
       "payReturnUrl": "https://my.service.gov.uk"
     }
   }
  ```
   - If you have already configured payApiKey or paymentReferenceFormat on the top level, e.g. 
  ```
  {
     "name": "Test form",
     "pages": [],
     "fees": [],
     "payApiKey": "AB-CD",
     "payReferenceFormat": "FCDO-"
   }
  ```
  - This configuration will still be valid. Joi will re-parse this automatically into the new `feeOptions` object. You must eventually migrate your JSON, these will be deprecated in a future version. 

example
- You have two similar services, `register a birth abroad` and `register a death abroad`.
- You need to use different subdomains, e.g. `register-a-birth.some.domain.uk`, `register-a-death.some.domain.uk`
- both require payments. They may also have their own GOV.UK Pay teams (and therefore different API keys)
  - after the payment is complete, it must redirect back to the form runner to submit the form to your webhook. previously, the return URL had to be the same across all forms, so was not suitable when you're serving on different subdomains. 

Instead of setting up two different containers or instances, per subdomain, you can create one container and load the two forms, e.g. `birth.json` and `death.json`.
When setting up your ingress controller, you will need to 
  - Route requests to register-a-birth.some.domain.uk to `<container-name>:<port>/birth`, 
  - Route requests to register-a-death.some.domain.uk to `<container-name>:<port>/death`, 


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [ ] Unit tests
- [ ] Manual

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
