### PR TITLE
redirect after submission

### DIFF
--- a/e2e/cypress/e2e/runner/initialiseSession.feature
+++ b/e2e/cypress/e2e/runner/initialiseSession.feature
@@ -3,8 +3,8 @@ Feature: Initialise session - prepopulate a session
   Scenario: Without customisations the default text is displayed
     Given the form "initialiseSession" exists
     When the session is initialised with the options
-      | form              | callbackUrl     | redirectPath | message | htmlMessage | title |
-      | initialiseSession | http://webho.ok | /summary     |         |             |       |
+      | form              | callbackUrl                                                | redirectPath | message | htmlMessage | title |
+      | initialiseSession | https://61bca17e-fe74-40e0-9c15-a901ad120eca.mock.pstmn.io | /summary     |         |             |       |
     And I go to the initialised session URL
     Then I see "Summary"
 
@@ -12,8 +12,8 @@ Feature: Initialise session - prepopulate a session
   Scenario: The configured message is displayed
     Given the form "initialiseSession" exists
     When the session is initialised with the options
-      | form              | callbackUrl     | redirectPath | message                     | htmlMessage | title |
-      | initialiseSession | http://webho.ok | /summary     | your favourite egg is wrong |             |       |
+      | form              | callbackUrl                                                | redirectPath | message                     | htmlMessage | title |
+      | initialiseSession | https://61bca17e-fe74-40e0-9c15-a901ad120eca.mock.pstmn.io | /summary     | your favourite egg is wrong |             |       |
     And I go to the initialised session URL
     Then I see "Summary"
     And I see "your favourite egg is wrong"
@@ -21,8 +21,8 @@ Feature: Initialise session - prepopulate a session
   Scenario: The configured htmlMessage is displayed
     Given the form "initialiseSession" exists
     When the session is initialised with the options
-      | form              | callbackUrl     | redirectPath | message | htmlMessage                      | title |
-      | initialiseSession | http://webho.ok | /summary     |         | <p>This is not a type of egg</p> |       |
+      | form              | callbackUrl                                                 | redirectPath | message | htmlMessage                      | title |
+      | initialiseSession | hhttps://61bca17e-fe74-40e0-9c15-a901ad120eca.mock.pstmn.io | /summary     |         | <p>This is not a type of egg</p> |       |
     And I go to the initialised session URL
     Then I see "Summary"
     And I see "This is not a type of egg"
@@ -31,9 +31,19 @@ Feature: Initialise session - prepopulate a session
   Scenario: The configured title is displayed
     Given the form "initialiseSession" exists
     When the session is initialised with the options
-      | form              | callbackUrl     | redirectPath | message | htmlMessage | title               |
-      | initialiseSession | http://webho.ok | /summary     |         |             | Update your details |
+      | form              | callbackUrl                                                | redirectPath | message | htmlMessage | title               |
+      | initialiseSession | https://61bca17e-fe74-40e0-9c15-a901ad120eca.mock.pstmn.io | /summary     |         |             | Update your details |
     And I go to the initialised session URL
     Then I see "Update your details"
 
 
+  Scenario: The configured title is displayed
+    Given the form "initialiseSession" exists
+    When the session is initialised with the options
+      | form              | callbackUrl                                                | redirectPath | message | htmlMessage | title               | redirectUrl |
+      | initialiseSession | https://61bca17e-fe74-40e0-9c15-a901ad120eca.mock.pstmn.io | /summary     |         |             | Update your details | http://localhost:3009/help/cookies |
+    And I go to the initialised session URL
+    And I declare and continue
+    Then I see "Cookies are files saved on your phone"
+    When  I revisit the status page
+    Then I see "Cookies are files saved on your phone"

--- a/e2e/cypress/e2e/runner/initialiseSession.feature
+++ b/e2e/cypress/e2e/runner/initialiseSession.feature
@@ -22,7 +22,7 @@ Feature: Initialise session - prepopulate a session
     Given the form "initialiseSession" exists
     When the session is initialised with the options
       | form              | callbackUrl                                                 | redirectPath | message | htmlMessage                      | title |
-      | initialiseSession | hhttps://61bca17e-fe74-40e0-9c15-a901ad120eca.mock.pstmn.io | /summary     |         | <p>This is not a type of egg</p> |       |
+      | initialiseSession | https://61bca17e-fe74-40e0-9c15-a901ad120eca.mock.pstmn.io | /summary     |         | <p>This is not a type of egg</p> |       |
     And I go to the initialised session URL
     Then I see "Summary"
     And I see "This is not a type of egg"

--- a/e2e/cypress/e2e/runner/initialiseSession.js
+++ b/e2e/cypress/e2e/runner/initialiseSession.js
@@ -4,7 +4,6 @@ When("the session is initialised with the options", (table) => {
   //     | form | callbackUrl | redirectPath | message | htmlMessage | title | redirectUrl
   const { form, redirectUrl, ...options } = table.hashes()[0];
   const url = `${Cypress.env("RUNNER_URL")}/session/${form}`;
-  console.log(redirectUrl);
   cy.request("POST", url, {
     options: {
       ...options,

--- a/e2e/cypress/e2e/runner/initialiseSession.js
+++ b/e2e/cypress/e2e/runner/initialiseSession.js
@@ -1,12 +1,17 @@
 import { When } from "@badeball/cypress-cucumber-preprocessor";
 
 When("the session is initialised with the options", (table) => {
-  //     | form | callbackUrl | redirectPath | message | htmlMessage | title |
-  const { form, ...requestBody } = table.hashes()[0];
+  //     | form | callbackUrl | redirectPath | message | htmlMessage | title | redirectUrl
+  const { form, redirectUrl, ...options } = table.hashes()[0];
   const url = `${Cypress.env("RUNNER_URL")}/session/${form}`;
-
+  console.log(redirectUrl);
   cy.request("POST", url, {
-    options: requestBody,
+    options: {
+      ...options,
+      skipSummary: {
+        redirectUrl,
+      },
+    },
     questions: [],
   }).then((res) => {
     cy.wrap(res.body.token).as("token");
@@ -17,4 +22,13 @@ When("I go to the initialised session URL", () => {
   const res = cy.get("@token").then((token) => {
     cy.visit(`${Cypress.env("RUNNER_URL")}/session/${token}`);
   });
+});
+
+When("I revisit the status page", () => {
+  cy.visit(`${Cypress.env("RUNNER_URL")}/initialiseSession/status`);
+});
+
+When("I declare and continue", () => {
+  cy.findByLabelText("Confirm").click();
+  cy.findByRole("button", { name: /submit/i }).click();
 });

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -50,10 +50,10 @@ ARG LAST_TAG=""
 ENV LAST_COMMIT=$LAST_COMMIT
 ENV LAST_TAG=$LAST_TAG
 COPY --chown=appuser:appuser ./runner/package.json ./runner/tsconfig.json ./runner/.babelrc ./runner/nodemon.json ./runner/
+COPY --chown=appuser:appuser ./runner/config ./runner/config
 RUN --mount=type=cache,target=.yarn/cache,uid=1001,mode=0755,id=runner \
     yarn workspaces focus @xgovformbuilder/runner
 COPY --chown=appuser:appuser ./runner/src ./runner/src/
-COPY --chown=appuser:appuser ./runner/config ./runner/config
 COPY --chown=appuser:appuser ./runner/bin ./runner/bin/
 COPY --chown=appuser:appuser ./runner/public ./runner/public/
 RUN touch runner/.env && \

--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -11,7 +11,6 @@ module.exports = {
    * Initialised sessions
    * Allows a user's state to be pre-populated.
    */
-  safelist: [], // Array of hostnames you want to accept when using a session callback. eg "gov.uk".
   initialisedSessionTimeout: minute * 60 * 24 * 28, // Defaults to 28 days. Set the TTL for the initialised session in ms.
   initialisedSessionKey: `${nanoid.random(16)}`, // This should be set if you are deploying replicas, otherwise the key will be different per replica
   initialisedSessionAlgorithm: "HS512", // allowed algorithms: "RS256", "RS384", "RS512","PS256", "PS384", "PS512", "ES256", "ES384", "ES512", "EdDSA", "RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "HS256", "HS384", "HS512"
@@ -127,4 +126,6 @@ module.exports = {
   logLevel: "info", // Accepts "trace" | "debug" | "info" | "warn" |"error"
   logPrettyPrint: true,
   logRedactPaths: ["req.headers['x-forwarded-for']"], // You should check your privacy policy before disabling this. Check https://getpino.io/#/docs/redaction on how to configure redaction paths
+
+  safelist: ["61bca17e-fe74-40e0-9c15-a901ad120eca.mock.pstmn.io"],
 };

--- a/runner/config/test.json
+++ b/runner/config/test.json
@@ -1,5 +1,5 @@
 {
-  "safelist": ["webho.ok"],
+  "safelist": ["https://61bca17e-fe74-40e0-9c15-a901ad120eca.mock.pstmn.io"],
   "isTest": true,
   "previewMode": true,
   "enforceCsrf": false,

--- a/runner/config/test.json
+++ b/runner/config/test.json
@@ -1,5 +1,8 @@
 {
-  "safelist": ["https://61bca17e-fe74-40e0-9c15-a901ad120eca.mock.pstmn.io"],
+  "safelist": [
+    "https://61bca17e-fe74-40e0-9c15-a901ad120eca.mock.pstmn.io",
+    "webho.ok"
+  ],
   "isTest": true,
   "previewMode": true,
   "enforceCsrf": false,

--- a/runner/config/test.json
+++ b/runner/config/test.json
@@ -1,6 +1,6 @@
 {
   "safelist": [
-    "https://61bca17e-fe74-40e0-9c15-a901ad120eca.mock.pstmn.io",
+    "61bca17e-fe74-40e0-9c15-a901ad120eca.mock.pstmn.io",
     "webho.ok"
   ],
   "isTest": true,

--- a/runner/src/server/plugins/applicationStatus.ts
+++ b/runner/src/server/plugins/applicationStatus.ts
@@ -63,6 +63,16 @@ const applicationStatus = {
               reference: newReference,
             } = await statusService.outputRequests(request);
 
+            if (state.callback?.skipSummary?.redirectUrl) {
+              const { redirectUrl } = state.callback?.skipSummary;
+              request.logger.info(
+                ["applicationStatus"],
+                `Callback skipSummary detected, redirecting ${request.yar.id} to ${redirectUrl} and clearing state`
+              );
+              await cacheService.clearState(request);
+              return h.redirect(redirectUrl);
+            }
+
             const viewModel = statusService.getViewModel(
               state,
               form,

--- a/runner/src/server/plugins/applicationStatus/checkUserCompletedSummary.ts
+++ b/runner/src/server/plugins/applicationStatus/checkUserCompletedSummary.ts
@@ -1,0 +1,20 @@
+import { HapiRequest, HapiResponseToolkit } from "server/types";
+
+export async function checkUserCompletedSummary(
+  request: HapiRequest,
+  h: HapiResponseToolkit
+) {
+  const { cacheService } = request.services([]);
+
+  const state = await cacheService.getState(request);
+
+  if (state?.userCompletedSummary !== true) {
+    request.logger.error(
+      [`/${request.params.id}/status`],
+      `${request.yar.id} user has incomplete state, redirecting to /summary`
+    );
+    return h.redirect(`/${request.params.id}/summary`).takeover();
+  }
+
+  return state.userCompletedSummary;
+}

--- a/runner/src/server/plugins/applicationStatus/handleUserWithConfirmationViewModel.ts
+++ b/runner/src/server/plugins/applicationStatus/handleUserWithConfirmationViewModel.ts
@@ -1,0 +1,36 @@
+import { HapiRequest, HapiResponseToolkit } from "server/types";
+
+export async function handleUserWithConfirmationViewModel(
+  request: HapiRequest,
+  h: HapiResponseToolkit
+) {
+  const { cacheService } = request.services([]);
+
+  const confirmationViewModel = await cacheService.getConfirmationState(
+    request
+  );
+
+  if (!confirmationViewModel) {
+    return null;
+  }
+
+  const { redirectUrl, confirmation } = confirmationViewModel;
+
+  if (redirectUrl) {
+    request.logger.info(
+      [`/${request.params.id}/status`, request.yar.id],
+      `confirmationViewModel.redirect detected. User will be redirected to ${redirectUrl}`
+    );
+    return h.redirect(redirectUrl).takeover();
+  }
+
+  if (confirmation) {
+    request.logger.info(
+      [`/${request.params.id}/status`, request.yar.id],
+      `confirmationViewModel.redirect detected.`
+    );
+    return h.view("confirmation", confirmation).takeover();
+  }
+
+  return null;
+}

--- a/runner/src/server/plugins/applicationStatus/handleUserWithConfirmationViewModel.ts
+++ b/runner/src/server/plugins/applicationStatus/handleUserWithConfirmationViewModel.ts
@@ -27,7 +27,7 @@ export async function handleUserWithConfirmationViewModel(
   if (confirmation) {
     request.logger.info(
       [`/${request.params.id}/status`, request.yar.id],
-      `confirmationViewModel.redirect detected.`
+      `confirmationViewModel.confirmation detected. Re-presenting ${confirmation}`
     );
     return h.view("confirmation", confirmation).takeover();
   }

--- a/runner/src/server/plugins/applicationStatus/index.ts
+++ b/runner/src/server/plugins/applicationStatus/index.ts
@@ -1,7 +1,10 @@
-import { redirectTo } from "./engine";
-import { HapiRequest, HapiResponseToolkit } from "../types";
+import { redirectTo } from "./../engine";
+import { HapiRequest, HapiResponseToolkit } from "../../types";
+import { retryPay } from "./retryPay";
+import { handleUserWithConfirmationViewModel } from "./handleUserWithConfirmationViewModel";
+import { checkUserCompletedSummary } from "./checkUserCompletedSummary";
 
-const applicationStatus = {
+const index = {
   plugin: {
     name: "applicationStatus",
     dependencies: "@hapi/vision",
@@ -13,45 +16,16 @@ const applicationStatus = {
         options: {
           pre: [
             {
-              method: (request) => {
-                const { statusService } = request.services([]);
-                return statusService.shouldRetryPay(request);
-              },
+              method: retryPay,
               assign: "shouldRetryPay",
             },
             {
-              method: async (request, h) => {
-                const { cacheService } = request.services([]);
-
-                const confirmationViewModel = await cacheService.getConfirmationState(
-                  request
-                );
-
-                if (!confirmationViewModel) {
-                  return null;
-                }
-
-                const { redirectUrl, confirmation } = confirmationViewModel;
-
-                if (redirectUrl) {
-                  request.logger.info(
-                    [`/${request.params.id}/status`, request.yar.id],
-                    `confirmationViewModel.redirect detected. User will be redirected to ${redirectUrl}`
-                  );
-                  return h.redirect(redirectUrl).takeover();
-                }
-
-                if (confirmation) {
-                  request.logger.info(
-                    [`/${request.params.id}/status`, request.yar.id],
-                    `confirmationViewModel.redirect detected.`
-                  );
-                  return h.view("confirmation", confirmation).takeover();
-                }
-
-                return cacheService.getConfirmationState(request);
-              },
+              method: handleUserWithConfirmationViewModel,
               assign: "confirmationViewModel",
+            },
+            {
+              method: checkUserCompletedSummary,
+              assign: "userCompletedSummary",
             },
           ],
           handler: async (request: HapiRequest, h: HapiResponseToolkit) => {
@@ -59,21 +33,7 @@ const applicationStatus = {
             const { params } = request;
             const form = server.app.forms[params.id];
 
-            if (request.pre.shouldRetryPay) {
-              return h.view("pay-error", {
-                errorList: ["there was a problem with your payment"],
-              });
-            }
-
             const state = await cacheService.getState(request);
-
-            if (state?.userCompletedSummary !== true) {
-              request.logger.error(
-                [`/${params.id}/status`],
-                `${request.yar.id} user has incomplete state`
-              );
-              return h.redirect(`/${params.id}/summary`);
-            }
 
             const {
               reference: newReference,
@@ -139,4 +99,4 @@ const applicationStatus = {
   },
 };
 
-export default applicationStatus;
+export default index;

--- a/runner/src/server/plugins/applicationStatus/retryPay.ts
+++ b/runner/src/server/plugins/applicationStatus/retryPay.ts
@@ -2,8 +2,7 @@ import { HapiRequest, HapiResponseToolkit } from "server/types";
 
 export async function retryPay(request: HapiRequest, h: HapiResponseToolkit) {
   const { statusService } = request.services([]);
-  const shouldRetryPay = statusService.shouldRetryPay(request);
-
+  const shouldRetryPay = await statusService.shouldRetryPay(request);
   if (shouldRetryPay) {
     return h
       .view("pay-error", {

--- a/runner/src/server/plugins/applicationStatus/retryPay.ts
+++ b/runner/src/server/plugins/applicationStatus/retryPay.ts
@@ -1,0 +1,16 @@
+import { HapiRequest, HapiResponseToolkit } from "server/types";
+
+export async function retryPay(request: HapiRequest, h: HapiResponseToolkit) {
+  const { statusService } = request.services([]);
+  const shouldRetryPay = statusService.shouldRetryPay(request);
+
+  if (shouldRetryPay) {
+    return h
+      .view("pay-error", {
+        errorList: ["there was a problem with your payment"],
+      })
+      .takeover();
+  }
+
+  return shouldRetryPay;
+}

--- a/runner/src/server/plugins/initialiseSession/types.ts
+++ b/runner/src/server/plugins/initialiseSession/types.ts
@@ -1,3 +1,5 @@
+import { ContentComponentsDef } from "@xgovformbuilder/model";
+
 export type InitialiseSession = {
   safelist: string[];
 };
@@ -11,6 +13,12 @@ export type InitialiseSessionOptions = {
   skipSummary?: {
     redirectUrl: string;
   };
+  customText: {
+    title: string;
+    paymentSkipped?: false | string;
+    nextSteps?: false | string;
+  };
+  components: ContentComponentsDef[];
 };
 
 export type DecodedSessionToken = {

--- a/runner/src/server/plugins/initialiseSession/types.ts
+++ b/runner/src/server/plugins/initialiseSession/types.ts
@@ -8,6 +8,9 @@ export type InitialiseSessionOptions = {
   message?: string;
   htmlMessage?: string;
   title?: string;
+  skipSummary?: {
+    redirectUrl: string;
+  };
 };
 
 export type DecodedSessionToken = {

--- a/runner/src/server/plugins/logging.ts
+++ b/runner/src/server/plugins/logging.ts
@@ -11,9 +11,9 @@ export default {
         return { level: label };
       },
     },
-    debug: false,
-    logRequestStart: false,
-    logRequestComplete: false,
+    debug: config.isDev,
+    logRequestStart: config.isDev,
+    logRequestComplete: config.isDev,
     ignoreFunc: (_options, request) =>
       request.path.startsWith("/assets") || request.url.contains("assets"),
     redact: {

--- a/runner/src/server/plugins/logging.ts
+++ b/runner/src/server/plugins/logging.ts
@@ -11,7 +11,9 @@ export default {
         return { level: label };
       },
     },
-    logRequestComplete: config.isDev,
+    debug: false,
+    logRequestStart: false,
+    logRequestComplete: false,
     ignoreFunc: (_options, request) =>
       request.path.startsWith("/assets") || request.url.contains("assets"),
     redact: {

--- a/runner/src/server/services/statusService.ts
+++ b/runner/src/server/services/statusService.ts
@@ -108,10 +108,6 @@ export class StatusService {
     if (callback) {
       this.logger.info(
         ["StatusService", "outputRequests"],
-        `Callback detected for ${request.yar.id}`
-      );
-      this.logger.info(
-        ["StatusService", "outputRequests"],
         `Callback detected for ${request.yar.id} - PUT to ${callback.callbackUrl}`
       );
       try {


### PR DESCRIPTION
# Description

For session initialisation `POST /session/:formId`, allow the application complete page to be skipped and redirect to a different page entirely.

The request options are now:

```.ts
export type InitialiseSessionOptions = {
  callbackUrl: string;
  redirectPath?: string;
  message?: string; // summary page message
  htmlMessage?: string; // summary page message
  title?: string; // summary page title
  skipSummary?: { // new 
    redirectUrl: string; // URL to redirect to 
  };
  customText: { // confirmation page 
    title: string;
    paymentSkipped?: false | string;
    nextSteps?: false | string;
  };
  components: ContentComponentsDef[];
}
```

⚠️ The user's answers will be cleared immediately after a successful submission. If a user attempts to return to `/:formid/status` they will be redirected to the configured link until `CONFIRMATION_SESSION_TIMEOUT`. 



## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

