### PR TITLE
feat: allow multiple decode keys

### DIFF
--- a/runner/config/custom-environment-variables.json
+++ b/runner/config/custom-environment-variables.json
@@ -45,5 +45,6 @@
   "safelist": "SAFELIST",
   "initialisedSessionTimeout": "INITIALISED_SESSION_TIMEOUT",
   "initialisedSessionKey": "INITIALISED_SESSION_KEY",
+  "initialisedSessionAdditionalDecodeKeys": "INITIALISED_SESSION_ADDITIONAL_DECODE_KEYS",
   "initialisedSessionAlgorithm": "INITIALISED_SESSION_ALGORITHM"
 }

--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -13,6 +13,7 @@ module.exports = {
    */
   initialisedSessionTimeout: minute * 60 * 24 * 28, // Defaults to 28 days. Set the TTL for the initialised session in ms.
   initialisedSessionKey: `${nanoid.random(16)}`, // This should be set if you are deploying replicas, otherwise the key will be different per replica
+  initialisedSessionAdditionalDecodeKeys: [], // If you have recently switched algos or changed keys, you can add old keys here if you have access to them. Add these as CSV when using env vars.
   initialisedSessionAlgorithm: "HS512", // allowed algorithms: "RS256", "RS384", "RS512","PS256", "PS384", "PS512", "ES256", "ES384", "ES512", "EdDSA", "RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "HS256", "HS384", "HS512"
 
   /**

--- a/runner/src/server/utils/configSchema.ts
+++ b/runner/src/server/utils/configSchema.ts
@@ -78,6 +78,10 @@ export const configSchema = Joi.object({
   safelist: Joi.array().items(Joi.string()),
   initialisedSessionTimeout: Joi.number(),
   initialisedSessionKey: Joi.string(),
+  initialisedSessionAdditionalDecodeKeys: Joi.array()
+    .items(Joi.string())
+    .single()
+    .optional(),
   initialisedSessionAlgorithm: Joi.string()
     .allow(
       "RS256",

--- a/runner/test/cases/server/utils/verifyToken.test.ts
+++ b/runner/test/cases/server/utils/verifyToken.test.ts
@@ -42,4 +42,28 @@ describe("verifyToken", function () {
     sinon.restore();
     expect(verifyToken(decodedToken).isValid).to.be.true();
   });
+  test("initialisedSessionAdditionalDecodeKeys are used to validate the key if they exist", () => {
+    sinon
+      .stub(config, "initialisedSessionAdditionalDecodeKeys")
+      .value("OLD_KEY1,OLD_KEY2");
+
+    sinon.stub(config, "initialisedSessionKey").value("OLD_KEY2");
+
+    const tokenWithOldKey = generateSessionTokenForForm("localhost", "test");
+
+    sinon.stub(config, "initialisedSessionKey").value("NEW_KEY");
+    const tokenWithNewKey = generateSessionTokenForForm("localhost", "test");
+
+    expect(verifyToken(Jwt.token.decode(tokenWithOldKey)).isValid).to.be.true();
+    expect(verifyToken(Jwt.token.decode(tokenWithNewKey)).isValid).to.be.true();
+
+    sinon
+      .stub(config, "initialisedSessionAdditionalDecodeKeys")
+      .value("OLD_KEY1");
+
+    expect(
+      verifyToken(Jwt.token.decode(tokenWithOldKey)).isValid
+    ).to.be.false();
+    expect(verifyToken(Jwt.token.decode(tokenWithNewKey)).isValid).to.be.true();
+  });
 });


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

- You may now set `initialisedSessionAdditionalDecodeKeys` in runner/config/*.json
- or use the env var INITIALISED_SESSION_ADDITIONAL_DECODE_KEYS
  - you must provide these as CSV INITIALISED_SESSION_ADDITIONAL_DECODE_KEYS="key1,key2". If your key contains a comma, then you must use a .json file.

This will allow the initialised session feature to decode tokens generated by old keys.

If you have deployed previously without an initialised session key, then these will be auto generated each time you deploy.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
