### PR TITLE
feat: add homepage redirect

### DIFF
--- a/runner/src/server/plugins/engine/plugin.ts
+++ b/runner/src/server/plugins/engine/plugin.ts
@@ -9,7 +9,7 @@ import Boom from "boom";
 import { PluginSpecificConfiguration } from "@hapi/hapi";
 import { FormPayload } from "./types";
 import { shouldLogin } from "server/plugins/auth";
-import config from "config";
+import config from "../../config";
 
 configure([
   // Configure Nunjucks to allow rendering of content that is revealed conditionally.
@@ -177,6 +177,11 @@ export const plugin = {
         if (model) {
           return getStartPageRedirect(request, h, id, model);
         }
+
+        if (config.serviceStartPage) {
+          return h.redirect(config.serviceStartPage);
+        }
+
         throw Boom.notFound("No default form found");
       },
     });


### PR DESCRIPTION
# Description
Currently, if no default form is set and a user navigates to the root of the service, they are presented with a 404. This change will make it so that when a user navigates to the root of a service, and the service has a start page set, the user will instead be redirected to the specified start page

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [X] Manually tested without the service start page set and no default form to see if the user is still shown the 404 page
- [X] Manually tested with the service start page variable to see if the user is sent to the start page

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
