### PR TITLE
feat: add-ocr-support

### DIFF
--- a/runner/src/server/services/uploadService.ts
+++ b/runner/src/server/services/uploadService.ts
@@ -194,9 +194,7 @@ export class UploadService {
           }
         } catch (e) {
           if (e.data?.res) {
-            const { error } = this.parsedDocumentUploadResponse(
-              e.data.payload?.toString()
-            );
+            const { error } = this.parsedDocumentUploadResponse(e.data);
             request.pre.errors = [
               ...(h.request.pre.errors || []),
               parsedError(key, error),

--- a/runner/src/server/services/uploadService.ts
+++ b/runner/src/server/services/uploadService.ts
@@ -62,31 +62,35 @@ export class UploadService {
 
   parsedDocumentUploadResponse(res: http.IncomingMessage, error?: any) {
     let location: string | undefined;
+    let parsedError = "There was an error uploading your file";
 
     if (error) {
-      error = JSON.parse(error).message.replace("[document_field]", '"%s"');
+      parsedError = JSON.parse(error).message.replace(
+        "[document_field]",
+        '"%s"'
+      );
     } else {
       switch (res.statusCode) {
         case 201:
           location = res.headers.location;
           break;
         case 413:
-          error = 'The selected file for "%s" is too large';
+          parsedError = 'The selected file for "%s" is too large';
           break;
         case 422:
-          error = 'The selected file for "%s" contained a virus';
+          parsedError = 'The selected file for "%s" contained a virus';
           break;
         case 400:
-          error = "Invalid file type. Upload a PNG, JPG or PDF";
+          parsedError = "Invalid file type. Upload a PNG, JPG or PDF";
           break;
         default:
-          error = "There was an error uploading your file";
+          break;
       }
     }
 
     return {
       location,
-      error,
+      error: parsedError,
     };
   }
 
@@ -185,7 +189,7 @@ export class UploadService {
             ];
           }
         } catch (e) {
-          if (e.data && e.data.res) {
+          if (e.data?.res) {
             const { error } = this.parsedDocumentUploadResponse(
               e.data.res,
               e.data.payload?.toString()

--- a/runner/src/server/services/uploadService.ts
+++ b/runner/src/server/services/uploadService.ts
@@ -69,22 +69,9 @@ export class UploadService {
 
   parsedDocumentUploadResponse(res: http.IncomingMessage, error?: any) {
     let location: string | undefined;
-    let parsedError = "There was an error uploading your file";
-    switch (res.statusCode) {
-      case 201:
-        location = res.headers.location;
-        break;
-      case 413:
-        parsedError = ERRORS.fileSizeError;
-        break;
-      case 422:
-        parsedError = ERRORS[error];
-        break;
-      case 400:
-        parsedError = ERRORS.fileTypeError;
-        break;
-      default:
-        break;
+    let parsedError = ERRORS[error] ?? "There was an error uploading your file";
+    if (res.statusCode === 201) {
+      location = res.headers.location;
     }
 
     return {

--- a/runner/src/server/services/uploadService.ts
+++ b/runner/src/server/services/uploadService.ts
@@ -20,6 +20,7 @@ const ERRORS = {
   fileTypeError: "Invalid file type. Upload a PNG, JPG or PDF",
   virusError: 'The selected file for "%s" contained a virus',
   qualityError: 'The selected file for "%s" was too blurry',
+  default: "There was an error uploading your file",
 };
 
 export class UploadService {
@@ -72,8 +73,8 @@ export class UploadService {
 
   parsedDocumentUploadResponse({ res, payload }) {
     const errorCodeFromApi = payload?.toString?.();
-    let error = "There was an error uploading your file";
-    let location: string;
+    let error: string | undefined;
+    let location: string | undefined;
     switch (res.statusCode) {
       case 201:
         location = res.headers.location;
@@ -88,6 +89,7 @@ export class UploadService {
         error = ERRORS[errorCodeFromApi] ?? ERRORS.virusError;
         break;
       default:
+        error = ERRORS.default;
         break;
     }
     return {

--- a/runner/src/server/services/uploadService.ts
+++ b/runner/src/server/services/uploadService.ts
@@ -16,6 +16,13 @@ const parsedError = (key: string, error?: string) => {
   };
 };
 
+const ERRORS = {
+  fileSizeError: 'The selected file for "%s" is too large',
+  fileTypeError: "Invalid file type. Upload a PNG, JPG or PDF",
+  virusError: 'The selected file for "%s" contained a virus',
+  qualityError: 'The selected file for "%s" was too blurry',
+};
+
 export class UploadService {
   /**
    * Service responsible for uploading files via the FileUploadField. This service has been registered by {@link #createServer}
@@ -63,29 +70,21 @@ export class UploadService {
   parsedDocumentUploadResponse(res: http.IncomingMessage, error?: any) {
     let location: string | undefined;
     let parsedError = "There was an error uploading your file";
-
-    if (error) {
-      parsedError = JSON.parse(error).message.replace(
-        "[document_field]",
-        '"%s"'
-      );
-    } else {
-      switch (res.statusCode) {
-        case 201:
-          location = res.headers.location;
-          break;
-        case 413:
-          parsedError = 'The selected file for "%s" is too large';
-          break;
-        case 422:
-          parsedError = 'The selected file for "%s" contained a virus';
-          break;
-        case 400:
-          parsedError = "Invalid file type. Upload a PNG, JPG or PDF";
-          break;
-        default:
-          break;
-      }
+    switch (res.statusCode) {
+      case 201:
+        location = res.headers.location;
+        break;
+      case 413:
+        parsedError = ERRORS.fileSizeError;
+        break;
+      case 422:
+        parsedError = ERRORS[error];
+        break;
+      case 400:
+        parsedError = ERRORS.fileTypeError;
+        break;
+      default:
+        break;
     }
 
     return {


### PR DESCRIPTION
# Description

Updated upload service to expect errors relating to image quality from OCR image checking.

- Updated UploadService.parseDocumentUploadResponse to use an error message from the document upload api if one was returned
- Otherwise, standard response handling is done

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [X] Manual testing with local document upload api and standard form with upload field

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
