### PR TITLE
fix/submitter performance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v3.6
         with:
           node-version: "16.x"
           cache: yarn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v3.6
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: "16.x"
           cache: yarn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       app:
-        description: the app to build "designer", "runner" or "sumbitter"
+        description: the app to build "designer", "runner" or "submitter"
         required: true
         type: string
       publish:
@@ -32,7 +32,7 @@ jobs:
       tag: ${{ steps.hashFile.outputs.tag }}
       hash: ${{ steps.hashFile.outputs.hash }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.6.0
       - name: Use Node.js
         uses: actions/setup-node@v3.6.0
         with:

--- a/submitter/src/submission/plugins/poll.ts
+++ b/submitter/src/submission/plugins/poll.ts
@@ -1,11 +1,24 @@
 import config from "../../config";
+import { QueueService } from "../services";
 
 export const pluginPoll = {
   name: "poll",
   register: async function (server, _options) {
     const { queueService } = server.services([]);
-    setInterval(async () => {
-      await queueService.processSubmissions();
-    }, config.pollingInterval);
+    await poll(queueService);
   },
 };
+
+async function poll(queueService: QueueService) {
+  const submission = await queueService.getSubmissions();
+  if (!submission) {
+    setTimeout(() => {
+      poll(queueService);
+    }, config.pollingInterval);
+  } else {
+    await queueService.submit(submission);
+    setTimeout(() => {
+      poll(queueService);
+    }, config.pollingInterval);
+  }
+}

--- a/submitter/src/submission/plugins/poll.ts
+++ b/submitter/src/submission/plugins/poll.ts
@@ -1,24 +1,28 @@
 import config from "../../config";
 import { QueueService } from "../services";
+import { Logger } from "pino";
 
 export const pluginPoll = {
   name: "poll",
   register: async function (server, _options) {
     const { queueService } = server.services([]);
-    await poll(queueService);
+    await poll(queueService, server.logger);
   },
 };
 
-async function poll(queueService: QueueService) {
+async function poll(queueService: QueueService, logger: Logger) {
   const submission = await queueService.getSubmissions();
   if (!submission) {
-    setTimeout(() => {
-      poll(queueService);
+    logger.info(["poll"], "No unprocessed submissions found. Continuing");
+    setTimeout(async () => {
+      await poll(queueService, logger);
     }, config.pollingInterval);
   } else {
+    logger.info(
+      ["poll"],
+      `Unprocessed submission found. Row ref: ${submission.id}`
+    );
     await queueService.submit(submission);
-    setTimeout(() => {
-      poll(queueService);
-    }, config.pollingInterval);
+    await poll(queueService, logger);
   }
 }

--- a/submitter/src/submission/services/__tests__/queueService.test.ts
+++ b/submitter/src/submission/services/__tests__/queueService.test.ts
@@ -22,8 +22,8 @@ const queueService = new QueueService(server);
 test("Queue service does not process any submissions if none found", async () => {
   (prisma.submission.findMany as jest.Mock).mockResolvedValueOnce([]);
 
-  await queueService.processSubmissions();
-  expect(webhookService.postRequest).not.toBeCalled();
+  const row = await queueService.getSubmissions();
+  expect(row).toBe(undefined);
 });
 
 test("Queue service updates a submission entry with an error if the webhook fails", async () => {
@@ -46,7 +46,8 @@ test("Queue service updates a submission entry with an error if the webhook fail
   });
   const updateWithError = jest.spyOn(queueService, "updateWithError");
 
-  await queueService.processSubmissions();
+  const row = await queueService.getSubmissions();
+  await queueService.submit(row);
   expect(updateWithError).toBeCalled();
 });
 test("Queue service updates a submission entry with a successful response if the webhook was successful", async () => {
@@ -69,7 +70,8 @@ test("Queue service updates a submission entry with a successful response if the
   });
 
   const updateFunc = jest.spyOn(queueService, "updateWithSuccess");
-  await queueService.processSubmissions();
+  const row = await queueService.getSubmissions();
+  await queueService.submit(row);
 
   expect(updateFunc).toBeCalled();
 });

--- a/submitter/src/submission/services/queueService.ts
+++ b/submitter/src/submission/services/queueService.ts
@@ -35,7 +35,7 @@ export class QueueService {
 
   async getSubmissions() {
     try {
-      return await this.prisma.submission.findMany({
+      const submissionRes = await this.prisma.submission.findMany({
         where: {
           complete: false,
           webhook_url: {
@@ -53,21 +53,15 @@ export class QueueService {
             error: { sort: "asc", nulls: "first" },
           },
         ],
+        take: 1,
       });
+      return submissionRes.at(0);
     } catch (e) {
       this.logger.error(
         ["queueService", "processSubmissions"],
         `${ERRORS.DB_FIND_ERROR}: ${e?.message ?? e}`
       );
-      return [];
-    }
-  }
-
-  async processSubmissions() {
-    const submissions = await this.getSubmissions();
-    this.logger.info(`Found ${submissions.length} to submit`);
-    for (const row of submissions) {
-      await this.submit(row);
+      return;
     }
   }
 


### PR DESCRIPTION
# Description

The submitter would run into problems if there were multiple submissions being processed at once, running into issues with duplicating submissions, or hitting memory limits and crashing. This PR should fix these issues by better pacing submission processing.

- Changed poll plugin to be a recursive function. This blocks new submissions from processing while a submission is being processed, but still allows polling on a timed basis
- Changed queue service to only grab one submission at a time. This stops from too many webhook requests to run at the same time

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [X] Manual testing with a local endpoint and db instance

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
