### PR TITLE
fix/submitter-allow-retry-issue

### DIFF
--- a/runner/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/runner/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -132,7 +132,10 @@ export class SummaryViewModel {
             case "webhook":
               return {
                 type: "webhook",
-                outputData: { url: output.outputConfiguration.url },
+                outputData: {
+                  url: output.outputConfiguration.url,
+                  allowRetry: output.outputConfiguration.allowRetry,
+                },
               };
             default:
               return {};


### PR DESCRIPTION
# Description

Submitter was recognising the allow_retry flag, however the summaryViewModel hadn't been updated, meaning that the runner was always passing through `true`. This meant that retrying was always enabled.

- Updated summaryViewModel to pass through allowRetry option if it exists now

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [X] Manually tested with form e2e to check that it works as expected

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
