### PR TITLE
Fix/date parts max min days

### DIFF
--- a/runner/src/server/plugins/engine/components/DatePartsField.ts
+++ b/runner/src/server/plugins/engine/components/DatePartsField.ts
@@ -79,13 +79,9 @@ export class DatePartsField extends FormComponent {
     const { maxDaysInPast, maxDaysInFuture } = options as any;
     let schema: any = this.stateSchema;
 
-    if (maxDaysInPast ?? false) {
-      schema = schema.min(sub(new Date(), { days: maxDaysInPast }));
-    }
-
-    if (maxDaysInFuture ?? false) {
-      schema = schema.max(add(new Date(), { days: maxDaysInFuture }));
-    }
+    schema = schema.custom(
+      helpers.getCustomDateValidator(maxDaysInPast, maxDaysInFuture)
+    );
 
     return { [this.name]: schema };
   }

--- a/runner/src/server/plugins/engine/components/helpers.ts
+++ b/runner/src/server/plugins/engine/components/helpers.ts
@@ -1,6 +1,5 @@
 import joi from "joi";
 import Joi from "joi";
-import { DatePartsField } from "server/plugins/engine/components/DatePartsField";
 import { add, startOfToday, sub } from "date-fns";
 
 /**

--- a/runner/src/server/plugins/engine/components/helpers.ts
+++ b/runner/src/server/plugins/engine/components/helpers.ts
@@ -94,8 +94,8 @@ export const addClassOptionIfNone = (
 };
 
 export function getCustomDateValidator(
-  maxDaysInFuture?: number,
-  maxDaysInPast?: number
+  maxDaysInPast?: number,
+  maxDaysInFuture?: number
 ) {
   return (value: Date, helpers: Joi.CustomHelpers) => {
     if (maxDaysInPast) {

--- a/runner/src/server/plugins/engine/components/helpers.ts
+++ b/runner/src/server/plugins/engine/components/helpers.ts
@@ -95,30 +95,28 @@ export const addClassOptionIfNone = (
 };
 
 export function getCustomDateValidator(
-  maxDaysInPast?: number,
-  maxDaysInFuture?: number
+  maxDaysInFuture?: number,
+  maxDaysInPast?: number
 ) {
   return (value: Date, helpers: Joi.CustomHelpers) => {
-    let minDate = new Date(1000, 1);
-    let maxDate = new Date(3000, 1);
     if (maxDaysInPast) {
-      minDate = sub(startOfToday(), { days: maxDaysInPast });
+      const minDate = sub(startOfToday(), { days: maxDaysInPast });
+      if (value < minDate) {
+        return helpers.error("date.min", {
+          label: helpers.state.key,
+          limit: minDate,
+        });
+      }
     }
     if (maxDaysInFuture) {
-      maxDate = add(startOfToday(), { days: maxDaysInFuture });
+      const maxDate = add(startOfToday(), { days: maxDaysInFuture });
+      if (value > maxDate) {
+        return helpers.error("date.max", {
+          label: helpers.state.key,
+          limit: maxDate,
+        });
+      }
     }
-    if (value <= maxDate && value >= minDate) {
-      return value;
-    }
-    if (value > maxDate) {
-      return helpers.error("date.max", {
-        label: helpers.state.key,
-        limit: maxDate,
-      });
-    }
-    return helpers.error("date.min", {
-      label: helpers.state.key,
-      limit: minDate,
-    });
+    return value;
   };
 }

--- a/runner/test/cases/server/plugins/engine/datepartsfield.test.ts
+++ b/runner/test/cases/server/plugins/engine/datepartsfield.test.ts
@@ -90,3 +90,5 @@ function dateComponent(name, width) {
     attributes: {},
   };
 }
+
+// TODO: write test to make sure maxDaysInPast and maxDaysInFuture work as expected (based on current date instead of server initialisation date)


### PR DESCRIPTION
# Description

Date parts fields were validating min and max date based on when the runner server was initialised, as opposed to the current date. this has been changed to use a custom validator, which provides a new Date instance instead of an old one.

- Removed standard joi.date.in and joi.date.max validators, and replaced with custom validator
- Created new getCustomDateValidator function to pass min and max date to custom validator

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [X] Manual testing with date parts field with various maxDaysInPast and maxDaysInFuture properties

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
