### PR TITLE
add more feeOptions

### DIFF
--- a/docs/runner/fee-options.md
+++ b/docs/runner/fee-options.md
@@ -1,0 +1,47 @@
+# Fee options
+
+`feeOptions` is a top level property in a form json. Fee options are used to configure API keys for GOV.UK Pay, and the behaviour of retrying payments. 
+
+
+```.json5
+{
+  // pages, sections, conditions etc ..
+  "feeOptions": {
+  /**
+   * If a payment is required, but the user fails, allow the user to skip payment
+   * and submit the form. this is the default behaviour.
+   *
+   * Any versions AFTER (and not including) v3.25.68-rc.927 allows this behaviour
+   * to be configurable. If you do not want payment to be skippable, set
+   * `allowSubmissionWithoutPayment: false`
+   */
+  "allowSubmissionWithoutPayment": true,
+
+  /**
+   * The maximum number of times a user can attempt to pay before the form is auto submitted.
+   * There is no limit when allowSubmissionWithoutPayment is false. (The user can retry as many times as they like).
+   */
+  "maxAttempts": 3,
+
+  /**
+   * A supplementary error message (`customPayErrorMessage`)
+   */
+  "customPayErrorMessage": "Custom error message",
+  }
+}
+```
+
+As a failsafe, if a user was not able to pay, we will allow them to try up to 3 times (`maxRetries`), then auto submit (`"allowSubmissionWithoutPayment": true`).
+This is the default behaviour. Makes sure you check your organisations policy or legislative requirements. You must ensure there is a process to remediate payment failures.
+
+When a user fails a payment, they will see the page [pay-error](./../../runner/src/server/views/pay-error.html).
+
+When `allowSubmissionsWithoutPayment` is true, the user will also see a link which allows them to skip payment. 
+
+
+## Recommendations 
+
+If your service does not allow submission without payment, set 
+`allowSubmissionWithoutPayment: false`. `maxAttempts` will have no effect. The user will be able to retry as many times as they like.
+You can provide them with `customPayErrorMessage` to provide them with another route to payment.  
+

--- a/docs/runner/fee-options.md
+++ b/docs/runner/fee-options.md
@@ -31,12 +31,12 @@
 }
 ```
 
-As a failsafe, if a user was not able to pay, we will allow them to try up to 3 times (`maxRetries`), then auto submit (`"allowSubmissionWithoutPayment": true`).
+As a failsafe, if a user was not able to pay, we will allow them to try up to 3 times (`maxAttempts`), then auto submit (`"allowSubmissionWithoutPayment": true`).
 This is the default behaviour. Makes sure you check your organisations policy or legislative requirements. You must ensure there is a process to remediate payment failures.
 
 When a user fails a payment, they will see the page [pay-error](./../../runner/src/server/views/pay-error.html).
 
-When `allowSubmissionsWithoutPayment` is true, the user will also see a link which allows them to skip payment. 
+When `allowSubmissionWithoutPayment` is true, the user will also see a link which allows them to skip payment. 
 
 
 ## Recommendations 

--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -156,4 +156,11 @@ export type FormDefinition = {
   payApiKey?: string | MultipleApiKeys | undefined;
   specialPages?: SpecialPages;
   paymentReferenceFormat?: string;
+  feeOptions: {
+    paymentReferenceFormat?: string;
+    payReturnUrl?: string;
+    allowSubmissionWithoutPayment: boolean;
+    maxAttempts: number;
+    customPayErrorMessage?: "";
+  };
 };

--- a/model/src/schema/__tests__/schema.test.ts
+++ b/model/src/schema/__tests__/schema.test.ts
@@ -72,7 +72,7 @@ describe("payment configuration", () => {
       ...baseConfiguration,
       feeOptions: {
         allowSubmissionWithoutPayment: false,
-        maxRetries: 10,
+        maxAttempts: 10,
         paymentReferenceFormat: "EGGS-",
         payReturnUrl: "https://my.egg.service.scramble",
       },
@@ -84,7 +84,7 @@ describe("payment configuration", () => {
 
     expect(value.feeOptions).toEqual({
       allowSubmissionWithoutPayment: false,
-      maxRetries: 10,
+      maxAttempts: 10,
       paymentReferenceFormat: "EGGS-",
       payReturnUrl: "https://my.egg.service.scramble",
     });
@@ -96,7 +96,7 @@ describe("payment configuration", () => {
       paymentReferenceFormat: "FRIED-",
       feeOptions: {
         allowSubmissionWithoutPayment: true,
-        maxRetries: 3,
+        maxAttempts: 3,
         paymentReferenceFormat: "EGGS-",
         payReturnUrl: "https://my.egg.service.scramble",
       },
@@ -108,7 +108,7 @@ describe("payment configuration", () => {
 
     expect(value.feeOptions).toEqual({
       allowSubmissionWithoutPayment: true,
-      maxRetries: 3,
+      maxAttempts: 3,
       paymentReferenceFormat: "EGGS-",
       payReturnUrl: "https://my.egg.service.scramble",
     });

--- a/model/src/schema/__tests__/schema.test.ts
+++ b/model/src/schema/__tests__/schema.test.ts
@@ -71,6 +71,8 @@ describe("payment configuration", () => {
     const configuration = {
       ...baseConfiguration,
       feeOptions: {
+        allowSubmissionWithoutPayment: false,
+        maxRetries: 10,
         paymentReferenceFormat: "EGGS-",
         payReturnUrl: "https://my.egg.service.scramble",
       },
@@ -81,6 +83,8 @@ describe("payment configuration", () => {
     });
 
     expect(value.feeOptions).toEqual({
+      allowSubmissionWithoutPayment: false,
+      maxRetries: 10,
       paymentReferenceFormat: "EGGS-",
       payReturnUrl: "https://my.egg.service.scramble",
     });
@@ -91,6 +95,8 @@ describe("payment configuration", () => {
       ...baseConfiguration,
       paymentReferenceFormat: "FRIED-",
       feeOptions: {
+        allowSubmissionWithoutPayment: true,
+        maxRetries: 3,
         paymentReferenceFormat: "EGGS-",
         payReturnUrl: "https://my.egg.service.scramble",
       },
@@ -101,6 +107,8 @@ describe("payment configuration", () => {
     });
 
     expect(value.feeOptions).toEqual({
+      allowSubmissionWithoutPayment: true,
+      maxRetries: 3,
       paymentReferenceFormat: "EGGS-",
       payReturnUrl: "https://my.egg.service.scramble",
     });

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -236,7 +236,7 @@ const feeOptionSchema = joi
     paymentReferenceFormat: [joi.string().optional()],
     payReturnUrl: joi.string().optional(),
     allowSubmissionWithoutPayment: joi.boolean().optional().default(true),
-    maxRetries: joi.number().optional().default(3),
+    maxAttempts: joi.number().optional().default(3),
     customPayErrorMessage: joi.string().optional(),
   })
   .default(({ payApiKey, paymentReferenceFormat }) => {

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -236,7 +236,7 @@ const feeOptionSchema = joi
     paymentReferenceFormat: [joi.string().optional()],
     payReturnUrl: joi.string().optional(),
     allowSubmissionWithoutPayment: joi.boolean().optional().default(true),
-    maxRetries: joi.boolean().optional().default(3),
+    maxRetries: joi.number().optional().default(3),
     customPayErrorMessage: joi.string().optional(),
   })
   .default(({ payApiKey, paymentReferenceFormat }) => {

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -235,6 +235,9 @@ const feeOptionSchema = joi
     payApiKey: [joi.string().allow("").optional(), multiApiKeySchema],
     paymentReferenceFormat: [joi.string().optional()],
     payReturnUrl: joi.string().optional(),
+    allowSubmissionWithoutPayment: joi.boolean().optional().default(true),
+    maxRetries: joi.boolean().optional().default(3),
+    customPayErrorMessage: joi.string().optional(),
   })
   .default(({ payApiKey, paymentReferenceFormat }) => {
     return {

--- a/runner/src/server/plugins/applicationStatus/index.ts
+++ b/runner/src/server/plugins/applicationStatus/index.ts
@@ -17,7 +17,7 @@ const index = {
           pre: [
             {
               method: retryPay,
-              assign: "shouldRetryPay",
+              assign: "shouldShowPayErrorPage",
             },
             {
               method: handleUserWithConfirmationViewModel,

--- a/runner/src/server/plugins/applicationStatus/retryPay.ts
+++ b/runner/src/server/plugins/applicationStatus/retryPay.ts
@@ -1,15 +1,27 @@
 import { HapiRequest, HapiResponseToolkit } from "server/types";
+import { FormModel } from "server/plugins/engine/models";
 
 export async function retryPay(request: HapiRequest, h: HapiResponseToolkit) {
   const { statusService } = request.services([]);
-  const shouldRetryPay = await statusService.shouldRetryPay(request);
-  if (shouldRetryPay) {
+  const shouldShowPayErrorPage = await statusService.shouldShowPayErrorPage(
+    request
+  );
+
+  const form: FormModel = request.server.app.forms[request.params.id];
+  const feeOptions = form.feeOptions;
+  const {
+    allowSubmissionWithoutPayment = true,
+    customPayErrorMessage,
+  } = feeOptions;
+  if (shouldShowPayErrorPage) {
     return h
       .view("pay-error", {
         errorList: ["there was a problem with your payment"],
+        allowSubmissionWithoutPayment,
+        customPayErrorMessage,
       })
       .takeover();
   }
 
-  return shouldRetryPay;
+  return shouldShowPayErrorPage;
 }

--- a/runner/src/server/plugins/engine/models/FormModel.feeOptions.ts
+++ b/runner/src/server/plugins/engine/models/FormModel.feeOptions.ts
@@ -8,5 +8,15 @@ export const DEFAULT_FEE_OPTIONS = {
    * `allowSubmissionWithoutPayment: false`
    */
   allowSubmissionWithoutPayment: true,
+
+  /**
+   * The maximum number of times a user can attempt to pay before the form is auto submitted.
+   * There is no limit when allowSubmissionWithoutPayment is false. (The user can retry as many times as they like).
+   */
   maxAttempts: 3,
+
+  /**
+   * A supplementary error message (`customPayErrorMessage`) may also be configured if allowSubmissionWithoutPayment is false.
+   */
+  // customPayErrorMessage: "Custom error message",
 };

--- a/runner/src/server/plugins/engine/models/FormModel.feeOptions.ts
+++ b/runner/src/server/plugins/engine/models/FormModel.feeOptions.ts
@@ -1,0 +1,12 @@
+export const DEFAULT_FEE_OPTIONS = {
+  /**
+   * If a payment is required, but the user fails, allow the user to skip payment
+   * and submit the form. this is the default behaviour.
+   *
+   * Any versions AFTER (and not including) v3.25.61-rc.920 allows this behaviour
+   * to be configurable. If you do not want payment to be skippable, set
+   * `allowSubmissionWithoutPayment: false`
+   */
+  allowSubmissionWithoutPayment: true,
+  maxAttempts: 3,
+};

--- a/runner/src/server/plugins/engine/models/FormModel.ts
+++ b/runner/src/server/plugins/engine/models/FormModel.ts
@@ -15,6 +15,7 @@ import { FormSubmissionState } from "../types";
 import { PageControllerBase, getPageController } from "../pageControllers";
 import { PageController } from "../pageControllers/PageController";
 import { ExecutableCondition } from "server/plugins/engine/models/types";
+import { DEFAULT_FEE_OPTIONS } from "server/plugins/engine/models/FormModel.feeOptions";
 
 class EvaluationContext {
   constructor(conditions, value) {
@@ -50,9 +51,12 @@ export class FormModel {
   pages: any;
   startPage: any;
 
-  feeOptions?: {
+  feeOptions: {
     paymentReferenceFormat?: string;
     payReturnUrl?: string;
+    allowSubmissionWithoutPayment: boolean;
+    maxAttempts: number;
+    customPayErrorMessage?: "";
   };
 
   constructor(def, options) {
@@ -108,7 +112,7 @@ export class FormModel {
     this.pages = def.pages.map((pageDef) => this.makePage(pageDef));
     this.startPage = this.pages.find((page) => page.path === def.startPage);
 
-    this.feeOptions = def.feeOptions;
+    this.feeOptions = { ...DEFAULT_FEE_OPTIONS, ...def.feeOptions };
   }
 
   /**

--- a/runner/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/runner/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -73,7 +73,7 @@ export class SummaryViewModel {
     this.declaration = def.declaration;
     // @ts-ignore
     this.skipSummary = def.skipSummary;
-    this._payApiKey = def.payApiKey;
+    this._payApiKey = def.feeOptions?.payApiKey ?? def.payApiKey;
     this.endPage = endPage;
     this.feedbackLink =
       def.feedback?.url ??

--- a/runner/src/server/views/pay-error.html
+++ b/runner/src/server/views/pay-error.html
@@ -6,13 +6,18 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     {% set tmpl = 'There was a problem with your payment' %}
-
     {{ govukErrorSummary({
       titleText: tmpl,
       errorList: [
-        { text: "The payment failed" }
+        { text: "The payment failed"  }
       ]
     }) }}
+
+    {% if not allowSubmissionsWithoutPayment %}
+    <p class="govuk-body">
+      {{ customPayErrorMessage | safe }}
+    </p>
+    {% endif %}
     <form method="post" autocomplete="off" novalidate>
       <input type="hidden" name="crumb" value="{{crumb}}" />
       {{ govukButton({ attributes: { id: "submit" }, text: "Retry" }) }}

--- a/runner/src/server/views/pay-error.html
+++ b/runner/src/server/views/pay-error.html
@@ -9,7 +9,7 @@
     {{ govukErrorSummary({
       titleText: tmpl,
       errorList: [
-        { text: "The payment failed"  }
+        { text: "The payment failed" }
       ]
     }) }}
 

--- a/runner/src/server/views/pay-error.html
+++ b/runner/src/server/views/pay-error.html
@@ -24,7 +24,7 @@
       {{ govukButton({ attributes: { id: "submit" }, text: "Retry" }) }}
     </form>
 
-    {% if allowSubmissionsWithoutPayment %}
+    {% if allowSubmissionWithoutPayment %}
     <p class="govuk-body">
       <a href="?continue=true" class="govuk-link">Continue without paying</a>. Someone will be in touch about your application.
     </p>

--- a/runner/src/server/views/pay-error.html
+++ b/runner/src/server/views/pay-error.html
@@ -18,13 +18,17 @@
       {{ customPayErrorMessage | safe }}
     </p>
     {% endif %}
+
     <form method="post" autocomplete="off" novalidate>
       <input type="hidden" name="crumb" value="{{crumb}}" />
       {{ govukButton({ attributes: { id: "submit" }, text: "Retry" }) }}
     </form>
+
+    {% if allowSubmissionsWithoutPayment %}
     <p class="govuk-body">
       <a href="?continue=true" class="govuk-link">Continue without paying</a>. Someone will be in touch about your application.
     </p>
+    {% endif %}
   </div>
 </div>
 {% endblock %}

--- a/runner/src/server/views/pay-error.html
+++ b/runner/src/server/views/pay-error.html
@@ -13,7 +13,7 @@
       ]
     }) }}
 
-    {% if not allowSubmissionsWithoutPayment %}
+    {% if customPayErrorMessage %}
     <p class="govuk-body">
       {{ customPayErrorMessage | safe }}
     </p>


### PR DESCRIPTION
# Description

As a failsafe, if a user was not able to pay, we will allow them to try up to 3 times, then auto submit.

This feature now allows this behaviour to be configurable. 

You must migrate any top level fee related options into the new feeOptions key. These are `paymentReferenceFormat` and `payApiKey`. 


in the form json,


```.json5
{ //..
  feeOptions: {
    "payApiKey": {
       "test": "test_key_123",
       "production": "production_key"
    },

    // optional
    // "paymentReferenceFormat": "",
    
    // optional, if you want to override PAY_RETURN_URL global env var
    // "payReturnUrl": joi.string().optional(),

    // defaults to true to replicate existing behaviour
    // set to false if you do not want to allow users to submit without paying
    "allowSubmissionWithoutPayment": false,
    
    // defaults to 3. this has no affect if allowSubmissionWithoutPayment is false. 
    // the user can try as many times as they like.
    "maxAttempts": 3,
    
    // error message to show on pay error page. escaped HTML is allowed.
    "customPayErrorMessage": ":(" 
  }
}
```


**changes made**
- change `shouldRetryPay` to `shouldShowPayErrorPage`. 