### PR TITLE
fix/optional-text-lowercase

### DIFF
--- a/e2e/cypress/e2e/runner/completeAForm.feature
+++ b/e2e/cypress/e2e/runner/completeAForm.feature
@@ -11,7 +11,7 @@ Feature: Complete a form
     * I continue
     * I choose "No, I don't have evidence"
     * I continue
-    * I enter "the additional info" for "Additional Info (Optional)"
+    * I enter "the additional info" for "Additional Info (optional)"
     * I continue
     Then I see a summary list with the values
       | title                               | value                     |
@@ -51,7 +51,7 @@ Feature: Complete a form
     * I enter "jen+forms@cautionyourblast.com" for "Email address field"
     * I enter "123" for "Telephone number field"
     * I enter "line 1" for "Address line 1"
-    * I enter "line 2" for "Address line 2 (Optional)"
+    * I enter "line 2" for "Address line 2 (optional)"
     * I enter "London" for "Town or city"
     * I enter "ec2a4ps" for "Postcode"
     * I choose "Sole trader"
@@ -67,7 +67,7 @@ Feature: Complete a form
     When I choose "Yes"
     And I continue
     * I enter "line 1" for "Address line 1"
-    * I enter "line 2" for "Address line 2 (Optional)"
+    * I enter "line 2" for "Address line 2 (optional)"
     * I enter "London" for "Town or city"
     * I enter "ec2a4ps" for "Postcode"
     * I enter "2025-12-25" for "What date was the vehicle registered at this address?"

--- a/runner/src/server/plugins/engine/components/constants.ts
+++ b/runner/src/server/plugins/engine/components/constants.ts
@@ -1,1 +1,1 @@
-export const optionalText = " (Optional)";
+export const optionalText = " (optional)";

--- a/runner/test/cases/server/plugins/engine/datepartsfield.test.ts
+++ b/runner/test/cases/server/plugins/engine/datepartsfield.test.ts
@@ -44,7 +44,7 @@ suite("Date parts field", () => {
     expect(returned.fieldset).to.equal({
       legend: {
         classes: "govuk-label--s",
-        text: `${def.title} (Optional)`,
+        text: `${def.title} (optional)`,
       },
     });
     expect(returned.items).to.equal([

--- a/runner/test/cases/server/plugins/engine/datetimepartsfield.test.ts
+++ b/runner/test/cases/server/plugins/engine/datetimepartsfield.test.ts
@@ -46,7 +46,7 @@ suite("Date time parts field", () => {
     expect(returned.fieldset).to.equal({
       legend: {
         classes: "govuk-label--s",
-        text: `${def.title} (Optional)`,
+        text: `${def.title} (optional)`,
       },
     });
     expect(returned.items).to.equal([


### PR DESCRIPTION
# Description

Optional text for optional fields was capitalised. Per the [gov.uk design system docs](https://design-system.service.gov.uk/patterns/question-pages/) it should be lowercase.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [X] Manual testing with form with optional components
- [X] Ran runner tests checking for extra optional text

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
