### PR TITLE
fix: prevent prisma from initialising preemtively

### DIFF
--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -37,7 +37,7 @@ module.exports = {
     return this.env === "test";
   }),
   isSandbox: deferConfig(function () {
-    return evalBooleanEnvVar(this.sandbox);
+    return this.sandbox === true || this.sandbox === "true";
   }),
 
   /**

--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -37,7 +37,7 @@ module.exports = {
     return this.env === "test";
   }),
   isSandbox: deferConfig(function () {
-    return this.sandbox === true || this.sandbox === "true";
+    return evalBooleanEnvVar(this.sandbox);
   }),
 
   /**
@@ -133,7 +133,6 @@ module.exports = {
    * Failure queue
    */
   enableQueueService: false,
-  queueDatabaseUrl: "",
-  queueDatabasePassword: "",
+  // queueDatabaseUrl: "mysql://root:root@localhost:3306/queue"
   queueServicePollingInterval: "500",
 };

--- a/runner/config/development.json
+++ b/runner/config/development.json
@@ -2,7 +2,5 @@
   "isTest": true,
   "previewMode": true,
   "enforceCsrf": false,
-  "env": "development",
-  "enableQueueService": true,
-  "queueDatabaseUrl": "mysql://root:root@localhost:3306/queue"
+  "env": "development"
 }

--- a/runner/src/server/prismaClient.ts
+++ b/runner/src/server/prismaClient.ts
@@ -36,7 +36,10 @@ export const prisma: PrismaClient = new PrismaClient({
 if (config.enableQueueService) {
   prismaLogger.info("ENABLE_QUEUE_SERVICE is true, connecting to Prisma");
   prisma.$connect().catch((error) => {
-    prismaLogger.error(`Prisma Connect Error ${error.message}`);
+    prismaLogger.fatal(
+      `ENABLE_QUEUE_SERVICE is set to true, but Prisma failed to connect ${error}, exiting with status 1`
+    );
+    process.exit(1);
   });
 
   process.on("query", (e: Prisma.QueryEvent) => {

--- a/runner/src/server/prismaClient.ts
+++ b/runner/src/server/prismaClient.ts
@@ -33,32 +33,35 @@ export const prisma: PrismaClient = new PrismaClient({
   log: logLevel,
 });
 
-prisma.$connect().catch((error) => {
-  prismaLogger.error(`Prisma Connect Error ${error.message}`);
-});
+if (config.enableQueueService) {
+  prismaLogger.info("ENABLE_QUEUE_SERVICE is true, connecting to Prisma");
+  prisma.$connect().catch((error) => {
+    prismaLogger.error(`Prisma Connect Error ${error.message}`);
+  });
 
-process.on("query", (e: Prisma.QueryEvent) => {
-  if (!config.isTest) {
-    prismaLogger.info(`
+  process.on("query", (e: Prisma.QueryEvent) => {
+    if (!config.isTest) {
+      prismaLogger.info(`
       Prisma Query: ${e.query} \r\n
       Duration: ${e.duration}ms \r\n
       Params: ${e.params}
     `);
-  }
-});
+    }
+  });
 
-process.on("warn", (e) => {
-  prismaLogger.warn(e);
-});
+  process.on("warn", (e) => {
+    prismaLogger.warn(e);
+  });
 
-process.on("info", (e) => {
-  prismaLogger.info(e);
-});
+  process.on("info", (e) => {
+    prismaLogger.info(e);
+  });
 
-process.on("error", (e) => {
-  prismaLogger.error(e);
-});
+  process.on("error", (e) => {
+    prismaLogger.error(e);
+  });
 
-process.on("beforeExit", () => {
-  prismaLogger.info("Prisma is exiting");
-});
+  process.on("beforeExit", () => {
+    prismaLogger.info("Prisma is exiting");
+  });
+}

--- a/runner/src/server/utils/configSchema.ts
+++ b/runner/src/server/utils/configSchema.ts
@@ -104,18 +104,12 @@ export const configSchema = Joi.object({
 
   enableQueueService: Joi.boolean().optional(),
   queueDatabaseUrl: Joi.string().when("enableQueueService", {
+    is: true,
     then: Joi.required(),
-    otherwise: Joi.optional(),
-  }),
-  queueDatabaseUsername: Joi.string().when("enableQueueService", {
-    then: Joi.required(),
-    otherwise: Joi.optional(),
-  }),
-  queueDatabasePassword: Joi.string().when("enableQueueService", {
-    then: Joi.required(),
-    otherwise: Joi.optional(),
+    otherwise: Joi.optional().allow(""),
   }),
   queueServicePollingInterval: Joi.number().when("enableQueueService", {
+    is: true,
     then: Joi.required(),
     otherwise: Joi.optional(),
   }),

--- a/runner/src/server/utils/configSchema.ts
+++ b/runner/src/server/utils/configSchema.ts
@@ -101,6 +101,24 @@ export const configSchema = Joi.object({
       "HS512"
     )
     .default("HS512"),
+
+  enableQueueService: Joi.boolean().optional(),
+  queueDatabaseUrl: Joi.string().when("enableQueueService", {
+    then: Joi.required(),
+    otherwise: Joi.optional(),
+  }),
+  queueDatabaseUsername: Joi.string().when("enableQueueService", {
+    then: Joi.required(),
+    otherwise: Joi.optional(),
+  }),
+  queueDatabasePassword: Joi.string().when("enableQueueService", {
+    then: Joi.required(),
+    otherwise: Joi.optional(),
+  }),
+  queueServicePollingInterval: Joi.number().when("enableQueueService", {
+    then: Joi.required(),
+    otherwise: Joi.optional(),
+  }),
 });
 
 export function buildConfig(config) {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

- Prevents prisma from attempting to connect if ENABLE_QUEUE_SERVICE is true
- exits runner with exit code 1 if QUEUE_DATABASE_URL is not configured
- ensure queue service is not turned on by default