### PR TITLE
feat: add pay warning page

### DIFF
--- a/docs/runner/fee-options.md
+++ b/docs/runner/fee-options.md
@@ -1,33 +1,41 @@
-# Fee options
+# Fee options and Payment skipped warning page
 
-`feeOptions` is a top level property in a form json. Fee options are used to configure API keys for GOV.UK Pay, and the behaviour of retrying payments. 
+## Fee options
 
+`feeOptions` is a top level property in a form json. Fee options are used to configure API keys for GOV.UK Pay, and the behaviour of retrying payments.
 
-```.json5
+```json5
 {
   // pages, sections, conditions etc ..
-  "feeOptions": {
-  /**
-   * If a payment is required, but the user fails, allow the user to skip payment
-   * and submit the form. this is the default behaviour.
-   *
-   * Any versions AFTER (and not including) v3.25.68-rc.927 allows this behaviour
-   * to be configurable. If you do not want payment to be skippable, set
-   * `allowSubmissionWithoutPayment: false`
-   */
-  "allowSubmissionWithoutPayment": true,
+  feeOptions: {
+    /**
+     * If a payment is required, but the user fails, allow the user to skip payment
+     * and submit the form. this is the default behaviour.
+     *
+     * Any versions AFTER (and not including) v3.25.68-rc.927 allows this behaviour
+     * to be configurable. If you do not want payment to be skippable, set
+     * `allowSubmissionWithoutPayment: false`
+     */
+    allowSubmissionWithoutPayment: true,
 
-  /**
-   * The maximum number of times a user can attempt to pay before the form is auto submitted.
-   * There is no limit when allowSubmissionWithoutPayment is false. (The user can retry as many times as they like).
-   */
-  "maxAttempts": 3,
+    /**
+     * The maximum number of times a user can attempt to pay before the form is auto submitted.
+     * There is no limit when allowSubmissionWithoutPayment is false. (The user can retry as many times as they like).
+     */
+    maxAttempts: 3,
 
-  /**
-   * A supplementary error message (`customPayErrorMessage`)
-   */
-  "customPayErrorMessage": "Custom error message",
-  }
+    /**
+     * A supplementary error message (`customPayErrorMessage`)
+     */
+    customPayErrorMessage: "Custom error message",
+
+    /**
+     * Shows a link (button) below the "Submit and pay" button on the summary page. Clicking this will take the user to a page
+     * that provides additional messaging, you can warn the user that this may delay their application for example.
+     * allowSubmissionWithoutPayment must be true for this to be shown.
+     */
+    showPaymentSkippedWarningPage: false,
+  },
 }
 ```
 
@@ -36,12 +44,32 @@ This is the default behaviour. Makes sure you check your organisations policy or
 
 When a user fails a payment, they will see the page [pay-error](./../../runner/src/server/views/pay-error.html).
 
-When `allowSubmissionWithoutPayment` is true, the user will also see a link which allows them to skip payment. 
+When `allowSubmissionWithoutPayment` is true, the user will also see a link which allows them to skip payment.
 
+### Recommendations
 
-## Recommendations 
-
-If your service does not allow submission without payment, set 
+If your service does not allow submission without payment, set
 `allowSubmissionWithoutPayment: false`. `maxAttempts` will have no effect. The user will be able to retry as many times as they like.
-You can provide them with `customPayErrorMessage` to provide them with another route to payment.  
+You can provide them with `customPayErrorMessage` to provide them with another route to payment.
 
+## paymentSkippedWarningPage
+
+`paymentSkippedWarningPage` can be found on the `specialPages` top level property.
+
+If `feeOptions.showPaymentSkippedWarningPage` (and `feeOptions.allowSubmissionWithoutPayment`) is true,
+another page ([payment-skip-warning](./../../runner/src/server/views/payment-skip-warning.html)) will be presented to the user.
+Additional messaging can be provided to the user for alternative routes to payment, or may result in application delays.
+The can choose to continue or try online payment. This page will be shown only once.
+
+```json5
+{
+  // pages, sections, conditions etc ..
+  paymentSkippedWarningPage: {
+    customText: {
+      caption: "Payment",
+      title: "Pay at appointment",
+      body: '<p class="govuk-body">You have chosen to skip payment. You will not be able to submit your application until you have paid.</p><p class="govuk-body">If you are unable to pay online, you\'ll need to bring the equivalent of £50 in cash in the local currency to your appointment. You wil not be given any change. <a href="">Check current consular exchange rates</a></p>',
+    },
+  },
+}
+```

--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -151,7 +151,7 @@ export type FeeOptions = {
   allowSubmissionWithoutPayment: boolean;
   maxAttempts: number;
   customPayErrorMessage?: string;
-  showPaymentSkippedWarningPage?: boolean;
+  showPaymentSkippedWarningPage: boolean;
 };
 
 /**

--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -117,8 +117,17 @@ export type ConfirmationPage = {
   components: ComponentDef[];
 };
 
+export type PaymentSkippedWarningPage = {
+  customText: {
+    title: string;
+    caption: string;
+    body: string;
+  };
+};
+
 export type SpecialPages = {
   confirmationPage?: ConfirmationPage;
+  paymentSkippedWarningPage?: PaymentSkippedWarningPage;
 };
 
 export function isMultipleApiKey(
@@ -134,6 +143,15 @@ export type Fee = {
   multiplier?: string;
   condition?: string;
   prefix?: string;
+};
+
+export type FeeOptions = {
+  paymentReferenceFormat?: string;
+  payReturnUrl?: string;
+  allowSubmissionWithoutPayment: boolean;
+  maxAttempts: number;
+  customPayErrorMessage?: string;
+  showPaymentSkippedWarningPage?: boolean;
 };
 
 /**
@@ -156,11 +174,5 @@ export type FormDefinition = {
   payApiKey?: string | MultipleApiKeys | undefined;
   specialPages?: SpecialPages;
   paymentReferenceFormat?: string;
-  feeOptions: {
-    paymentReferenceFormat?: string;
-    payReturnUrl?: string;
-    allowSubmissionWithoutPayment: boolean;
-    maxAttempts: number;
-    customPayErrorMessage?: string;
-  };
+  feeOptions: FeeOptions;
 };

--- a/model/src/schema/__tests__/schema.test.ts
+++ b/model/src/schema/__tests__/schema.test.ts
@@ -87,6 +87,7 @@ describe("payment configuration", () => {
       maxAttempts: 10,
       paymentReferenceFormat: "EGGS-",
       payReturnUrl: "https://my.egg.service.scramble",
+      showPaymentSkippedWarningPage: false,
     });
   });
 
@@ -111,6 +112,7 @@ describe("payment configuration", () => {
       maxAttempts: 3,
       paymentReferenceFormat: "EGGS-",
       payReturnUrl: "https://my.egg.service.scramble",
+      showPaymentSkippedWarningPage: false,
     });
   });
 });

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -132,8 +132,17 @@ const confirmationPageSchema = joi.object({
   components: joi.array().items(componentSchema),
 });
 
+const paymentSkippedWarningPage = joi.object({
+  customText: joi.object({
+    title: joi.string().default("Pay for your application").optional(),
+    caption: joi.string().default("Payment").optional(),
+    body: joi.string().default("").optional(),
+  }),
+});
+
 const specialPagesSchema = joi.object().keys({
-  confirmationPage: confirmationPageSchema,
+  confirmationPage: confirmationPageSchema.optional(),
+  paymentSkippedWarningPage: paymentSkippedWarningPage.optional(),
 });
 
 const listItemSchema = joi.object().keys({
@@ -239,6 +248,11 @@ const feeOptionSchema = joi
     allowSubmissionWithoutPayment: joi.boolean().optional().default(true),
     maxAttempts: joi.number().optional().default(3),
     customPayErrorMessage: joi.string().optional(),
+    showPaymentSkippedWarningPage: joi.when("allowSubmissionWithoutPayment", {
+      is: true,
+      then: joi.boolean().valid(true, false).default(false),
+      otherwise: joi.boolean().valid(false).default(false),
+    }),
   })
   .default(({ payApiKey, paymentReferenceFormat }) => {
     return {

--- a/runner/src/client/sass/application.scss
+++ b/runner/src/client/sass/application.scss
@@ -4,7 +4,6 @@
 @import "modal-dialog";
 @import "upload-dialog";
 
-
 .flash-card {
   .govuk-button {
     background: #fff;
@@ -66,11 +65,23 @@
     &--hidden-titles {
       @extend .govuk-visually-hidden;
     }
-
   }
   &__key {
     &--hidden-titles {
       width: 100%;
+    }
+  }
+}
+
+.govuk-button {
+  &--link {
+    @extend .govuk-link;
+    border: none;
+    color: $govuk-link-colour;
+    cursor: pointer;
+    background-color: transparent;
+    &:hover {
+      color: $govuk-link-hover-colour;
     }
   }
 }

--- a/runner/src/server/plugins/applicationStatus/index.ts
+++ b/runner/src/server/plugins/applicationStatus/index.ts
@@ -3,7 +3,12 @@ import { HapiRequest, HapiResponseToolkit } from "../../types";
 import { retryPay } from "./retryPay";
 import { handleUserWithConfirmationViewModel } from "./handleUserWithConfirmationViewModel";
 import { checkUserCompletedSummary } from "./checkUserCompletedSummary";
-import config from "server/config";
+
+import Joi from "joi";
+import {
+  continueToPayAfterPaymentSkippedWarning,
+  paymentSkippedWarning,
+} from "./paymentSkippedWarning";
 
 const index = {
   plugin: {
@@ -95,6 +100,24 @@ const index = {
             },
           });
           return redirectTo(request, h, res._links.next_url.href);
+        },
+      });
+
+      server.route({
+        method: "get",
+        path: "/{id}/status/payment-skip-warning",
+        handler: paymentSkippedWarning,
+      });
+
+      server.route({
+        method: "post",
+        path: "/{id}/status/payment-skip-warning",
+        handler: continueToPayAfterPaymentSkippedWarning,
+        rules: {
+          payload: {
+            action: Joi.string().valid("continue", "pay").required(),
+            crumb: Joi.string(),
+          },
         },
       });
     },

--- a/runner/src/server/plugins/applicationStatus/index.ts
+++ b/runner/src/server/plugins/applicationStatus/index.ts
@@ -42,7 +42,6 @@ const index = {
           ],
           handler: async (request: HapiRequest, h: HapiResponseToolkit) => {
             const { statusService, cacheService } = request.services([]);
-            console.log(request.query);
             const { params } = request;
             const form = server.app.forms[params.id];
 

--- a/runner/src/server/plugins/applicationStatus/paymentSkippedWarning.ts
+++ b/runner/src/server/plugins/applicationStatus/paymentSkippedWarning.ts
@@ -28,10 +28,6 @@ export async function continueToPayAfterPaymentSkippedWarning(
   const { cacheService } = request.services([]);
   const state = await cacheService.getState(request);
 
-  if (request.payload.action === "continue") {
-    return h.redirect(`./../status`);
-  }
-
   const payState = state.pay;
   payState.meta++;
   await cacheService.mergeState(request, payState);

--- a/runner/src/server/plugins/applicationStatus/paymentSkippedWarning.ts
+++ b/runner/src/server/plugins/applicationStatus/paymentSkippedWarning.ts
@@ -1,0 +1,41 @@
+import { HapiRequest, HapiResponseToolkit } from "server/types";
+import { FormModel } from "server/plugins/engine/models";
+
+export async function paymentSkippedWarning(
+  request: HapiRequest,
+  h: HapiResponseToolkit
+) {
+  const form: FormModel = request.server.app.forms[request.params.id];
+  const { allowSubmissionWithoutPayment } = form.feeOptions;
+
+  if (allowSubmissionWithoutPayment) {
+    const { customText } = form.specialPages.paymentSkippedWarningPage;
+    return h
+      .view("payment-skip-warning", {
+        customText,
+        backLink: "./../summary",
+      })
+      .takeover();
+  }
+
+  return h.redirect(`${request.params.id}/status`);
+}
+
+export async function continueToPayAfterPaymentSkippedWarning(
+  request: HapiRequest,
+  h: HapiResponseToolkit
+) {
+  const { cacheService } = request.services([]);
+  const state = await cacheService.getState(request);
+
+  if (request.payload.action === "continue") {
+    return h.redirect(`./../status`);
+  }
+
+  const payState = state.pay;
+  payState.meta++;
+  await cacheService.mergeState(request, payState);
+
+  const payRedirectUrl = payState.next_url;
+  return h.redirect(payRedirectUrl);
+}

--- a/runner/src/server/plugins/applicationStatus/paymentSkippedWarning.ts
+++ b/runner/src/server/plugins/applicationStatus/paymentSkippedWarning.ts
@@ -9,7 +9,7 @@ export async function paymentSkippedWarning(
   const { allowSubmissionWithoutPayment } = form.feeOptions;
 
   if (allowSubmissionWithoutPayment) {
-    const { customText } = form.specialPages.paymentSkippedWarningPage;
+    const { customText } = form.specialPages?.paymentSkippedWarningPage ?? {};
     return h
       .view("payment-skip-warning", {
         customText,

--- a/runner/src/server/plugins/engine/models/FormModel.feeOptions.ts
+++ b/runner/src/server/plugins/engine/models/FormModel.feeOptions.ts
@@ -1,4 +1,6 @@
-export const DEFAULT_FEE_OPTIONS = {
+import { FormDefinition } from "@xgovformbuilder/model";
+
+export const DEFAULT_FEE_OPTIONS: FormDefinition["feeOptions"] = {
   /**
    * If a payment is required, but the user fails, allow the user to skip payment
    * and submit the form. this is the default behaviour.
@@ -19,4 +21,11 @@ export const DEFAULT_FEE_OPTIONS = {
    * A supplementary error message (`customPayErrorMessage`) may also be configured if allowSubmissionWithoutPayment is false.
    */
   // customPayErrorMessage: "Custom error message",
+
+  /**
+   * Shows a link (button) below the "Submit and pay" button on the summary page. Clicking this will take the user to a page
+   * that provides additional messaging, you can warn the user that this may delay their application for example.
+   * allowSubmissionWithoutPayment must be true for this to be shown.
+   */
+  showPaymentSkippedWarningPage: false,
 };

--- a/runner/src/server/plugins/engine/models/FormModel.ts
+++ b/runner/src/server/plugins/engine/models/FormModel.ts
@@ -51,13 +51,8 @@ export class FormModel {
   pages: any;
   startPage: any;
 
-  feeOptions: {
-    paymentReferenceFormat?: string;
-    payReturnUrl?: string;
-    allowSubmissionWithoutPayment: boolean;
-    maxAttempts: number;
-    customPayErrorMessage?: "";
-  };
+  feeOptions: FormDefinition["feeOptions"];
+  specialPages: FormDefinition["specialPages"];
 
   constructor(def, options) {
     const result = Schema.validate(def, { abortEarly: false });
@@ -111,7 +106,7 @@ export class FormModel {
     // @ts-ignore
     this.pages = def.pages.map((pageDef) => this.makePage(pageDef));
     this.startPage = this.pages.find((page) => page.path === def.startPage);
-
+    this.specialPages = def.specialPages;
     this.feeOptions = { ...DEFAULT_FEE_OPTIONS, ...def.feeOptions };
   }
 

--- a/runner/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/runner/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -150,12 +150,8 @@ export class SummaryViewModel {
     this.value = result.value;
     this.callback = state.callback;
     const { feeOptions } = model;
-    const {
-      showPaymentSkippedWarningPage,
-      allowSubmissionWithoutPayment,
-    } = feeOptions;
     this.showPaymentSkippedWarningPage =
-      showPaymentSkippedWarningPage && allowSubmissionWithoutPayment;
+      feeOptions.showPaymentSkippedWarningPage ?? false;
   }
 
   private processErrors(result, details) {

--- a/runner/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/runner/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -58,7 +58,7 @@ export class SummaryViewModel {
   _payApiKey: FormDefinition["payApiKey"];
   _webhookData: WebhookData | undefined;
   callback?: InitialiseSessionOptions;
-
+  showPaymentSkippedWarningPage: boolean = false;
   constructor(
     pageTitle: string,
     model: FormModel,
@@ -149,6 +149,13 @@ export class SummaryViewModel {
     this.state = state;
     this.value = result.value;
     this.callback = state.callback;
+    const { feeOptions } = model;
+    const {
+      showPaymentSkippedWarningPage,
+      allowSubmissionWithoutPayment,
+    } = feeOptions;
+    this.showPaymentSkippedWarningPage =
+      showPaymentSkippedWarningPage && allowSubmissionWithoutPayment;
   }
 
   private processErrors(result, details) {

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -175,8 +175,6 @@ export class SummaryPageController extends PageController {
         webhookData: summaryViewModel.validatedWebhookData,
       });
 
-      const { skipPayment } = request.payload;
-
       /**
        * If a user does not need to pay, redirect them to /status
        */
@@ -202,6 +200,7 @@ export class SummaryPageController extends PageController {
         url
       );
 
+      // TODO:- refactor - this is repeated in applicationStatus
       const payState = {
         pay: {
           payId: res.payment_id,
@@ -226,16 +225,10 @@ export class SummaryPageController extends PageController {
       });
 
       const payRedirectUrl = payState.pay.next_url;
-      const {
-        showPaymentSkippedWarningPage,
-        allowSubmissionWithoutPayment,
-      } = this.model.feeOptions;
+      const { showPaymentSkippedWarningPage } = this.model.feeOptions;
 
-      if (
-        skipPayment === "true" &&
-        showPaymentSkippedWarningPage &&
-        allowSubmissionWithoutPayment
-      ) {
+      const { skipPayment } = request.payload;
+      if (skipPayment === "true" && showPaymentSkippedWarningPage) {
         payState.pay.meta.attempts = 0;
         await cacheService.mergeState(request, payState);
         return h

--- a/runner/src/server/services/payService.ts
+++ b/runner/src/server/services/payService.ts
@@ -87,11 +87,12 @@ export class PayService {
 
   referenceFromFees(prefixes = [], referenceFormat = "") {
     if (!referenceFormat) {
+      const reference = nanoid(10);
       this.logger.info(
         ["payService", "referenceFromFees"],
-        `no reference format provided, generating random reference`
+        `no reference format provided, generated random reference: ${reference}`
       );
-      return nanoid(10);
+      return reference;
     }
 
     this.logger.info(

--- a/runner/src/server/services/payService.ts
+++ b/runner/src/server/services/payService.ts
@@ -86,13 +86,18 @@ export class PayService {
   }
 
   referenceFromFees(prefixes = [], referenceFormat = "") {
-    this.logger.info(
-      ["payService", "referenceFromFees"],
-      `requested pay reference format ${referenceFormat}`
-    );
     if (!referenceFormat) {
+      this.logger.info(
+        ["payService", "referenceFromFees"],
+        `no reference format provided, generating random reference`
+      );
       return nanoid(10);
     }
+
+    this.logger.info(
+      ["payService", "referenceFromFees"],
+      `requested pay reference format: "${referenceFormat}"`
+    );
 
     let reference = referenceFormat;
     reference = reference.replace(REFERENCE_TAG.PREFIX, prefixes.join("-"));

--- a/runner/src/server/views/payment-skip-warning.html
+++ b/runner/src/server/views/payment-skip-warning.html
@@ -17,7 +17,7 @@
     <form method="post">
       <input type="hidden" name="crumb" value="{{crumb}}"/>
       <div class="govuk-button-group">
-        <button class="govuk-button" name="action" value="continue" data-module="govuk-button">Continue</button>
+        <a class="govuk-button" href="./../status?continue=true">Continue</a>
         <button class="govuk-link govuk-button--link" name="action" value="pay" data-module="govuk-button">Pay online instead</button>
       </div>
     </form>

--- a/runner/src/server/views/payment-skip-warning.html
+++ b/runner/src/server/views/payment-skip-warning.html
@@ -1,0 +1,26 @@
+{% extends 'layout.html' %}
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-caption-l govuk-!-margin-top-0">
+      {{customText.caption if customText.caption else 'Payment'}}</h2>
+    <h1 class="govuk-heading-l">
+      {{customText.title}}
+    </h1>
+    <div class="govuk-body">
+      {% if customText.body %}
+        {{ customText.body | safe }}
+      {% else %}
+        Only continue if you are unable to pay online, because for example you do not have a debit or credit card.
+      {% endif %}
+    </div>
+    <form method="post">
+      <input type="hidden" name="crumb" value="{{crumb}}"/>
+      <div class="govuk-button-group">
+        <button class="govuk-button" name="action" value="continue" data-module="govuk-button">Continue</button>
+        <button class="govuk-link govuk-button--link" name="action" value="pay" data-module="govuk-button">Pay online instead</button>
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/runner/src/server/views/payment-skip-warning.html
+++ b/runner/src/server/views/payment-skip-warning.html
@@ -17,7 +17,7 @@
     <form method="post">
       <input type="hidden" name="crumb" value="{{crumb}}"/>
       <div class="govuk-button-group">
-        <a class="govuk-button" href="./../status?continue=true">Continue</a>
+        <a class="govuk-button" href="../status?continue=true">Continue</a>
         <button class="govuk-link govuk-button--link" name="action" value="pay" data-module="govuk-button">Pay online instead</button>
       </div>
     </form>

--- a/runner/src/server/views/payment-skip-warning.html
+++ b/runner/src/server/views/payment-skip-warning.html
@@ -5,7 +5,7 @@
     <h2 class="govuk-caption-l govuk-!-margin-top-0">
       {{customText.caption if customText.caption else 'Payment'}}</h2>
     <h1 class="govuk-heading-l">
-      {{customText.title}}
+      {{customText.title if customText.title else 'You are about to skip payment'}}
     </h1>
     <div class="govuk-body">
       {% if customText.body %}

--- a/runner/src/server/views/summary.html
+++ b/runner/src/server/views/summary.html
@@ -36,6 +36,7 @@
             {% endfor %}
           </ul>
           <p class="govuk-body">Total cost: £{{fees.total / 100 }}</p>
+          <p class="govuk-body">You should not be charged an exchange fee if you pay with a UK credit or debit card.</p>
         {% endif %}
 
         {% if not result.error  %}
@@ -69,6 +70,15 @@
                         Submit
                     {% endif %}
                 </button>
+
+                {% if showPaymentSkippedWarningPage %}
+                <div class="govuk-body">
+                  <button data-prevent-double-click="true" class="govuk-body govuk-button--link" name="skipPayment" value="true" data-module="govuk-button">
+                    Unable to pay online
+                  </button>
+                </div>
+              {% endif %}
+
             </form>
         {% endif %}
       </div>


### PR DESCRIPTION
# Description

Allow the user to skip payment from the summary page, but allow a warning page to be configured.

https://github.com/XGovFormBuilder/digital-form-builder/assets/22080510/747158e1-b0e2-4bff-b7f5-5e1248676629


- add a new feeOption (bool) `showPaymentSkippedWarningPage`. `allowSubmissionWithoutPayment` must also be true.
- add a new specialPage, `specialPages.paymentSkippedWarningPage`
- add a GET route `/{id}/status/payment-skip-warning`
  - this will render `runner/src/server/views/payment-skip-warning.html`
  - content is configurable via paymentSkippedWarningPage

## Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [x] Manual


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
