### PR TITLE
Updated confirmation page template layout

### DIFF
--- a/runner/src/server/views/confirmation.html
+++ b/runner/src/server/views/confirmation.html
@@ -23,23 +23,23 @@
         titleText: "Application complete",
         html: tmpl
       }) }}
-
-      <h2 class="govuk-heading-m">What happens next</h2>
       {% if paymentSkipped %}
         <p class="govuk-body">
           Someone will be in touch to make a payment.
         </p>
-        {% else %}
+      {% else %}
         <p class="govuk-body">
           You will receive an email with details with the next steps.
         </p>
+      {% endif %}
+      {% if components.length > 0 %}
+      <h2 class="govuk-heading-m">What happens next</h2>
       {% endif %}
     {% else %}
       {{ govukPanel({
         titleText: customText.title,
         html: tmpl
       }) }}
-      <h2 class="govuk-heading-m">What happens next</h2>
       {% if paymentSkipped and customText.paymentSkipped %}
         <p class="govuk-body">
           {{ customText.paymentSkipped }}
@@ -50,6 +50,9 @@
             {{ customText.nextSteps }}
           </p>
         {% endif %}
+      {% endif %}
+      {% if components.length > 0 %}
+        <h2 class="govuk-heading-m">What happens next</h2>
       {% endif %}
     {% endif %}
 


### PR DESCRIPTION
# Description

the layout for the confirmation page has changed in the [GOV.UK design system](https://design-system.service.gov.uk/patterns/confirmation-pages/), so this PR will change the layout of our confirmation page so that it matches.

- confirmationPage.customText.nextSteps will now appear above the "what happens next" title
- "What happens next" title will now only show if there are components underneath it.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

# How Has This Been Tested?

- [X] Manual testing with different form jsons (attached)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry

[form-with-components.json](https://github.com/XGovFormBuilder/digital-form-builder/files/13546651/form-with-components.json)
[form-with-next-steps.json](https://github.com/XGovFormBuilder/digital-form-builder/files/13546652/form-with-next-steps.json)
[form-without-next-steps.json](https://github.com/XGovFormBuilder/digital-form-builder/files/13546653/form-without-next-steps.json)

