### PR TITLE
fix: allow selection fields to be optional

### DIFF
--- a/runner/src/server/forms/runner-components-test.json
+++ b/runner/src/server/forms/runner-components-test.json
@@ -243,47 +243,47 @@
       "items": [
         {
           "text": "Alfa Romeo",
-          "value": 1
+          "value": "alfa-romeo"
         },
         {
           "text": "BMW",
-          "value": 2
+          "value": "bmw"
         },
         {
           "text": "Ford",
-          "value": 3
+          "value": "ford"
         },
         {
           "text": "Citroen",
-          "value": 4
+          "value": "citroen"
         },
         {
           "text": "Nissan",
-          "value": 5
+          "value": "nissan"
         },
         {
           "text": "Honda",
-          "value": 6
+          "value": "honda"
         },
         {
           "text": "Mercedes",
-          "value": 8
+          "value": "mercedes"
         },
         {
           "text": "Audi",
-          "value": 9
+          "value": "audi"
         },
         {
           "text": "Toyota",
-          "value": 10
+          "value": "toyota"
         },
         {
           "text": "Hyundai",
-          "value": 11
+          "value": "hyundai"
         },
         {
           "text": "Kia",
-          "value": 12
+          "value": "kia"
         }
       ]
     },
@@ -294,58 +294,58 @@
       "items": [
         {
           "text": "Diesel",
-          "value": 1
+          "value": "diesel"
         },
         {
           "text": "Electric",
-          "value": 2
+          "value": "electric"
         },
         {
           "text": "Hydrogen",
-          "value": 3
+          "value": "hyrogen"
         },
         {
           "text": "Petrol",
-          "value": 4
+          "value": "petrol"
         },
         {
           "text": "Hybrid",
-          "value": 5
+          "value": "hybrid"
         }
       ]
     },
     {
       "title": "CAZ Location",
       "name": "O2uEB1",
-      "type": "number",
+      "type": "string",
       "items": [
         {
           "text": "Bath",
-          "value": 1
+          "value": "bath"
         },
         {
           "text": "Bristol",
-          "value": 2
+          "value": "bristol"
         },
         {
           "text": "Birmingham",
-          "value": 3
+          "value": "birmingham"
         },
         {
           "text": "Cardiff",
-          "value": 4
+          "value": "cardiff"
         },
         {
           "text": "Liverpool",
-          "value": 6
+          "value": "liverpool"
         },
         {
           "text": "Leeds",
-          "value": 7
+          "value": "leeds"
         },
         {
           "text": "Manchester",
-          "value": 8
+          "value": "manchester"
         }
       ]
     },
@@ -356,15 +356,15 @@
       "items": [
         {
           "text": "You are not a Robot",
-          "value": 1
+          "value": "not-robot"
         },
         {
           "text": "You have not previously claimed an exemption",
-          "value": 2
+          "value": "not-claimed-exemption"
         },
         {
           "text": "You have not omitted or purposely witheld information that might be detrimental to you claim",
-          "value": 3
+          "value": "not-a-liar"
         }
       ]
     }

--- a/runner/src/server/forms/runner-components-test.json
+++ b/runner/src/server/forms/runner-components-test.json
@@ -317,7 +317,7 @@
     {
       "title": "CAZ Location",
       "name": "O2uEB1",
-      "type": "string",
+      "type": "number",
       "items": [
         {
           "text": "Bath",

--- a/runner/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/runner/src/server/plugins/engine/components/ListFormComponent.ts
@@ -28,14 +28,13 @@ export class ListFormComponent extends FormComponent {
     this.listType = this.list.type ?? "string";
     this.options = def.options;
 
-    /**
-     * Only allow a user to answer with values that have been defined in the list
-     /**
-     * Only allow a user to answer with values that have been defined in the list
-     */
     let schema = joi[this.listType]();
 
+    /**
+     * Only allow a user to answer with values that have been defined in the list
+     */
     if (def.options.required === false) {
+      // null or empty string is valid for optional fields
       schema = schema.empty(null).valid(...this.values, "");
     } else {
       schema = schema.valid(...this.values).required();

--- a/runner/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/runner/src/server/plugins/engine/components/ListFormComponent.ts
@@ -30,14 +30,18 @@ export class ListFormComponent extends FormComponent {
 
     /**
      * Only allow a user to answer with values that have been defined in the list
+     /**
+     * Only allow a user to answer with values that have been defined in the list
      */
-    let schema = joi[this.listType]()
-      .allow(...this.values)
-      .label(def.title.toLowerCase());
+    let schema = joi[this.listType]();
 
-    if (def.options.required !== false) {
-      schema = schema.required();
+    if (def.options.required === false) {
+      schema = schema.empty(null).valid(...this.values, "");
+    } else {
+      schema = schema.valid(...this.values).required();
     }
+
+    schema = schema.label(def.title.toLowerCase());
 
     this.formSchema = schema;
     this.stateSchema = schema;

--- a/runner/test/cases/server/plugins/engine/SummaryViewModel.json
+++ b/runner/test/cases/server/plugins/engine/SummaryViewModel.json
@@ -64,7 +64,7 @@
     {
       "title": "CAZ Location",
       "name": "zone",
-      "type": "string",
+      "type": "number",
       "items": [
         {
           "text": "Bath",
@@ -103,10 +103,8 @@
       "title": "Named Section"
     }
   ],
-  "conditions": [
-  ],
-  "fees": [
-  ],
+  "conditions": [],
+  "fees": [],
   "outputs": [
     {
       "name": "webhook",
@@ -118,6 +116,6 @@
     }
   ],
   "version": 2,
-  "payApiKey": {"test": "test_api_key", "production": "production_api_key"},
+  "payApiKey": { "test": "test_api_key", "production": "production_api_key" },
   "skipSummary": false
 }

--- a/runner/test/cases/server/plugins/engine/components/ListFormComponents.test.ts
+++ b/runner/test/cases/server/plugins/engine/components/ListFormComponents.test.ts
@@ -62,7 +62,7 @@ suite("ListFormComponent", () => {
   });
 });
 
-describe.only("ListFormComponent validation", () => {
+describe("ListFormComponent validation", () => {
   component = new ListFormComponent(
     {
       ...componentDefinition,

--- a/runner/test/cases/server/plugins/engine/components/ListFormComponents.test.ts
+++ b/runner/test/cases/server/plugins/engine/components/ListFormComponents.test.ts
@@ -34,9 +34,10 @@ let formModel = {
   getList: () => lists[0],
   makePage: () => sinon.stub(),
 };
-let component;
 
 suite("ListFormComponent", () => {
+  let component;
+
   beforeEach(() => {
     component = new ListFormComponent(componentDefinition, formModel);
   });
@@ -62,8 +63,8 @@ suite("ListFormComponent", () => {
   });
 });
 
-describe("ListFormComponent validation", () => {
-  component = new ListFormComponent(
+describe("ListFormComponent optional validation", () => {
+  const optionalComponent = new ListFormComponent(
     {
       ...componentDefinition,
       options: {
@@ -74,7 +75,7 @@ describe("ListFormComponent validation", () => {
   );
 
   it("schema validates correctly when the field is optional", () => {
-    const schema = component.formSchema;
+    const schema = optionalComponent.formSchema;
 
     expect(schema.validate("1").error).to.not.exist();
     expect(schema.validate("2").error).to.not.exist();

--- a/runner/test/cases/server/plugins/engine/components/ListFormComponents.test.ts
+++ b/runner/test/cases/server/plugins/engine/components/ListFormComponents.test.ts
@@ -20,27 +20,24 @@ const lists = [
   },
 ];
 
+const componentDefinition = {
+  subType: "field",
+  type: "ListFormComponent",
+  name: "MyListFormComponent",
+  title: "Turnaround?",
+  options: {},
+  list: "Turnaround",
+  schema: {},
+};
+
+let formModel = {
+  getList: () => lists[0],
+  makePage: () => sinon.stub(),
+};
+let component;
+
 suite("ListFormComponent", () => {
-  let componentDefinition;
-  let formModel;
-  let component;
-
   beforeEach(() => {
-    componentDefinition = {
-      subType: "field",
-      type: "ListFormComponent",
-      name: "MyListFormComponent",
-      title: "Turnaround?",
-      options: {},
-      list: "Turnaround",
-      schema: {},
-    };
-
-    formModel = {
-      getList: () => lists[0],
-      makePage: () => sinon.stub(),
-    };
-
     component = new ListFormComponent(componentDefinition, formModel);
   });
 
@@ -62,5 +59,31 @@ suite("ListFormComponent", () => {
       expect(component.getDisplayStringFromState(state)).to.equal("2 hours");
       expect(component.getViewModel(state).value).to.equal(2);
     });
+  });
+});
+
+describe.only("ListFormComponent validation", () => {
+  component = new ListFormComponent(
+    {
+      ...componentDefinition,
+      options: {
+        required: false,
+      },
+    },
+    formModel
+  );
+
+  it("schema validates correctly when the field is optional", () => {
+    const schema = component.formSchema;
+
+    expect(schema.validate("1").error).to.not.exist();
+    expect(schema.validate("2").error).to.not.exist();
+    expect(schema.validate("").error).to.not.exist();
+    expect(schema.validate(null).error).to.not.exist();
+
+    const errorMessage = '"turnaround?" must be one of [1, 2, ]';
+    expect(schema.validate(10).error.message).to.be.equal(errorMessage);
+    expect(schema.validate("ten").error.message).to.be.equal(errorMessage);
+    expect(schema.validate(2).error.message).to.be.equal(errorMessage);
   });
 });


### PR DESCRIPTION
# Description

ListSelectionFields (Radios, select) do not allow no/empty answer when set to `{ required: false }`

- set schema correctly
- add tests

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [x] Manual
- [x] Unit

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
