### PR TITLE
fix: Update cookies page to describe cookies accurately and to allow changes to consent from cookies page

### DIFF
--- a/runner/src/server/plugins/engine/plugin.ts
+++ b/runner/src/server/plugins/engine/plugin.ts
@@ -271,8 +271,8 @@ export const plugin = {
           parse: true,
           multipart: { output: "stream" },
           maxBytes: uploadService.fileSizeLimit,
-          failAction: async (request: any, h: HapiResponseToolkit) => {
-            request.server?.plugins?.crumb?.generate?.(request, h);
+          failAction: async (request: HapiRequest, h: HapiResponseToolkit) => {
+            request.server.plugins.crumb.generate?.(request, h);
             return h.continue;
           },
         },

--- a/runner/src/server/plugins/router.ts
+++ b/runner/src/server/plugins/router.ts
@@ -42,11 +42,8 @@ export default {
           path: "/help/cookies",
           handler: async (request: HapiRequest, h: HapiResponseToolkit) => {
             const cookiesPolicy = request.state.cookies_policy;
-            let analytics: string | undefined;
-            if (cookiesPolicy) {
-              analytics =
-                cookiesPolicy?.analytics === "on" ? "accept" : "reject";
-            }
+            let analytics =
+              cookiesPolicy?.analytics === "on" ? "accept" : "reject";
             return h.view("help/cookies", {
               analytics,
             });
@@ -58,8 +55,11 @@ export default {
             payload: {
               parse: true,
               multipart: true,
-              failAction: async (request: any, h: HapiResponseToolkit) => {
-                request.server?.plugins?.crumb?.generate?.(request, h);
+              failAction: async (
+                request: HapiRequest,
+                h: HapiResponseToolkit
+              ) => {
+                request.server.plugins.crumb.generate?.(request, h);
                 return h.continue;
               },
             },

--- a/runner/src/server/plugins/router.ts
+++ b/runner/src/server/plugins/router.ts
@@ -40,13 +40,29 @@ export default {
         {
           method: "get",
           path: "/help/cookies",
-          handler: async (_request: HapiRequest, h: HapiResponseToolkit) => {
-            return h.view("help/cookies");
+          handler: async (request: HapiRequest, h: HapiResponseToolkit) => {
+            const cookiesPolicy = request.state.cookies_policy;
+            let analytics: string | undefined;
+            if (cookiesPolicy) {
+              analytics =
+                cookiesPolicy?.analytics === "on" ? "accept" : "reject";
+            }
+            return h.view("help/cookies", {
+              analytics,
+            });
           },
         },
         {
           method: "post",
           options: {
+            payload: {
+              parse: true,
+              multipart: true,
+              failAction: async (request: any, h: HapiResponseToolkit) => {
+                request.server?.plugins?.crumb?.generate?.(request, h);
+                return h.continue;
+              },
+            },
             validate: {
               payload: Joi.object({
                 cookies: Joi.string()

--- a/runner/src/server/views/help/cookies.html
+++ b/runner/src/server/views/help/cookies.html
@@ -1,4 +1,6 @@
 {% extends 'layout.html' %}
+{% from "radios/macro.njk" import govukRadios %}
+{% from "button/macro.njk" import govukButton %}
 
 {% block content %}
 <div class="govuk-grid-row">
@@ -20,14 +22,14 @@
             </thead>
             <tbody>
                 <tr class="govuk-table__row">
-                    <td class="govuk-table__cell">session</td>
-                    <td class="govuk-table__cell">Set to remember information you’ve entered into a form</td>
+                    <td class="govuk-table__cell">cookies_policy</td>
+                    <td class="govuk-table__cell">Saves your cookie consent settings</td>
                     <td class="govuk-table__cell">When you close your browser</td>
                 </tr>
                 <tr class="govuk-table__row">
-                    <td class="govuk-table__cell">seen_cookie</td>
-                    <td class="govuk-table__cell">Tracks whether you have seen the cookie banner and doesn't show it again if you have</td>
-                    <td class="govuk-table__cell">28 days</td>
+                    <td class="govuk-table__cell">session</td>
+                    <td class="govuk-table__cell">Set to remember information you’ve entered into a form</td>
+                    <td class="govuk-table__cell">When you close your browser</td>
                 </tr>
                 <tr class="govuk-table__row">
                     <td class="govuk-table__cell">crumb</td>
@@ -38,30 +40,52 @@
         </table>
 
         {% if gtmId1 or gtmId2 %}
-        <h2 class="govuk-heading-l">Cookies that measure website use</h2>
-        <h3 class="govuk-heading-m">Measuring website usage (Google Analytics)</h3>
-        <p class="govuk-body">We use Google Analytics to measure how you use the website so we can improve it based on user needs. We do not allow Google to use or share the data about how you use this site.</p>
-        <table class="govuk-table">
-            <thead>
-            <tr class="govuk-table__row">
-                <th class="govuk-table__header" scope="col">Name</th>
-                <th class="govuk-table__header" scope="col">Purpose</th>
-                <th class="govuk-table__header" scope="col">Expires</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell">_ga</td>
-                <td class="govuk-table__cell">Used to distinguish users</td>
-                <td class="govuk-table__cell">2 years</td>
-            </tr>
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell">_ga_[id]</td>
-                <td class="govuk-table__cell">used to persist session state</td>
-                <td class="govuk-table__cell">2 years</td>
-            </tr>
-            </tbody>
-        </table>
+        <form method="post" enctype="multipart/form-data" autocomplete="on">
+            <input type="hidden" name="crumb" value="{{crumb}}"/>
+            <h2 class="govuk-heading-l">Cookies that measure website use</h2>
+            <h3 class="govuk-heading-m">Measuring website usage (Google Analytics)</h3>
+            <p>We use Google Analytics to measure how you use the website so we can improve it based on user needs. We do not allow Google to use or share the data about how you use this site.</p>
+            <p>Google Analytics sets cookies that store anonymised information about:</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>how you got to the site</li>
+                <li>the pages you visit within this service, GOV.UK and other government digital services, and how long you spend on each page</li>
+                <li>what you click on while you are visiting the site</li>
+            </ul>
+            <table class="govuk-table">
+                <thead>
+                <tr class="govuk-table__row">
+                    <th class="govuk-table__header" scope="col">Name</th>
+                    <th class="govuk-table__header" scope="col">Purpose</th>
+                    <th class="govuk-table__header" scope="col">Expires</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">_ga</td>
+                    <td class="govuk-table__cell">Used to distinguish users</td>
+                    <td class="govuk-table__cell">2 years</td>
+                </tr>
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">_ga_[id]</td>
+                    <td class="govuk-table__cell">used to persist session state</td>
+                    <td class="govuk-table__cell">2 years</td>
+                </tr>
+                </tbody>
+            </table>
+            {{ govukRadios({
+                name: "cookies",
+                items: [
+                    {
+                        value: "accept",
+                        text: "Use cookies that measure my website use"
+                    },
+                    {
+                        value: "reject",
+                        text: "Do not use cookies that measure my website use"
+                    }
+                ],
+                value: analytics
+            }) }}
         {% endif %}
 
         {% if matomoUrl and matomoId %}
@@ -70,6 +94,10 @@
         <p class="govuk-body">We use Matomo Analytics software to collect non-personally-identifying information of the sort that web browsers and servers typically make available, such as the browser type, language preference, referring site, and the date and time of each visitor request.</p>
         <p class="govuk-body">We do this to better understand how applicants for overseas loans use the website. From time to time, the Foreign and Commonwealth Office may release non-personally-identifying information in the aggregate, eg, by publishing a report on trends in the usage of its website.</p>
         <p class="govuk-body">We don't use any cookies to do this.</p>
+        {% endif %}
+        {% if gtmId1 or gtmId2 %}
+                {{ govukButton({ attributes: { id: "submit" }, text: "Save changes" }) }}
+            </form>
         {% endif %}
     </div>
 </div>


### PR DESCRIPTION
# Description

At some point there was an update to the way cookies were saved, but the content on the cookies page hadn't been updated to reflect this.

In addition to this there was previously no way to reset cookies after setting them initially, unless the user manually cleared their cookies. This update adds a form to the cookies page allowing the user to update their preferences at any time.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [X] Cookies policy unit tests
- [X] Manual testing with both the existing banner and the new form to check values were being set properly

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
