### PR TITLE
fix: Updated pay return url to allow insecure redirect urls if the environment is in test

### DIFF
--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -104,6 +104,9 @@ module.exports = {
   // Control which is used. Accepts "test" | "production" | "".
   apiEnv: "",
   payApiUrl: "https://publicapi.payments.service.gov.uk/v1",
+  // If both the api env and node env are set to "production", the pay return url will need to be secure.
+  // This is not the case if either are set to "test", or if the node env is set to "development"
+  // payReturnUrl: "http://localhost:3009"
   // documentUploadApiUrl: "",
   // ordnanceSurveyKey: "", // deprecated - this API is deprecated
   // browserRefreshUrl: "", // deprecated - idk what this does

--- a/runner/src/server/utils/configSchema.ts
+++ b/runner/src/server/utils/configSchema.ts
@@ -31,7 +31,11 @@ export const configSchema = Joi.object({
   matomoId: Joi.string().optional(),
   matomoUrl: Joi.string().custom(secureUrl).optional(),
   payApiUrl: Joi.string().custom(secureUrl),
-  payReturnUrl: Joi.string().custom(secureUrl),
+  payReturnUrl: Joi.when("env", {
+    is: Joi.valid("test"),
+    then: Joi.string().default("http://localhost:3009"),
+    otherwise: Joi.string().custom(secureUrl),
+  }),
   serviceUrl: Joi.string().optional(),
   redisHost: Joi.string().optional(),
   redisPort: Joi.number().optional(),

--- a/runner/src/server/utils/configSchema.ts
+++ b/runner/src/server/utils/configSchema.ts
@@ -32,9 +32,13 @@ export const configSchema = Joi.object({
   matomoUrl: Joi.string().custom(secureUrl).optional(),
   payApiUrl: Joi.string().custom(secureUrl),
   payReturnUrl: Joi.when("env", {
-    is: Joi.valid("test"),
+    is: Joi.string().valid("development", "test"),
     then: Joi.string().default("http://localhost:3009"),
-    otherwise: Joi.string().custom(secureUrl),
+    otherwise: Joi.when("apiEnv", {
+      is: Joi.string().valid("test"),
+      then: Joi.string().default("http://localhost:3009"),
+      otherwise: Joi.string().custom(secureUrl),
+    }),
   }),
   serviceUrl: Joi.string().optional(),
   redisHost: Joi.string().optional(),

--- a/runner/test/cases/server/config.test.js
+++ b/runner/test/cases/server/config.test.js
@@ -42,10 +42,22 @@ suite(`Server config validation`, () => {
     );
   });
 
-  test("it succeeds when PAY_RETURN_URL is insecure and the environment is test", () => {
+  test("it succeeds when PAY_RETURN_URL is insecure and the node environment is test", () => {
     const configWithInsecureUrl = {
       payReturnUrl: "http://insecure.url",
       env: "test",
+      apiEnv: "production",
+    };
+
+    const result = configSchema.validate(configWithInsecureUrl);
+
+    expect(Object.keys(result)).to.not.contain("error");
+  });
+
+  test("it succeeds when PAY_RETURN_URL is insecure and the api environment is test", () => {
+    const configWithInsecureUrl = {
+      payReturnUrl: "http://insecure.url",
+      env: "production",
       apiEnv: "test",
     };
 

--- a/runner/test/cases/server/config.test.js
+++ b/runner/test/cases/server/config.test.js
@@ -28,9 +28,11 @@ suite(`Server config validation`, () => {
     );
   });
 
-  test("it throws when PAY_RETURN_URL is insecure", () => {
+  test("it throws when PAY_RETURN_URL is insecure and the environment is production", () => {
     const configWithInsecureUrl = {
       payReturnUrl: "http://insecure.url",
+      env: "production",
+      apiEnv: "production",
     };
 
     const { error } = configSchema.validate(configWithInsecureUrl);
@@ -38,6 +40,18 @@ suite(`Server config validation`, () => {
     expect(error.message).to.contain(
       "Provided payReturnUrl is insecure, please use https"
     );
+  });
+
+  test("it succeeds when PAY_RETURN_URL is insecure and the environment is test", () => {
+    const configWithInsecureUrl = {
+      payReturnUrl: "http://insecure.url",
+      env: "test",
+      apiEnv: "test",
+    };
+
+    const result = configSchema.validate(configWithInsecureUrl);
+
+    expect(Object.keys(result)).to.not.contain("error");
   });
 
   test("it throws when oAuth config is incomplete", () => {


### PR DESCRIPTION
# Description

Previously when running smoke tests, if you needed to check confirmation page content based on the user having paid for their application, you would need to use a version of the service accessible by https. This change will allow redirect to http applications (including localhost) when either the current node environment or api environment are in test mode or development mode.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [X] Manual testing with each combination of variables to check the joi validation works properly

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
