### PR TITLE
feat: hide section titles

### DIFF
--- a/designer/client/i18n/translations/en.translation.json
+++ b/designer/client/i18n/translations/en.translation.json
@@ -398,6 +398,10 @@
     "titleField": {
       "helpText": "Appears above the page title. However, if these titles are the same, the form will only show the page title.",
       "title": "Section title"
+    },
+    "hideTitleField": {
+      "helpText": "If you do not want the section title displayed on any page that's part of this section, tick this box",
+      "title": "Hide section title"
     }
   },
   "title": "Title",

--- a/designer/client/i18n/translations/en.translation.json
+++ b/designer/client/i18n/translations/en.translation.json
@@ -400,7 +400,7 @@
       "title": "Section title"
     },
     "hideTitleField": {
-      "helpText": "If you do not want the section title displayed on any page that's part of this section, tick this box",
+      "helpText": "Tick this box if you do not want the section title to show on any pages in this section",
       "title": "Hide section title"
     }
   },

--- a/designer/client/section/section-edit.js
+++ b/designer/client/section/section-edit.js
@@ -1,7 +1,8 @@
 import React from "react";
 import randomId from "../randomId";
-import { withI18n } from "../i18n";
+import { i18n, withI18n } from "../i18n";
 import { Input } from "@govuk-jsx/input";
+import { Checkboxes } from "@xgovformbuilder/govuk-react-jsx";
 import {
   validateName,
   validateTitle,
@@ -11,6 +12,7 @@ import ErrorSummary from "../error-summary";
 import { DataContext } from "../context";
 import { addSection } from "../data";
 import logger from "../plugins/logger";
+import { Actions } from "../reducers/component/types";
 
 class SectionEdit extends React.Component {
   static contextType = DataContext;
@@ -24,6 +26,7 @@ class SectionEdit extends React.Component {
     this.state = {
       name: section?.name ?? randomId(),
       title: section?.title ?? "",
+      hideTitle: section?.hideTitle ?? false,
       errors: {},
     };
   }
@@ -35,11 +38,11 @@ class SectionEdit extends React.Component {
     if (hasValidationErrors(validationErrors)) return;
 
     const { data, save } = this.context;
-    const { name, title } = this.state;
+    const { name, title, hideTitle } = this.state;
     let updated = { ...data };
 
     if (this.isNewSection) {
-      updated = addSection(data, { name, title: title.trim() });
+      updated = addSection(data, { name, title: title.trim(), hideTitle });
     } else {
       const previousName = this.props.section?.name;
       const nameChanged = previousName !== name;
@@ -59,6 +62,7 @@ class SectionEdit extends React.Component {
         });
       }
       copySection.title = title;
+      copySection.hideTitle = hideTitle;
     }
 
     try {
@@ -110,7 +114,7 @@ class SectionEdit extends React.Component {
 
   render() {
     const { i18n } = this.props;
-    const { title, name, errors } = this.state;
+    const { title, name, hideTitle, errors } = this.state;
 
     return (
       <>
@@ -151,6 +155,27 @@ class SectionEdit extends React.Component {
               errors?.name ? { children: errors?.name.children } : undefined
             }
           />
+          <div className="govuk-checkboxes govuk-form-group">
+            <div className="govuk-checkboxes__item">
+              <input
+                className="govuk-checkboxes__input"
+                id="section-hideTitle"
+                name="hideTitle"
+                type="checkbox"
+                checked={hideTitle}
+                onChange={(e) => this.setState({ hideTitle: e.target.checked })}
+              />
+              <label
+                className="govuk-label govuk-checkboxes__label"
+                htmlFor="section-hideTitle"
+              >
+                {i18n("sectionEdit.hideTitleField.title")}
+              </label>
+              <span className="govuk-hint govuk-checkboxes__hint">
+                {i18n("sectionEdit.hideTitleField.helpText")}
+              </span>
+            </div>
+          </div>
           <button className="govuk-button" type="submit">
             Save
           </button>{" "}

--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -35,6 +35,7 @@ export interface RepeatingFieldPage extends Page {
 export interface Section {
   name: string;
   title: string;
+  hideTitle: boolean;
 }
 
 export interface Item {

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -8,6 +8,7 @@ export const CURRENT_VERSION = 2;
 const sectionsSchema = joi.object().keys({
   name: joi.string().required(),
   title: joi.string().required(),
+  hideTitle: joi.boolean().default(false),
 });
 
 const conditionFieldSchema = joi.object().keys({

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -120,7 +120,7 @@ export class PageControllerBase {
         ...formData,
       });
     }
-    let sectionTitle = this.section?.title;
+    let sectionTitle = !this.section?.hideTitle && this.section?.title;
     if (sectionTitle && iteration !== undefined) {
       sectionTitle = `${sectionTitle} ${iteration}`;
     }

--- a/runner/test/cases/server/titles.json
+++ b/runner/test/cases/server/titles.json
@@ -97,10 +97,59 @@
       ],
       "next": [
         {
-          "path": "/summary"
+          "path": "/applicant-two"
         }
       ],
       "title": "Applicant contact details"
+    },
+    {
+      "path": "/applicant-two",
+      "title": "Applicant 2 details",
+      "section": "applicantTwoDetails",
+      "components": [
+        {
+          "type": "Para",
+          "content": "Provide the details as they appear on your passport.",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        },
+        {
+          "type": "TextField",
+          "name": "firstName",
+          "title": "First name",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        },
+        {
+          "options": {
+            "required": false,
+            "optionalText": false
+          },
+          "type": "TextField",
+          "name": "middleName",
+          "title": "Middle name",
+          "hint": "If you have a middle name on your passport you must include it here",
+          "schema": {}
+        },
+        {
+          "type": "TextField",
+          "name": "lastName",
+          "title": "Surname",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        }
+      ],
+      "next": [
+        {
+          "path": "/summary"
+        }
+      ]
     },
     {
       "path": "/summary",
@@ -110,8 +159,7 @@
       "next": []
     }
   ],
-  "lists": [
-  ],
+  "lists": [],
   "sections": [
     {
       "name": "applicantDetails",
@@ -120,15 +168,17 @@
     {
       "name": "applicantOneDetails",
       "title": "Applicant 1"
+    },
+    {
+      "name": "applicantTwoDetails",
+      "title": "Applicant 2",
+      "hideTitle": true
     }
   ],
   "phaseBanner": {},
-  "fees": [
-  ],
+  "fees": [],
   "payApiKey": "",
-  "outputs": [
-  ],
+  "outputs": [],
   "version": 2,
-  "conditions": [
-  ]
+  "conditions": []
 }

--- a/runner/test/cases/server/titles.test.js
+++ b/runner/test/cases/server/titles.test.js
@@ -57,4 +57,17 @@ describe("Title and section title", () => {
     expect($("h1 #section-title").html()).to.be.null();
     expect($("h2#section-title")).to.exist();
   });
+
+  it("Does not render the section title if hideTitle is set to true", async () => {
+    const options = {
+      method: "GET",
+      url: `/titles/applicant-two?visit=1`,
+    };
+
+    const response = await server.inject(options);
+    const $ = cheerio.load(response.payload);
+
+    expect($("h1").text().trim()).to.startWith("Applicant 2 details");
+    expect($("h2#section-title").html()).to.be.null();
+  });
 });


### PR DESCRIPTION
# Description

In some instances it might be necessary to keep sections for the sake of making the summary page easier to read, but the flow of the sections may be confusing to the user. In these cases it may be necessary for the user's journey to keep the pages and sections in this order, and therefore may be a better user experience if section titles are hidden.

This PR adds an optional flag to sections `hideTitle` which will hide the section title for all pages that use that section title.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [X] Added unit test to check no summary text is shown if `hideTitle` is `true`
- [X] Manually tested with custom form

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
