### PR TITLE
Feat/queue pgboss

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,8 +41,9 @@ services:
       - LAST_COMMIT
       - LAST_TAG
     #      - ENABLE_QUEUE_SERVICE=true
-    #      - QUEUE_DATABASE_URL=mysql://root:root@mysql:3306/queue
+    #      - QUEUE_DATABASE_URL=mysql://root:root@mysql:3306/queue # or postgres://user:root@postgres:5432/queue
     #      - DEBUG="prisma*"
+    #      - QUEUE_TYPE="MYSQL"
     command: yarn runner start
     depends_on:
       redis:
@@ -54,32 +55,44 @@ services:
     command: redis-server --requirepass 123abc
     ports:
       - "6379:6379"
-  #  submitter:
-  #    image: digital-form-builder-submitter
-  #    build:
-  #      context: .
-  #      dockerfile: ./submitter/Dockerfile
-  #    ports:
-  #      - "9000:9000"
-  #    environment:
-  #      - PORT=9000
-  #      - QUEUE_DATABASE_URL=mysql://root:root@mysql:3306/queue
-  #      - QUEUE_POLLING_INTERVAL=5000
-  #      - DEBUG="prisma*"
-  #    command: yarn submitter start
-  #    depends_on:
-  #      mysql:
-  #        condition: service_healthy
-  mysql:
-    container_name: mysql
-    image: "mysql:latest"
-    command: --default-authentication-plugin=mysql_native_password
-    ports:
-      - "3306:3306"
-    environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: queue
-    healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-      timeout: 20s
-      retries: 10
+#  if using MYSQL, uncomment submitter
+#  submitter:
+#    image: digital-form-builder-submitter
+#    build:
+#      context: .
+#      dockerfile: ./submitter/Dockerfile
+#    ports:
+#      - "9000:9000"
+#    environment:
+#      - PORT=9000
+#      - QUEUE_DATABASE_URL=mysql://root:root@mysql:3306/queue
+#      - QUEUE_POLLING_INTERVAL=5000
+#      - DEBUG="prisma*"
+#    command: yarn submitter start
+#    depends_on:
+#      mysql:
+#        condition: service_healthy
+#  mysql:
+#    container_name: mysql
+#    image: "mysql:latest"
+#    command: --default-authentication-plugin=mysql_native_password
+#    ports:
+#      - "3306:3306"
+#    environment:
+#      MYSQL_ROOT_PASSWORD: root
+#      MYSQL_DATABASE: queue
+#    healthcheck:
+#      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+#      timeout: 20s
+#      retries: 10
+
+# use psql if you want a PostgreSQL based queue (recommended)
+#  postgres:
+#    container_name: postgres
+#    image: "postgres:16"
+#    ports:
+#      - "5432:5432"
+#    environment:
+#      POSTGRES_DB: queue
+#      POSTGRES_PASSWORD: root
+#      POSTGRES_USER: user

--- a/docs/adr/0003-submitter.md
+++ b/docs/adr/0003-submitter.md
@@ -1,8 +1,8 @@
 # Submitter and DB queue
 
-- Status: [ accepted ]
+- Status: [ accepted ] | superseded by [ADR-0004](./0004-submitter.md)
 - Deciders: FCDO / OS maintainers: [@jenbutongit](https://github.com/jenbutongit) [@superafroman](https://github.com/superafroman)
-- Date: [2023-07-14 when the decision was last updated]
+- Date: [2023-07-14]
 
 ## Context and Problem Statement
 

--- a/docs/adr/0004-submitter.md
+++ b/docs/adr/0004-submitter.md
@@ -1,0 +1,40 @@
+# Submitter and DB queue - Upgrade to PostgreSQL and pg-boss
+
+- Status: [ accepted ]
+- Deciders: FCDO / OS maintainers: [@jenbutongit](https://github.com/jenbutongit) [@superafroman](https://github.com/superafroman)
+- Date: 2024-01-12
+
+## Context and Problem Statement
+
+This is an addition to [0003-submitter.md](./0003-submitter.md). ADRs 0003-submitter and 0004-submitter aim to make your services more reliable and resilient.
+
+As stated in [0003-submitter.md](./0003-submitter.md), an upgrade to option 2 would be possible.
+Instead of polling a database for the reference number, it will make a GET request instead. This allows for better microservices architecture.
+
+## Decision Drivers <!-- optional -->
+
+### Better architectural decoupling (microservices)
+
+When queues are enabled the database, runner, submitter, and webhook endpoints are tightly coupled. Each of the services (runner, submitter and webhook)
+are communicating via a single entry. If the schema is required to change, it creates a breaking change across all 3 services, and the deployments need to be coordinated.
+
+By only allowing the runner to submit to a queue, and poll reference numbers via an API, we remove the coupling from the runner. It no longer needs to keep track of the databases' schema.
+
+### Performance
+
+#### PostgreSQL and pg-boss
+
+pg-boss relies on PostgreSQL to queue jobs and easily allow processing of jobs. It also leverages node's event features (e.g. events and event emitter) to improve performance.
+PostgreSQL has features with messaging built in mind, for example SKIP LOCKED to ensure rows are not being read or written by different processes. The MySQL based submitter does not currently do this.
+
+### Support/Maintenance
+
+Pg-boss is a lot more feature rich than our mysql based submitter. It has support for exponential backoff, pub/sub, automatic creation of tables and more.
+It's far too much for us to write our own equivalent! There are some equivalent libraries available for MySQL, but are not as feature rich, or as well maintained.
+
+The pg-boss implementation will also allow easier support for other queues, like SQS, Kafka, RabbitMQ. All with their own libraries or SDKs that allow events to be emitted and consumed easily.
+
+### Negative Consequences
+
+- The MySQL queue is likely to be deprecated due to support/maintenance overheads.
+- For the time being, both queue types will be supported, which means that there is more code to maintain and some additional complexity

--- a/docs/runner/submission-queue.md
+++ b/docs/runner/submission-queue.md
@@ -39,8 +39,8 @@ support that is required.
 - A worker process which can connect to the PostgreSQL database
 - An API endpoint with a GET request `${queueReferenceApiUrl}/${jobId}`,
   e.g. `localhost:9000/reference/d28a4e85-b7d4-4983-bf0d-9c93b05e342d`
-    - The `jobId` is generated when a users' submission is successfully inserted into the queue
-    - The API endpoint should respond with application/json `{ "reference": "FCDO-3252" }`
+  - The `jobId` is generated when a users' submission is successfully inserted into the queue
+  - The API endpoint should respond with application/json `{ "reference": "FCDO-3252" }`
 
 #### MYSQL Prerequisites
 
@@ -49,7 +49,7 @@ support that is required.
 ### Environment variables
 
 | Variable name                  | Definition                                                                                                 | Default | Example                                     |
-|--------------------------------|------------------------------------------------------------------------------------------------------------|---------|---------------------------------------------|
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------- |
 | ENABLE_QUEUE_SERVICE           | Whether the queue service is enabled or not                                                                | `false` |                                             |
 | QUEUE_DATABASE_TYPE            | PGBOSS or MYSQL                                                                                            |         |                                             |
 | QUEUE_DATABASE_URL             | Used for configuring the endpoint of the database instance                                                 |         | mysql://username:password@endpoint/database |
@@ -75,7 +75,6 @@ Webhooks can be configured so that the submitter only attempts to post to the we
 }
 ```
 
-
 ## Running locally
 
 To use the submission queue locally, you will need to have a running instance of a database, the runner, and the
@@ -88,6 +87,7 @@ In that file, you will see the following lines commented out:
 #      - QUEUE_DATABASE_URL=mysql://root:root@mysql:3306/queue
 #      - DEBUG="prisma*"
 ```
+
 ```yaml
 #  if using MYSQL, uncomment submitter
 #  submitter:
@@ -149,6 +149,20 @@ If sending the form submission to the queue, or polling the database for the for
 following errors will be thrown:
 
 | Tags                                        | Example                                                           |
-|---------------------------------------------|-------------------------------------------------------------------|
+| ------------------------------------------- | ----------------------------------------------------------------- |
 | QueueStatusService, outputRequests          | There was an issue sending the submission to the submission queue |
 | QueueService, pollForRef, Row ref: [row_id] | Submission row not found                                          |
+
+## Migration guide
+
+If you are moving from MYSQL to PGBOSS, ensure you have a worker which will handle the jobs added to your queue. For "zero downtime",
+
+1. Set up any new infrastructure components if necessary (e.g. database and worker)
+1. Point the runner to the new components via `QUEUE_DATABASE_URL` and `QUEUE_REFERENCE_API_URL`
+1. Keep the MySQL database as well as the submitter running. Do not delete these yet
+1. Deploy new infrastructure components alongside the existing components
+
+Any submissions that have previously failed, or were submitted during deployment, can continue to run and submit to your webhook endpoints.
+Check the database to ensure that there are no more failed entries.
+
+You may then safely remove the submitter, and MySQL database (if it is not used for any other purpose).

--- a/docs/runner/submission-queue.md
+++ b/docs/runner/submission-queue.md
@@ -1,20 +1,62 @@
 # Submission queue
 
-The runner can be configured to add new submissions to a queue, and for this queue to be processed by the submitter module.
+The runner can be configured to add new submissions to a queue and, if using the MYSQL queue type, for this queue to be
+processed by the submitter module.
 
-By enabling the queue service this will change the webhook process, so that the runner will push the submission to a specified database, and will await a response from the submitter for a few seconds before returning the success screen to the user.
+Two queue types are currently allowed, MYSQL and PGBOSS.
+
+For `MYSQL`, enabling the queue service this will change the webhook process, so that the runner will push the
+submission to a
+specified database, and will await a response from the submitter for a few seconds before returning the success screen
+to the user.
+
+For `PGBOSS`, which handles events and queues as expected from event based architecture. The `PGBOSS` queue type
+uses [pg-boss](https://www.npmjs.com/package/pg-boss).
+You must have a postgres v11 database configured. The runner will add job to the queue. It will then
+request `${queueReferenceApiUrl}/${jobId}`
+for the reference number you wish to return to the user. You must implement this endpoint yourself.
+
+In future, we may add support for different types of queues, like SQS.
 
 ## Setup
 
-Before enabling the queue service you will need a database instance set up which the runner can access. Once your database is set up, you can enable the queue service by configuring the following environment variables:
+### Prerequisites
 
-| Variable name                  | Definition                                                                               | Default | Example                                     |
-| ------------------------------ | ---------------------------------------------------------------------------------------- | ------- | ------------------------------------------- |
-| ENABLE_QUEUE_SERVICE           | Whether the queue service is enabled or not                                              | `false` |                                             |
-| QUEUE_DATABASE_URL             | Used for configuring the endpoint of the database instance                               |         | mysql://username:password@endpoint/database |
-| QUEUE_DATABASE_USERNAME        | Used for configuring the user being used to access the database                          |         | root                                        |
-| QUEUE_DATABASE_PASSWORD        | Used for configuring the password used for accessing the database                        |         | password                                    |
-| QUEUE_SERVICE_POLLING_INTERVAL | The amount of time, in milliseconds, between poll requests for updates from the database | 500     |                                             |
+Decide if event or message based architecture is the right approach for your service, and if you have the digital
+capability to support it in your organisation.
+You may need queuing if your service expects high volume of submissions, but your webhook endpoints or further
+downstream endpoints change frequently or have slow response times.
+
+You will need to set up a MySQL or PostgreSQL database.
+
+Use `PGBOSS` and PostgreSQL for higher availability and features like exponential backoff.
+It is highly recommended you use `PGBOSS` and PostgreSQL. MYSQL may be deprecated due to the additional overhead and
+support that is required.
+
+#### PGBOSS Prerequisites
+
+- PostgreSQL database >=v11
+- A worker process which can connect to the PostgreSQL database
+- An API endpoint with a GET request `${queueReferenceApiUrl}/${jobId}`,
+  e.g. `localhost:9000/reference/d28a4e85-b7d4-4983-bf0d-9c93b05e342d`
+    - The `jobId` is generated when a users' submission is successfully inserted into the queue
+    - The API endpoint should respond with application/json `{ "reference": "FCDO-3252" }`
+
+#### MYSQL Prerequisites
+
+- MySQL database
+
+### Environment variables
+
+| Variable name                  | Definition                                                                                                 | Default | Example                                     |
+|--------------------------------|------------------------------------------------------------------------------------------------------------|---------|---------------------------------------------|
+| ENABLE_QUEUE_SERVICE           | Whether the queue service is enabled or not                                                                | `false` |                                             |
+| QUEUE_DATABASE_TYPE            | PGBOSS or MYSQL                                                                                            |         |                                             |
+| QUEUE_DATABASE_URL             | Used for configuring the endpoint of the database instance                                                 |         | mysql://username:password@endpoint/database |
+| QUEUE_DATABASE_USERNAME        | Used for configuring the user being used to access the database                                            |         | root                                        |
+| QUEUE_DATABASE_PASSWORD        | Used for configuring the password used for accessing the database                                          |         | password                                    |
+| QUEUE_REFERENCE_API_URL        | Required if you are using the PGBOSS queue type. It must return a users' reference number, based on job id |         | password                                    |
+| QUEUE_SERVICE_POLLING_INTERVAL | The amount of time, in milliseconds, between poll requests for updates from the database                   | 500     |                                             |
 
 Webhooks can be configured so that the submitter only attempts to post to the webhook URL once.
 
@@ -33,49 +75,80 @@ Webhooks can be configured so that the submitter only attempts to post to the we
 }
 ```
 
+
 ## Running locally
 
-To use the submission queue locally, you will need to have a running instance of a database, the runner, and the submitter. The easiest way to do this is by using the provided `docker-compose.yml` file.
+To use the submission queue locally, you will need to have a running instance of a database, the runner, and the
+submitter. The easiest way to do this is by using the provided `docker-compose.yml` file.
 
 In that file, you will see the following lines commented out:
 
 ```yaml
-43    #      - ENABLE_QUEUE_SERVICE=true
-44    #      - QUEUE_DATABASE_URL=mysql://root:root@mysql:3306/queue
-45    #      - DEBUG="prisma*"
- ---------------------------------------------------------------------
-50    #      mysql:
-51    #        condition: service_healthy
- ---------------------------------------------------------------------
-57    #  submitter:
-58    #    image: digital-form-builder-submitter
-59    #    build:
-60    #      context: .
-61    #      dockerfile: ./submitter/Dockerfile
-62    #    ports:
-63    #      - "9000:9000"
-64    #    environment:
-65    #      - PORT=9000
-66    #      - QUEUE_DATABASE_URL=mysql://root:root@mysql:3306/queue
-67    #      - QUEUE_POLLING_INTERVAL=5000
-68    #      - DEBUG="prisma*"
-69    #    command: yarn submitter start
-70    #    depends_on:
-71    #      mysql:
-72    #        condition: service_healthy
+#      - ENABLE_QUEUE_SERVICE=true
+#      - QUEUE_DATABASE_URL=mysql://root:root@mysql:3306/queue
+#      - DEBUG="prisma*"
+```
+```yaml
+#  if using MYSQL, uncomment submitter
+#  submitter:
+#    image: digital-form-builder-submitter
+#    build:
+#      context: .
+#      dockerfile: ./submitter/Dockerfile
+#    ports:
+#      - "9000:9000"
+#    environment:
+#      - PORT=9000
+#      - QUEUE_DATABASE_URL=mysql://root:root@mysql:3306/queue
+#      - QUEUE_POLLING_INTERVAL=5000
+#      - DEBUG="prisma*"
+#    command: yarn submitter start
+#    depends_on:
+#      mysql:
+#        condition: service_healthy
+#  mysql:
+#    container_name: mysql
+#    image: "mysql:latest"
+#    command: --default-authentication-plugin=mysql_native_password
+#    ports:
+#      - "3306:3306"
+#    environment:
+#      MYSQL_ROOT_PASSWORD: root
+#      MYSQL_DATABASE: queue
+#    healthcheck:
+#      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+#      timeout: 20s
+#      retries: 10
+
+# use psql if you want a PostgreSQL based queue (recommended)
+#  postgres:
+#    container_name: postgres
+#    image: "postgres:16"
+#    ports:
+#      - "5432:5432"
+#    environment:
+#      POSTGRES_DB: queue
+#      POSTGRES_PASSWORD: root
+#      POSTGRES_USER: user
 ```
 
-Uncommenting the environment variables under the runner configuration will enable the queue service, set the database url to the url of your mysql container, and turn on debug messages for prisma (the ORM used to communicate with the database).
-Uncommenting the mysql dependency will make sure the mysql server is started before prisma starts trying to connect to it.
-Uncommenting the submitter configuration will trigger the submitter to be created, exposed on port 9000, connecting to the mysql container, with a polling interval of 5 seconds.
+Uncommenting the environment variables under the runner configuration will enable the queue service, set the database
+url to the url of your mysql container, and turn on debug messages for prisma (the ORM used to communicate with the
+database).
+Uncommenting the mysql dependency will make sure the mysql server is started before prisma starts trying to connect to
+it.
+Uncommenting the submitter configuration will trigger the submitter to be created, exposed on port 9000, connecting to
+the mysql container, with a polling interval of 5 seconds.
 
-Once your docker-compose file is ready, start all of your containers by using the command `docker compose up` or `docker compose up -d` to run the containers in detached mode.
+Once your docker-compose file is ready, start all of your containers by using the command `docker compose up`
+or `docker compose up -d` to run the containers in detached mode.
 
 ## Error codes
 
-If sending the form submission to the queue, or polling the database for the form reference, is not successful the following errors will be thrown:
+If sending the form submission to the queue, or polling the database for the form reference, is not successful the
+following errors will be thrown:
 
 | Tags                                        | Example                                                           |
-| ------------------------------------------- | ----------------------------------------------------------------- |
+|---------------------------------------------|-------------------------------------------------------------------|
 | QueueStatusService, outputRequests          | There was an issue sending the submission to the submission queue |
 | QueueService, pollForRef, Row ref: [row_id] | Submission row not found                                          |

--- a/runner/config/custom-environment-variables.json
+++ b/runner/config/custom-environment-variables.json
@@ -47,6 +47,8 @@
   "initialisedSessionKey": "INITIALISED_SESSION_KEY",
   "initialisedSessionAlgorithm": "INITIALISED_SESSION_ALGORITHM",
   "enableQueueService": "ENABLE_QUEUE_SERVICE",
+  "queueType": "QUEUE_TYPE",
+  "queueReferenceApiUrl": "QUEUE_REFERENCE_API_URL",
   "queueDatabaseUrl": "QUEUE_DATABASE_URL",
   "queueDatabaseUsername": "QUEUE_DATABASE_USERNAME",
   "queueDatabasePassword": "QUEUE_DATABASE_PASSWORD",

--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -136,7 +136,8 @@ module.exports = {
    * Failure queue
    */
   enableQueueService: false,
-  // queueDatabaseUrl: "mysql://root:root@localhost:3306/queue"
+  // queueType: "" // accepts "MYSQL" | "PGBOSS"
+  // queueDatabaseUrl: "mysql://root:root@localhost:3306/queue" | "postgresql://root:root@localhost:5432/queue
   queueServicePollingInterval: "500",
 
   allowUserTemplates: false,

--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -138,6 +138,7 @@ module.exports = {
   enableQueueService: false,
   // queueType: "" // accepts "MYSQL" | "PGBOSS"
   // queueDatabaseUrl: "mysql://root:root@localhost:3306/queue" | "postgresql://root:root@localhost:5432/queue
+  //queueReferenceApiUrl: // for PGBOSS (or future queue types), a get request will be done on ${queueReferenceApiUrl}/{jobId} to get the reference number you wish to display to the user.
   queueServicePollingInterval: "500",
 
   allowUserTemplates: false,

--- a/runner/package.json
+++ b/runner/package.json
@@ -73,6 +73,7 @@
     "nodemailer": "~6.6.0",
     "notifications-node-client": "^7.0.4",
     "nunjucks": "^3.2.3",
+    "pg-boss": "^9.0.3",
     "resolve": "^1.19.0",
     "schmervice": "^1.6.0",
     "tmp": "^0.2.1",

--- a/runner/src/server/forms/test.json
+++ b/runner/src/server/forms/test.json
@@ -469,11 +469,11 @@
   "payApiKey": "",
   "outputs": [
     {
-      "name": "Ric43H5Ctwl4NBDC9x1_4",
-      "title": "email",
-      "type": "email",
+      "name": "LwQeVI",
+      "title": "Test webhook",
+      "type": "webhook",
       "outputConfiguration": {
-        "emailAddress": "jennifermyanh.duong@digital.homeoffice.gov.uk"
+        "url": "https://61bca17e-fe74-40e0-9c15-a901ad120eca.mock.pstmn.io"
       }
     }
   ],

--- a/runner/src/server/index.ts
+++ b/runner/src/server/index.ts
@@ -39,6 +39,7 @@ import getRequestInfo from "./utils/getRequestInfo";
 import { pluginQueue } from "server/plugins/queue";
 import { QueueStatusService } from "server/services/queueStatusService";
 import { QueueService } from "server/services/queueService";
+import { PgBossQueueService } from "server/services/pgBossQueueService";
 
 const serverOptions = (): ServerOptions => {
   const hasCertificate = config.sslKey && config.sslCert;
@@ -124,8 +125,11 @@ async function createServer(routeConfig: RouteConfig) {
   server.registerService([EmailService]);
 
   if (config.enableQueueService) {
+    const queueType = config.queueType;
+    const queueService =
+      queueType === "PGBOSS" ? PgBossQueueService : QueueService;
     server.registerService([
-      QueueService,
+      queueService,
       Schmervice.withName("statusService", QueueStatusService),
     ]);
   } else {

--- a/runner/src/server/index.ts
+++ b/runner/src/server/index.ts
@@ -129,7 +129,7 @@ async function createServer(routeConfig: RouteConfig) {
     const queueService =
       queueType === "PGBOSS" ? PgBossQueueService : MySqlQueueService;
     server.registerService([
-      queueService,
+      Schmervice.withName("queueService", queueService),
       Schmervice.withName("statusService", QueueStatusService),
     ]);
   } else {

--- a/runner/src/server/index.ts
+++ b/runner/src/server/index.ts
@@ -38,7 +38,7 @@ import { HapiRequest, HapiResponseToolkit, RouteConfig } from "./types";
 import getRequestInfo from "./utils/getRequestInfo";
 import { pluginQueue } from "server/plugins/queue";
 import { QueueStatusService } from "server/services/queueStatusService";
-import { QueueService } from "server/services/queueService";
+import { MySqlQueueService } from "server/services/mySqlQueueService";
 import { PgBossQueueService } from "server/services/pgBossQueueService";
 
 const serverOptions = (): ServerOptions => {
@@ -127,7 +127,7 @@ async function createServer(routeConfig: RouteConfig) {
   if (config.enableQueueService) {
     const queueType = config.queueType;
     const queueService =
-      queueType === "PGBOSS" ? PgBossQueueService : QueueService;
+      queueType === "PGBOSS" ? PgBossQueueService : MySqlQueueService;
     server.registerService([
       queueService,
       Schmervice.withName("statusService", QueueStatusService),

--- a/runner/src/server/prismaClient.ts
+++ b/runner/src/server/prismaClient.ts
@@ -39,7 +39,7 @@ if (config.enableQueueService && config.queueType === "MYSQL") {
   );
   prisma.$connect().catch((error) => {
     prismaLogger.fatal(
-      `ENABLE_QUEUE_SERVICE is set to true, but Prisma failed to connect ${error}, exiting with status 1`
+      `ENABLE_QUEUE_SERVICE is set to true, and queueType is set to MYSQL but Prisma failed to connect ${error}, exiting with status 1`
     );
     process.exit(1);
   });

--- a/runner/src/server/prismaClient.ts
+++ b/runner/src/server/prismaClient.ts
@@ -33,8 +33,10 @@ export const prisma: PrismaClient = new PrismaClient({
   log: logLevel,
 });
 
-if (config.enableQueueService) {
-  prismaLogger.info("ENABLE_QUEUE_SERVICE is true, connecting to Prisma");
+if (config.enableQueueService && config.queueType === "MYSQL") {
+  prismaLogger.info(
+    "ENABLE_QUEUE_SERVICE is true, and queueType is set to MYSQL connecting to Prisma"
+  );
   prisma.$connect().catch((error) => {
     prismaLogger.fatal(
       `ENABLE_QUEUE_SERVICE is set to true, but Prisma failed to connect ${error}, exiting with status 1`

--- a/runner/src/server/services/QueueService.ts
+++ b/runner/src/server/services/QueueService.ts
@@ -19,7 +19,7 @@ export abstract class QueueService {
   abstract sendToQueue(
     data: object,
     url: string,
-    allowRetry: boolean
+    allowRetry?: boolean
   ): Promise<QueueResponse>;
 
   abstract pollForRef(rowId: number | string): Promise<string | void>;

--- a/runner/src/server/services/QueueService.ts
+++ b/runner/src/server/services/QueueService.ts
@@ -22,7 +22,5 @@ export abstract class QueueService {
     allowRetry?: boolean
   ): Promise<QueueResponse>;
 
-  abstract pollForRef(rowId: number | string): Promise<string | void>;
-
   abstract getReturnRef(rowId: number | string): Promise<string | null>;
 }

--- a/runner/src/server/services/QueueService.ts
+++ b/runner/src/server/services/QueueService.ts
@@ -1,0 +1,28 @@
+import { HapiServer } from "server/types";
+
+type QueueResponse = [number | string, string | undefined];
+
+export abstract class QueueService {
+  logger: HapiServer["logger"];
+
+  constructor(server: HapiServer) {
+    this.logger = server.logger;
+  }
+
+  /**
+   * Send data from form submission to submission queue
+   * @param data
+   * @param url
+   * @param allowRetry
+   * @returns The ID of the newly added row, or undefined in the event of an error
+   */
+  abstract sendToQueue(
+    data: object,
+    url: string,
+    allowRetry: boolean
+  ): Promise<QueueResponse>;
+
+  abstract pollForRef(rowId: number): Promise<string | void>;
+
+  abstract getReturnRef(rowId: number): Promise<string>;
+}

--- a/runner/src/server/services/QueueService.ts
+++ b/runner/src/server/services/QueueService.ts
@@ -22,7 +22,7 @@ export abstract class QueueService {
     allowRetry: boolean
   ): Promise<QueueResponse>;
 
-  abstract pollForRef(rowId: number): Promise<string | void>;
+  abstract pollForRef(rowId: number | string): Promise<string | void>;
 
-  abstract getReturnRef(rowId: number): Promise<string>;
+  abstract getReturnRef(rowId: number | string): Promise<string | null>;
 }

--- a/runner/src/server/services/httpService.ts
+++ b/runner/src/server/services/httpService.ts
@@ -25,7 +25,7 @@ export const request: Request = async (method, url, options = {}) => {
   }
 };
 
-export const get = <T = any>(url: string, options?: object) => {
+export const get = <T>(url: string, options?: object) => {
   return request<T>("get", url, options);
 };
 

--- a/runner/src/server/services/mySqlQueueService.ts
+++ b/runner/src/server/services/mySqlQueueService.ts
@@ -4,7 +4,7 @@ import { prisma } from "../prismaClient";
 import config from "../config";
 
 type QueueResponse = [number, string | undefined];
-export class QueueService {
+export class MySqlQueueService {
   prisma: PrismaClient;
   logger: HapiServer["logger"];
   interval: number;

--- a/runner/src/server/services/mySqlQueueService.ts
+++ b/runner/src/server/services/mySqlQueueService.ts
@@ -9,7 +9,6 @@ export class MySqlQueueService extends QueueService {
   prisma: PrismaClient;
   logger: HapiServer["logger"];
   interval: number;
-  // emitter: EventEmitter;
 
   constructor(server: HapiServer) {
     super(server);
@@ -82,7 +81,6 @@ export class MySqlQueueService extends QueueService {
       }, config.queueServicePollingInterval);
     });
   }
-
   async getReturnRef(rowId: number) {
     const row = await this.prisma.submission.findUnique({
       select: {
@@ -95,6 +93,6 @@ export class MySqlQueueService extends QueueService {
     if (!row) {
       throw new Error("Submission row not found");
     }
-    return row?.return_reference;
+    return row.return_reference;
   }
 }

--- a/runner/src/server/services/mySqlQueueService.ts
+++ b/runner/src/server/services/mySqlQueueService.ts
@@ -2,17 +2,18 @@ import { HapiServer } from "server/types";
 import { PrismaClient } from "@xgovformbuilder/queue-model";
 import { prisma } from "../prismaClient";
 import config from "../config";
+import { QueueService } from "server/services/QueueService";
 
 type QueueResponse = [number, string | undefined];
-export class MySqlQueueService {
+export class MySqlQueueService extends QueueService {
   prisma: PrismaClient;
   logger: HapiServer["logger"];
   interval: number;
   // emitter: EventEmitter;
 
   constructor(server: HapiServer) {
+    super(server);
     this.prisma = prisma;
-    this.logger = server.logger;
     this.interval = parseInt(config.queueServicePollingInterval);
   }
 

--- a/runner/src/server/services/pgBossQueueService.ts
+++ b/runner/src/server/services/pgBossQueueService.ts
@@ -18,7 +18,7 @@ export class PgBossQueueService extends QueueService {
   sendToQueue(
     data: object,
     url: string,
-    allowRetry: boolean
+    allowRetry?: boolean
   ): Promise<QueueResponse> {
     return Promise.resolve(undefined);
   }

--- a/runner/src/server/services/pgBossQueueService.ts
+++ b/runner/src/server/services/pgBossQueueService.ts
@@ -1,5 +1,5 @@
 import { QueueService } from "server/services/QueueService";
-import server from "src/server";
+type QueueResponse = [number | string, string | undefined];
 
 export class PgBossQueueService extends QueueService {
   constructor(server) {
@@ -7,7 +7,7 @@ export class PgBossQueueService extends QueueService {
     this.logger.info("Using PGBossQueueService");
   }
 
-  getReturnRef(rowId: number): Promise<string> {
+  getReturnRef(rowId: string): Promise<string> {
     return Promise.resolve("");
   }
 

--- a/runner/src/server/services/pgBossQueueService.ts
+++ b/runner/src/server/services/pgBossQueueService.ts
@@ -79,7 +79,7 @@ export class PgBossQueueService extends QueueService {
       throw Error("Job could not be created");
     }
 
-    this.logger.info(logMetadata, `success: ${jobId}`);
+    this.logger.info(logMetadata, `success job created with id: ${jobId}`);
     try {
       const newRowRef = await this.getReturnRef(jobId);
       this.logger.info(

--- a/runner/src/server/services/pgBossQueueService.ts
+++ b/runner/src/server/services/pgBossQueueService.ts
@@ -33,8 +33,12 @@ export class PgBossQueueService extends QueueService {
    * This request will happen once, and timeout in 2s.
    */
   async getReturnRef(jobId: string): Promise<string> {
-    const url = new URL(jobId, this.queueReferenceApiUrl).toString();
-    const { res, payload, error } = await get(url, { timeout: 2000 });
+    const url = `${this.queueReferenceApiUrl}/${jobId}`;
+    const { res, payload, error } = await get(url, {
+      path: jobId,
+      timeout: 2000,
+      json: true,
+    });
     this.logger.info(
       ["PgBossQueueService", "getReturnRef"],
       `GET to ${url} responded with ${res.statusCode}`

--- a/runner/src/server/services/pgBossQueueService.ts
+++ b/runner/src/server/services/pgBossQueueService.ts
@@ -1,0 +1,3 @@
+import { QueueService } from "server/services/queueService";
+
+export class PgBossQueueService extends QueueService {}

--- a/runner/src/server/services/pgBossQueueService.ts
+++ b/runner/src/server/services/pgBossQueueService.ts
@@ -1,8 +1,25 @@
-import { MySqlQueueService } from "server/services/mySqlQueueService";
+import { QueueService } from "server/services/QueueService";
+import server from "src/server";
 
-export class PgBossQueueService extends MySqlQueueService {
+export class PgBossQueueService extends QueueService {
   constructor(server) {
     super(server);
     this.logger.info("Using PGBossQueueService");
+  }
+
+  getReturnRef(rowId: number): Promise<string> {
+    return Promise.resolve("");
+  }
+
+  pollForRef(rowId: number): Promise<string | void> {
+    return Promise.resolve(undefined);
+  }
+
+  sendToQueue(
+    data: object,
+    url: string,
+    allowRetry: boolean
+  ): Promise<QueueResponse> {
+    return Promise.resolve(undefined);
   }
 }

--- a/runner/src/server/services/pgBossQueueService.ts
+++ b/runner/src/server/services/pgBossQueueService.ts
@@ -1,6 +1,6 @@
-import { QueueService } from "server/services/queueService";
+import { MySqlQueueService } from "server/services/mySqlQueueService";
 
-export class PgBossQueueService extends QueueService {
+export class PgBossQueueService extends MySqlQueueService {
   constructor(server) {
     super(server);
     this.logger.info("Using PGBossQueueService");

--- a/runner/src/server/services/pgBossQueueService.ts
+++ b/runner/src/server/services/pgBossQueueService.ts
@@ -1,3 +1,8 @@
 import { QueueService } from "server/services/queueService";
 
-export class PgBossQueueService extends QueueService {}
+export class PgBossQueueService extends QueueService {
+  constructor(server) {
+    super(server);
+    this.logger.info("Using PGBossQueueService");
+  }
+}

--- a/runner/src/server/services/queueStatusService.ts
+++ b/runner/src/server/services/queueStatusService.ts
@@ -1,10 +1,10 @@
 import { StatusService } from "server/services/statusService";
 import { HapiRequest, HapiServer } from "server/types";
 import Boom from "boom";
-import { QueueService } from "server/services/queueService";
+import { MySqlQueueService } from "server/services/mySqlQueueService";
 
 export class QueueStatusService extends StatusService {
-  queueService: QueueService;
+  queueService: MySqlQueueService;
   constructor(server: HapiServer) {
     super(server);
     const { queueService } = server.services([]);

--- a/runner/src/server/services/queueStatusService.ts
+++ b/runner/src/server/services/queueStatusService.ts
@@ -2,9 +2,10 @@ import { StatusService } from "server/services/statusService";
 import { HapiRequest, HapiServer } from "server/types";
 import Boom from "boom";
 import { MySqlQueueService } from "server/services/mySqlQueueService";
+import { PgBossQueueService } from "server/services/pgBossQueueService";
 
 export class QueueStatusService extends StatusService {
-  queueService: MySqlQueueService;
+  queueService: MySqlQueueService | PgBossQueueService;
   constructor(server: HapiServer) {
     super(server);
     const { queueService } = server.services([]);

--- a/runner/src/server/types.ts
+++ b/runner/src/server/types.ts
@@ -19,7 +19,7 @@ import {
   WebhookService,
 } from "./services";
 import { QueueStatusService } from "server/services/queueStatusService";
-import { MySqlQueueService } from "server/services/mySqlQueueService";
+import { QueueService } from "./services/QueueService";
 
 type Services = (
   services: string[]
@@ -31,7 +31,7 @@ type Services = (
   uploadService: UploadService;
   webhookService: WebhookService;
   statusService: StatusService;
-  queueService: MySqlQueueService;
+  queueService: QueueService;
   queueStatusService: QueueStatusService;
 };
 

--- a/runner/src/server/types.ts
+++ b/runner/src/server/types.ts
@@ -19,7 +19,7 @@ import {
   WebhookService,
 } from "./services";
 import { QueueStatusService } from "server/services/queueStatusService";
-import { QueueService } from "server/services/queueService";
+import { MySqlQueueService } from "server/services/mySqlQueueService";
 
 type Services = (
   services: string[]
@@ -31,7 +31,7 @@ type Services = (
   uploadService: UploadService;
   webhookService: WebhookService;
   statusService: StatusService;
-  queueService: QueueService;
+  queueService: MySqlQueueService;
   queueStatusService: QueueStatusService;
 };
 

--- a/runner/src/server/utils/configSchema.ts
+++ b/runner/src/server/utils/configSchema.ts
@@ -113,7 +113,7 @@ export const configSchema = Joi.object({
   enableQueueService: Joi.boolean().optional(),
   queueType: Joi.string().when("enableQueueService", {
     is: true,
-    then: Joi.required().allow("MYSQL", "PGBOSS"),
+    then: Joi.required().allow("MYSQL", "PGBOSS").default("MYSQL"),
     otherwise: Joi.optional().allow(""),
   }),
   queueDatabaseUrl: Joi.string().when("enableQueueService", {

--- a/runner/src/server/utils/configSchema.ts
+++ b/runner/src/server/utils/configSchema.ts
@@ -126,6 +126,11 @@ export const configSchema = Joi.object({
     then: Joi.required(),
     otherwise: Joi.optional(),
   }),
+  queueReferenceApiUrl: Joi.string().when("queueType", {
+    is: "PGBOSS",
+    then: Joi.string().uri().required(),
+    otherwise: Joi.optional().allow(""),
+  }),
   allowUserTemplates: Joi.boolean().optional(),
 });
 

--- a/runner/src/server/utils/configSchema.ts
+++ b/runner/src/server/utils/configSchema.ts
@@ -111,6 +111,11 @@ export const configSchema = Joi.object({
     .default("HS512"),
 
   enableQueueService: Joi.boolean().optional(),
+  queueType: Joi.string().when("enableQueueService", {
+    is: true,
+    then: Joi.required().allow("MYSQL", "PGBOSS"),
+    otherwise: Joi.optional().allow(""),
+  }),
   queueDatabaseUrl: Joi.string().when("enableQueueService", {
     is: true,
     then: Joi.required(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -5176,6 +5176,7 @@ __metadata:
     nodemon: ^3.0.2
     notifications-node-client: ^7.0.4
     nunjucks: ^3.2.3
+    pg-boss: ^9.0.3
     pino: 8.15.1
     prisma: ^5.1.1
     resolve: ^1.19.0
@@ -6775,6 +6776,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-writer@npm:2.0.0":
+  version: 2.0.0
+  resolution: "buffer-writer@npm:2.0.0"
+  checksum: 11736b48bb75106c52ca8ec9f025e7c1b3b25ce31875f469d7210eabd5c576c329e34f6b805d4a8d605ff3f0db1e16342328802c4c963e9c826b0e43a4e631c2
+  languageName: node
+  linkType: hard
+
 "buffer-xor@npm:^1.0.3":
   version: 1.0.3
   resolution: "buffer-xor@npm:1.0.3"
@@ -7921,6 +7929,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cron-parser@npm:^4.0.0":
+  version: 4.9.0
+  resolution: "cron-parser@npm:4.9.0"
+  dependencies:
+    luxon: ^3.2.1
+  checksum: 3cf248fc5cae6c19ec7124962b1cd84b76f02b9bc4f58976b3bd07624db3ef10aaf1548efcc2d2dcdab0dad4f12029d640a55ecce05ea5e1596af9db585502cf
+  languageName: node
+  linkType: hard
+
 "cron@npm:^1.7.1":
   version: 1.8.2
   resolution: "cron@npm:1.8.2"
@@ -8469,6 +8486,13 @@ __metadata:
     pify: ^4.0.1
     rimraf: ^2.6.3
   checksum: 521f7da44bd79da841c06d573923d1f64f423aee8b8219c973478d3150ce1dcc024d03ad605929292adbff56d6448bca60d96dcdd2d8a53b46dbcb27e265c94b
+  languageName: node
+  linkType: hard
+
+"delay@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "delay@npm:5.0.0"
+  checksum: 62f151151ecfde0d9afbb8a6be37a6d103c4cb24f35a20ef3fe56f920b0d0d0bb02bc9c0a3084d0179ef669ca332b91155f2ee4d9854622cd2cdba5fc95285f9
   languageName: node
   linkType: hard
 
@@ -15105,6 +15129,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"luxon@npm:^3.2.1":
+  version: 3.4.4
+  resolution: "luxon@npm:3.4.4"
+  checksum: 36c1f99c4796ee4bfddf7dc94fa87815add43ebc44c8934c924946260a58512f0fd2743a629302885df7f35ccbd2d13f178c15df046d0e3b6eb71db178f1c60c
+  languageName: node
+  linkType: hard
+
 "lz-string@npm:^1.5.0":
   version: 1.5.0
   resolution: "lz-string@npm:1.5.0"
@@ -16602,6 +16633,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"packet-reader@npm:1.0.0":
+  version: 1.0.0
+  resolution: "packet-reader@npm:1.0.0"
+  checksum: 0b7516f0cbf3e322aad591bed29ba544220088c53943145c0d9121a6f59182ad811f7fd6785a8979a34356aca69d97653689029964c5998dc02645633d88ffd7
+  languageName: node
+  linkType: hard
+
 "pako@npm:~1.0.2, pako@npm:~1.0.5":
   version: 1.0.11
   resolution: "pako@npm:1.0.11"
@@ -16887,6 +16925,104 @@ __metadata:
   version: 2.1.0
   resolution: "performance-now@npm:2.1.0"
   checksum: 534e641aa8f7cba160f0afec0599b6cecefbb516a2e837b512be0adbe6c1da5550e89c78059c7fabc5c9ffdf6627edabe23eb7c518c4500067a898fa65c2b550
+  languageName: node
+  linkType: hard
+
+"pg-boss@npm:^9.0.3":
+  version: 9.0.3
+  resolution: "pg-boss@npm:9.0.3"
+  dependencies:
+    cron-parser: ^4.0.0
+    delay: ^5.0.0
+    lodash.debounce: ^4.0.8
+    p-map: ^4.0.0
+    pg: ^8.5.1
+    serialize-error: ^8.1.0
+    uuid: ^9.0.0
+  checksum: d720acf61c42cd9b92a77367bd63330f25a6dd7123ad61b05648661e32f14d223b717f9fb25a4172f28719d6c31fc34a5f4979895816248b4d8542cd97fd3541
+  languageName: node
+  linkType: hard
+
+"pg-cloudflare@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "pg-cloudflare@npm:1.1.1"
+  checksum: 32aac06b5dc4588bbf78801b6267781bc7e13be672009df949d08e9627ba9fdc26924916665d4de99d47f9b0495301930547488dad889d826856976c7b3f3731
+  languageName: node
+  linkType: hard
+
+"pg-connection-string@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "pg-connection-string@npm:2.6.2"
+  checksum: 22265882c3b6f2320785378d0760b051294a684989163d5a1cde4009e64e84448d7bf67d9a7b9e7f69440c3ee9e2212f9aa10dd17ad6773f6143c6020cebbcb5
+  languageName: node
+  linkType: hard
+
+"pg-int8@npm:1.0.1":
+  version: 1.0.1
+  resolution: "pg-int8@npm:1.0.1"
+  checksum: a1e3a05a69005ddb73e5f324b6b4e689868a447c5fa280b44cd4d04e6916a344ac289e0b8d2695d66e8e89a7fba023affb9e0e94778770ada5df43f003d664c9
+  languageName: node
+  linkType: hard
+
+"pg-pool@npm:^3.6.1":
+  version: 3.6.1
+  resolution: "pg-pool@npm:3.6.1"
+  peerDependencies:
+    pg: ">=8.0"
+  checksum: 8a6513e6f74a794708c9dd16d2ccda0debadc56435ec2582de2b2e35b01315550c5dab8a0a9a2a16f4adce45523228f5739940fb7687ec7e9c300f284eb08fd1
+  languageName: node
+  linkType: hard
+
+"pg-protocol@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "pg-protocol@npm:1.6.0"
+  checksum: e12662d2de2011e0c3a03f6a09f435beb1025acdc860f181f18a600a5495dc38a69d753bbde1ace279c8c442536af9c1a7c11e1d0fe3fad3aa1348b28d9d2683
+  languageName: node
+  linkType: hard
+
+"pg-types@npm:^2.1.0":
+  version: 2.2.0
+  resolution: "pg-types@npm:2.2.0"
+  dependencies:
+    pg-int8: 1.0.1
+    postgres-array: ~2.0.0
+    postgres-bytea: ~1.0.0
+    postgres-date: ~1.0.4
+    postgres-interval: ^1.1.0
+  checksum: bf4ec3f594743442857fb3a8dfe5d2478a04c98f96a0a47365014557cbc0b4b0cee01462c79adca863b93befbf88f876299b75b72c665b5fb84a2c94fbd10316
+  languageName: node
+  linkType: hard
+
+"pg@npm:^8.5.1":
+  version: 8.11.3
+  resolution: "pg@npm:8.11.3"
+  dependencies:
+    buffer-writer: 2.0.0
+    packet-reader: 1.0.0
+    pg-cloudflare: ^1.1.1
+    pg-connection-string: ^2.6.2
+    pg-pool: ^3.6.1
+    pg-protocol: ^1.6.0
+    pg-types: ^2.1.0
+    pgpass: 1.x
+  peerDependencies:
+    pg-native: ">=3.0.1"
+  dependenciesMeta:
+    pg-cloudflare:
+      optional: true
+  peerDependenciesMeta:
+    pg-native:
+      optional: true
+  checksum: 8af9468b8969fa0d73a6b349216c8cbc953d938fcae5594f2d24043060e9226a072c8085fc4230172b5576fcab4c39c8563c655f271dc2a9209b6ad5370cafe5
+  languageName: node
+  linkType: hard
+
+"pgpass@npm:1.x":
+  version: 1.0.5
+  resolution: "pgpass@npm:1.0.5"
+  dependencies:
+    split2: ^4.1.0
+  checksum: 947ac096c031eebdf08d989de2e9f6f156b8133d6858c7c2c06c041e1e71dda6f5f3bad3c0ec1e96a09497bbc6ef89e762eefe703b5ef9cb2804392ec52ec400
   languageName: node
   linkType: hard
 
@@ -17213,6 +17349,36 @@ __metadata:
     picocolors: ^1.0.0
     source-map-js: ^1.0.2
   checksum: 6f98b2af4b76632a3de20c4f47bf0e984a1ce1a531cf11adcb0b1d63a6cbda0aae4165e578b66c32ca4879038e3eaad386a6be725a8fb4429c78e3c1ab858fe9
+  languageName: node
+  linkType: hard
+
+"postgres-array@npm:~2.0.0":
+  version: 2.0.0
+  resolution: "postgres-array@npm:2.0.0"
+  checksum: 0e1e659888147c5de579d229a2d95c0d83ebdbffc2b9396d890a123557708c3b758a0a97ed305ce7f58edfa961fa9f0bbcd1ea9f08b6e5df73322e683883c464
+  languageName: node
+  linkType: hard
+
+"postgres-bytea@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "postgres-bytea@npm:1.0.0"
+  checksum: d844ae4ca7a941b70e45cac1261a73ee8ed39d72d3d74ab1d645248185a1b7f0ac91a3c63d6159441020f4e1f7fe64689ac56536a307b31cef361e5187335090
+  languageName: node
+  linkType: hard
+
+"postgres-date@npm:~1.0.4":
+  version: 1.0.7
+  resolution: "postgres-date@npm:1.0.7"
+  checksum: 5745001d47e51cd767e46bcb1710649cd705d91a24d42fa661c454b6dcbb7353c066a5047983c90a626cd3bbfea9e626cc6fa84a35ec57e5bbb28b49f78e13ed
+  languageName: node
+  linkType: hard
+
+"postgres-interval@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "postgres-interval@npm:1.2.0"
+  dependencies:
+    xtend: ^4.0.0
+  checksum: 746b71f93805ae33b03528e429dc624706d1f9b20ee81bf743263efb6a0cd79ae02a642a8a480dbc0f09547b4315ab7df6ce5ec0be77ed700bac42730f5c76b2
   languageName: node
   linkType: hard
 
@@ -18856,6 +19022,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"serialize-error@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "serialize-error@npm:8.1.0"
+  dependencies:
+    type-fest: ^0.20.2
+  checksum: 2eef236d50edd2d7926e602c14fb500dc3a125ee52e9f08f67033181b8e0be5d1122498bdf7c23c80683cddcad083a27974e9e7111ce23165f4d3bcdd6d65102
+  languageName: node
+  linkType: hard
+
 "serialize-javascript@npm:^4.0.0":
   version: 4.0.0
   resolution: "serialize-javascript@npm:4.0.0"
@@ -19445,7 +19620,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"split2@npm:^4.0.0":
+"split2@npm:^4.0.0, split2@npm:^4.1.0":
   version: 4.2.0
   resolution: "split2@npm:4.2.0"
   checksum: 05d54102546549fe4d2455900699056580cca006c0275c334611420f854da30ac999230857a85fdd9914dc2109ae50f80fda43d2a445f2aa86eccdc1dfce779d
@@ -21024,6 +21199,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.0":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

To reduce support/maintenance workloads and better conform to event driven and microservice architecture, we are adding support for pg-boss https://github.com/timgit/pg-boss. 

pg-boss relies on PostgreSQL to queue jobs and easily allow processing of jobs. It also leverages node's event features (e.g. events and event emitter) to improve performance. PostgreSQL has features with messaging built in mind, for example `SKIP LOCKED` to ensure rows are not being read or written by different processes. The MySQL based submitter does not currently do this.

- Add support for PGBOSS queues

to use pg-boss, you must have
- a postgres database 
- set `QUEUE_TYPE=PGBOSS`
- set `QUEUE_REFERENCE_API_URL`
  - this endpoint must accept a GET request at `${QUEUE_REFERENCE_API_URL}/{job_id}`, and return a reference number for the user. Since queueing is used, as long as adding the users' submission to the queue was successful, the user will see a confirmation page

Further documentation can be found at `docs/runner/submission-queue.md`.

The ADR has also been amended. 



## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [x] Manual


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry