### PR TITLE
feat: Redirect page controller

### DIFF
--- a/runner/src/server/forms/redirects-example.json
+++ b/runner/src/server/forms/redirects-example.json
@@ -1,0 +1,33 @@
+{
+  "metadata": {},
+  "startPage": "/first-page",
+  "pages": [
+    {
+      "title": "First page",
+      "path": "/first-page",
+      "components": [],
+      "next": [{ "path": "/second-page" }],
+      "controller": "RedirectPageController"
+    },
+    {
+      "path": "/second-page",
+      "title": "Second page",
+      "components": [],
+      "next": [{ "path": "/summary" }]
+    },
+    {
+      "title": "Summary",
+      "path": "/summary",
+      "controller": "./pages/summary.js",
+      "components": []
+    }
+  ],
+  "lists": [],
+  "sections": [],
+  "conditions": [],
+  "fees": [],
+  "outputs": [],
+  "version": 2,
+  "skipSummary": false,
+  "feeOptions": {}
+}

--- a/runner/src/server/plugins/engine/pageControllers/RedirectPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RedirectPageController.ts
@@ -1,0 +1,24 @@
+import { PageController } from "server/plugins/engine/pageControllers/PageController";
+import { FormModel } from "server/plugins/engine/models";
+import { HapiRequest, HapiResponseToolkit } from "server/types";
+import * as redirectsMap from "server/templates/redirects.json";
+
+export class RedirectPageController extends PageController {
+  redirectMap: Record<string, string>;
+  constructor(model: FormModel, pageDef: any) {
+    super(model, pageDef);
+    this.redirectMap = redirectsMap;
+  }
+
+  makeGetRouteHandler() {
+    return async (request: HapiRequest, h: HapiResponseToolkit) => {
+      const { url } = request;
+      const pathWithQuery = `${url.pathname}${url.search}`;
+      if (this.redirectMap[pathWithQuery]) {
+        return h.redirect(this.redirectMap[pathWithQuery]);
+      }
+
+      return super.makeGetRouteHandler()(request, h);
+    };
+  }
+}

--- a/runner/src/server/plugins/engine/pageControllers/helpers.ts
+++ b/runner/src/server/plugins/engine/pageControllers/helpers.ts
@@ -10,6 +10,7 @@ import { PageControllerBase } from "./PageControllerBase";
 import { RepeatingFieldPageController } from "./RepeatingFieldPageController";
 import { Page } from "@xgovformbuilder/model";
 import { UploadPageController } from "server/plugins/engine/pageControllers/UploadPageController";
+import { RedirectPageController } from "server/plugins/engine/pageControllers/RedirectPageController";
 
 const PageControllers = {
   DobPageController,
@@ -21,6 +22,7 @@ const PageControllers = {
   PageControllerBase,
   RepeatingFieldPageController,
   UploadPageController,
+  RedirectPageController,
 };
 
 export const controllerNameFromPath = (filePath: string) => {

--- a/runner/src/server/plugins/engine/pageControllers/index.ts
+++ b/runner/src/server/plugins/engine/pageControllers/index.ts
@@ -5,4 +5,5 @@ export { StartDatePageController } from "./StartDatePageController";
 export { StartPageController } from "./StartPageController";
 export { SummaryPageController } from "./SummaryPageController";
 export { PageControllerBase } from "./PageControllerBase";
+export { RedirectPageController } from "./RedirectPageController";
 export { getPageController, controllerNameFromPath } from "./helpers";

--- a/runner/src/server/templates/redirects.json
+++ b/runner/src/server/templates/redirects.json
@@ -1,0 +1,4 @@
+{
+  "/redirects-example/first-page?goto=google": "https://google.co.uk",
+  "/redirects-example/first-page?goto=govuk": "https://gov.uk"
+}


### PR DESCRIPTION
# Description

Sometimes there might be part of a user's application process that cannot be handled in the form runner, and therefore the user needs to be redirected to another application. Previously to achieve this effect there would need to be a content page with a link to the other service.

This PR adds a redirect page controller> When a page is using this controller, if there is a matching pattern in `templates/redirects.json`, the user will be automatically redirected to the specified location.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [X] Manual testing using redirects example form
- [X] Redirect page controller smoke tests

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
