### PR TITLE
fix: prevent form runner from automatically redirecting to start page when query params have been filled in

### DIFF
--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -450,6 +450,7 @@ export class PageControllerBase {
       const shouldRedirectToStartPage =
         !this.model.options.previewMode &&
         progress.length === 0 &&
+        !request.pre.hasPrepopulatedSessionFromQueryParameter &&
         !isStartPage &&
         !isInitialisedSession;
 

--- a/runner/src/server/plugins/engine/plugin.ts
+++ b/runner/src/server/plugins/engine/plugin.ts
@@ -212,6 +212,9 @@ export const plugin = {
         state
       );
       await cacheService.mergeState(request, newValues);
+      if (Object.keys(newValues).length > 0) {
+        h.request.pre.hasPrepopulatedSessionFromQueryParameter = true;
+      }
       return h.continue;
     };
 


### PR DESCRIPTION
# Description

Previously, due to the form progress being empty in the state, the user would be automatically redirected to the start page even if they were using query parameters to skip these pages. This PR adds a `hasPrepopulatedSessionFromQueryParameter` flag to the request pre object to prevent redirecting in this first instance.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [X] Manual testing with a few different scenarios

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
