### PR TITLE
feat: allow pollingTimeout to be configured for pgboss

### DIFF
--- a/docs/runner/submission-queue.md
+++ b/docs/runner/submission-queue.md
@@ -88,6 +88,7 @@ When using pgboss, it is important that successful work returns `{ reference }` 
 | QUEUE_DATABASE_USERNAME        | Used for configuring the user being used to access the database                          |         | root                                        |
 | QUEUE_DATABASE_PASSWORD        | Used for configuring the password used for accessing the database                        |         | password                                    |
 | QUEUE_SERVICE_POLLING_INTERVAL | The amount of time, in milliseconds, between poll requests for updates from the database | 500     |                                             |
+| QUEUE_SERVICE_POLLING_TIMEOUT  | The total amount of time, in milliseconds, to poll requests for from the database        | 2000    |                                             |
 
 Webhooks can be configured so that the submitter only attempts to post to the webhook URL once.
 

--- a/runner/config/custom-environment-variables.json
+++ b/runner/config/custom-environment-variables.json
@@ -52,5 +52,6 @@
   "queueDatabaseUsername": "QUEUE_DATABASE_USERNAME",
   "queueDatabasePassword": "QUEUE_DATABASE_PASSWORD",
   "queueServicePollingInterval": "QUEUE_SERVICE_POLLING_INTERVAL",
+  "queueServicePollingTimeout": "QUEUE_SERVICE_POLLING_TIMEOUT",
   "allowUserTemplates": "ALLOW_USER_TEMPLATES"
 }

--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -139,6 +139,7 @@ module.exports = {
   // queueType: "" // accepts "MYSQL" | "PGBOSS"
   // queueDatabaseUrl: "mysql://root:root@localhost:3306/queue" | "postgresql://root:root@localhost:5432/queue
   queueServicePollingInterval: "500",
+  queueServicePollingTimeout: "2000",
 
   allowUserTemplates: false,
 };

--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -138,8 +138,8 @@ module.exports = {
   enableQueueService: false,
   // queueType: "" // accepts "MYSQL" | "PGBOSS"
   // queueDatabaseUrl: "mysql://root:root@localhost:3306/queue" | "postgresql://root:root@localhost:5432/queue
-  queueServicePollingInterval: "500",
-  queueServicePollingTimeout: "2000",
+  queueServicePollingInterval: "500", // How frequently to check the queue for a reference number
+  queueServicePollingTimeout: "2000", // Total time to wait for a reference number
 
   allowUserTemplates: false,
 };

--- a/runner/src/server/services/pgBossQueueService.ts
+++ b/runner/src/server/services/pgBossQueueService.ts
@@ -22,8 +22,9 @@ export class PgBossQueueService extends QueueService {
     super(server);
     this.logger.info("Using PGBossQueueService");
     this.queueReferenceApiUrl = config.queueReferenceApiUrl;
-    this.pollingInterval = config.queueServicePollingInterval;
-    this.pollingTimeout = config.queueServicePollingTimeout;
+    this.pollingInterval = parseInt(config.queueServicePollingInterval);
+    this.pollingTimeout = parseInt(config.queueServicePollingTimeout);
+
     const boss = new PgBoss(config.queueDatabaseUrl);
     this.queue = boss;
     boss.on("error", this.logger.error);

--- a/runner/src/server/utils/configSchema.ts
+++ b/runner/src/server/utils/configSchema.ts
@@ -126,6 +126,11 @@ export const configSchema = Joi.object({
     then: Joi.required(),
     otherwise: Joi.optional(),
   }),
+  queueServicePollingTimeout: Joi.number().when("enableQueueService", {
+    is: true,
+    then: Joi.required(),
+    otherwise: Joi.optional(),
+  }),
   allowUserTemplates: Joi.boolean().optional(),
 });
 

--- a/runner/src/server/utils/configSchema.ts
+++ b/runner/src/server/utils/configSchema.ts
@@ -123,12 +123,12 @@ export const configSchema = Joi.object({
   }),
   queueServicePollingInterval: Joi.number().when("enableQueueService", {
     is: true,
-    then: Joi.required(),
+    then: Joi.number().required(),
     otherwise: Joi.optional(),
   }),
   queueServicePollingTimeout: Joi.number().when("enableQueueService", {
     is: true,
-    then: Joi.required(),
+    then: Joi.number().required(),
     otherwise: Joi.optional(),
   }),
   allowUserTemplates: Joi.boolean().optional(),


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

For slow webhooks, you may now increase how long to wait for a reference number. 


- allow `QUEUE_SERVICE_POLLING_TIMEOUT` to be configurable by env var.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [x] manual

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
