### PR TITLE
feat: added toggle for new metadata being sent to webhook

### DIFF
--- a/docs/runner/fee-options.md
+++ b/docs/runner/fee-options.md
@@ -147,15 +147,31 @@ This will be parsed and sent to GOV.UK Pay as:
 
 When viewing this payment in GOV.UK Pay, you can sort by these columns, and will appear as "metadata" in their interface.
 
+## Additional payment metadata
+
+With fee options, there is the possibility to send through more payment metadata to your webhook outputs. This metadata will tell your webhook about the status of the payment, the payment id, and the payment reference.
+
+If you require this metadata, add the `sendAdditionaPayMetadata` option to your webhook output configuration as below:
+
+```json5
+{
+  name: "outputName",
+  title: "Webhook output",
+  type: "webhook",
+  outputConfiguration: {
+    url: "https://some-url.com",
+    sendAdditionalPayMetadata: true,
+  },
+}
+```
+
 ## Other - Reference numbers
 
-Reference numbers are generated with the alphabet "1234567890ABCDEFGHIJKLMNPQRSTUVWXYZ-_". Note that the letter O is omitted.
+Reference numbers are generated with the alphabet "1234567890ABCDEFGHIJKLMNPQRSTUVWXYZ-\_". Note that the letter O is omitted.
 
-You may configure the length of the reference number by setting the environment variable `PAY_REFERENCE_LENGTH`. The default is 10 characters. 
-Use [Nano ID Collision Calculator](https://zelark.github.io/nano-id-cc/) to determine the right length for your service. 
-Since each user will "keep" their own reference number for multiple attempts, calculate the speed at unique users per hour. 
+You may configure the length of the reference number by setting the environment variable `PAY_REFERENCE_LENGTH`. The default is 10 characters.
+Use [Nano ID Collision Calculator](https://zelark.github.io/nano-id-cc/) to determine the right length for your service.
+Since each user will "keep" their own reference number for multiple attempts, calculate the speed at unique users per hour.
 
-e.g. If your service expects 100,000 users per annum, you should expect ~274 users per day, and 11 users per hour. 
+e.g. If your service expects 100,000 users per annum, you should expect ~274 users per day, and 11 users per hour.
 Using nano-id-cc, and a reference length of 10 characters it will take 102 years, or 9 million IDs generated for a 1% chance of collision.
-
-

--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -160,6 +160,7 @@ export type FeeOptions = {
   customPayErrorMessage?: string;
   showPaymentSkippedWarningPage: boolean;
   additionalReportingColumns?: AdditionalReportingColumn[];
+  sendAdditionalMetadata?: boolean;
 };
 
 /**

--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -95,7 +95,7 @@ export type NotifyOutputConfiguration = {
 
 export type WebhookOutputConfiguration = {
   url: string;
-  sendAdditionalMetadata?: boolean;
+  sendAdditionalPayMetadata?: boolean;
 };
 
 export type OutputConfiguration =

--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -95,6 +95,7 @@ export type NotifyOutputConfiguration = {
 
 export type WebhookOutputConfiguration = {
   url: string;
+  sendAdditionalMetadata?: boolean;
 };
 
 export type OutputConfiguration =
@@ -160,7 +161,6 @@ export type FeeOptions = {
   customPayErrorMessage?: string;
   showPaymentSkippedWarningPage: boolean;
   additionalReportingColumns?: AdditionalReportingColumn[];
-  sendAdditionalMetadata?: boolean;
 };
 
 /**

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -213,6 +213,7 @@ const emailSchema = joi.object().keys({
 
 const webhookSchema = joi.object().keys({
   url: joi.string(),
+  sendAdditionalMetadata: joi.boolean().optional().default(true),
   allowRetry: joi.boolean().default(true),
 });
 
@@ -269,7 +270,6 @@ const feeOptionSchema = joi
         })
       )
       .optional(),
-    sendAdditionalMetadata: joi.boolean().optional().default(true),
   })
   .default(({ payApiKey, paymentReferenceFormat }) => {
     return {

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -269,6 +269,7 @@ const feeOptionSchema = joi
         })
       )
       .optional(),
+    sendAdditionalMetadata: joi.boolean().optional().default(true),
   })
   .default(({ payApiKey, paymentReferenceFormat }) => {
     return {

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -213,7 +213,7 @@ const emailSchema = joi.object().keys({
 
 const webhookSchema = joi.object().keys({
   url: joi.string(),
-  sendAdditionalMetadata: joi.boolean().optional().default(true),
+  sendAdditionalPayMetadata: joi.boolean().optional().default(false),
   allowRetry: joi.boolean().default(true),
 });
 

--- a/runner/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/runner/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -136,8 +136,8 @@ export class SummaryViewModel {
                 type: "webhook",
                 outputData: {
                   url: output.outputConfiguration.url,
-                  sendAdditionalMetadata:
-                    output.outputConfiguration.sendAdditionalMetadata,
+                  sendAdditionalPayMetadata:
+                    output.outputConfiguration.sendAdditionalPayMetadata,
                   allowRetry: output.outputConfiguration.allowRetry,
                 },
               };

--- a/runner/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/runner/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -136,6 +136,8 @@ export class SummaryViewModel {
                 type: "webhook",
                 outputData: {
                   url: output.outputConfiguration.url,
+                  sendAdditionalMetadata:
+                    output.outputConfiguration.sendAdditionalMetadata,
                   allowRetry: output.outputConfiguration.allowRetry,
                 },
               };

--- a/runner/src/server/services/queueStatusService.ts
+++ b/runner/src/server/services/queueStatusService.ts
@@ -88,12 +88,12 @@ export class QueueStatusService extends StatusService {
 
     const requests = [
       ...notify.map((args) => this.notifyService.sendNotification(args)),
-      ...webhook.map(({ url, sendAdditionalMetadata, formData }) =>
+      ...webhook.map(({ url, sendAdditionalPayMetadata, formData }) =>
         this.webhookService.postRequest(
           url,
           formData,
           "POST",
-          sendAdditionalMetadata
+          sendAdditionalPayMetadata
         )
       ),
     ];

--- a/runner/src/server/services/queueStatusService.ts
+++ b/runner/src/server/services/queueStatusService.ts
@@ -88,8 +88,13 @@ export class QueueStatusService extends StatusService {
 
     const requests = [
       ...notify.map((args) => this.notifyService.sendNotification(args)),
-      ...webhook.map(({ url, formData }) =>
-        this.webhookService.postRequest(url, formData)
+      ...webhook.map(({ url, sendAdditionalMetadata, formData }) =>
+        this.webhookService.postRequest(
+          url,
+          formData,
+          "POST",
+          sendAdditionalMetadata
+        )
       ),
     ];
 

--- a/runner/src/server/services/statusService.ts
+++ b/runner/src/server/services/statusService.ts
@@ -1,4 +1,4 @@
-import { HapiRequest, HapiResponseToolkit, HapiServer } from "../types";
+import { HapiRequest, HapiServer } from "../types";
 import {
   CacheService,
   NotifyService,
@@ -151,7 +151,9 @@ export class StatusService {
     if (firstWebhook) {
       newReference = await this.webhookService.postRequest(
         firstWebhook.outputData.url,
-        formData
+        { ...formData },
+        "POST",
+        firstWebhook.outputData.sendAdditionalMetadata
       );
       await this.cacheService.mergeState(request, {
         reference: newReference,
@@ -167,8 +169,15 @@ export class StatusService {
 
     const requests = [
       ...notify.map((args) => this.notifyService.sendNotification(args)),
-      ...webhook.map(({ url, formData }) =>
-        this.webhookService.postRequest(url, formData)
+      ...webhook.map(({ url, sendAdditionalMetadata, formData }) =>
+        this.webhookService.postRequest(
+          url,
+          {
+            ...formData,
+          },
+          "POST",
+          sendAdditionalMetadata
+        )
       ),
     ];
 
@@ -261,11 +270,11 @@ export class StatusService {
           notify.push(args);
         }
         if (isWebhookModel(currentValue.outputData)) {
-          const { url } = currentValue.outputData;
-          webhook.push({ url, formData });
+          const { url, sendAdditionalMetadata } = currentValue.outputData;
+          webhook.push({ url, sendAdditionalMetadata, formData });
           this.logger.trace(
             ["StatusService", "outputArgs", "webhookArgs"],
-            JSON.stringify({ url, formData })
+            JSON.stringify({ url, sendAdditionalMetadata, formData })
           );
         }
 

--- a/runner/src/server/services/statusService.ts
+++ b/runner/src/server/services/statusService.ts
@@ -153,7 +153,7 @@ export class StatusService {
         firstWebhook.outputData.url,
         { ...formData },
         "POST",
-        firstWebhook.outputData.sendAdditionalMetadata
+        firstWebhook.outputData.sendAdditionalPayMetadata
       );
       await this.cacheService.mergeState(request, {
         reference: newReference,
@@ -169,14 +169,14 @@ export class StatusService {
 
     const requests = [
       ...notify.map((args) => this.notifyService.sendNotification(args)),
-      ...webhook.map(({ url, sendAdditionalMetadata, formData }) =>
+      ...webhook.map(({ url, sendAdditionalPayMetadata, formData }) =>
         this.webhookService.postRequest(
           url,
           {
             ...formData,
           },
           "POST",
-          sendAdditionalMetadata
+          sendAdditionalPayMetadata
         )
       ),
     ];
@@ -270,11 +270,11 @@ export class StatusService {
           notify.push(args);
         }
         if (isWebhookModel(currentValue.outputData)) {
-          const { url, sendAdditionalMetadata } = currentValue.outputData;
-          webhook.push({ url, sendAdditionalMetadata, formData });
+          const { url, sendAdditionalPayMetadata } = currentValue.outputData;
+          webhook.push({ url, sendAdditionalPayMetadata, formData });
           this.logger.trace(
             ["StatusService", "outputArgs", "webhookArgs"],
-            JSON.stringify({ url, sendAdditionalMetadata, formData })
+            JSON.stringify({ url, sendAdditionalPayMetadata, formData })
           );
         }
 

--- a/runner/src/server/services/webhookService.ts
+++ b/runner/src/server/services/webhookService.ts
@@ -36,7 +36,7 @@ export class WebhookService {
     let request = method === "POST" ? post : put;
     try {
       if (!sendAdditionalMetadata) {
-        delete data.metadata.pay;
+        delete data?.metadata?.pay;
       }
       const { payload } = await request(url, {
         ...DEFAULT_OPTIONS,

--- a/runner/src/server/services/webhookService.ts
+++ b/runner/src/server/services/webhookService.ts
@@ -18,9 +18,9 @@ export class WebhookService {
   /**
    * Posts data to a webhook
    * @param url - url of the webhook
-   * @param sendAdditionalMetadata - whether to include additional metadata in the request
    * @param data - object to send to the webhook
    * @param method - POST or PUT request, defaults to POST
+   * @param sendAdditionalMetadata - whether to include additional metadata in the request
    * @returns object with the property `reference` webhook if the response returns with a reference number. If the call fails, the reference will be 'UNKNOWN'.
    */
   async postRequest(

--- a/runner/src/server/services/webhookService.ts
+++ b/runner/src/server/services/webhookService.ts
@@ -18,6 +18,7 @@ export class WebhookService {
   /**
    * Posts data to a webhook
    * @param url - url of the webhook
+   * @param sendAdditionalMetadata - whether to include additional metadata in the request
    * @param data - object to send to the webhook
    * @param method - POST or PUT request, defaults to POST
    * @returns object with the property `reference` webhook if the response returns with a reference number. If the call fails, the reference will be 'UNKNOWN'.
@@ -25,7 +26,8 @@ export class WebhookService {
   async postRequest(
     url: string,
     data: object,
-    method: "POST" | "PUT" = "POST"
+    method: "POST" | "PUT" = "POST",
+    sendAdditionalMetadata: boolean = false
   ) {
     this.logger.info(
       ["WebhookService", "postRequest body"],
@@ -33,6 +35,9 @@ export class WebhookService {
     );
     let request = method === "POST" ? post : put;
     try {
+      if (!sendAdditionalMetadata) {
+        delete data.metadata.pay;
+      }
       const { payload } = await request(url, {
         ...DEFAULT_OPTIONS,
         payload: JSON.stringify(data),

--- a/runner/src/server/services/webhookService.ts
+++ b/runner/src/server/services/webhookService.ts
@@ -20,14 +20,14 @@ export class WebhookService {
    * @param url - url of the webhook
    * @param data - object to send to the webhook
    * @param method - POST or PUT request, defaults to POST
-   * @param sendAdditionalMetadata - whether to include additional metadata in the request
+   * @param sendAdditionalPayMetadata - whether to include additional metadata in the request
    * @returns object with the property `reference` webhook if the response returns with a reference number. If the call fails, the reference will be 'UNKNOWN'.
    */
   async postRequest(
     url: string,
     data: object,
     method: "POST" | "PUT" = "POST",
-    sendAdditionalMetadata: boolean = false
+    sendAdditionalPayMetadata: boolean = false
   ) {
     this.logger.info(
       ["WebhookService", "postRequest body"],
@@ -35,7 +35,7 @@ export class WebhookService {
     );
     let request = method === "POST" ? post : put;
     try {
-      if (!sendAdditionalMetadata) {
+      if (!sendAdditionalPayMetadata) {
         delete data?.metadata?.pay;
       }
       const { payload } = await request(url, {


### PR DESCRIPTION
# Description

Some apis may not be compatible with the new pay metadata schema introduced by the fee options object. To overcome this we've added a toggle to allow webhooks to choose whether to send this data through.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [X] Unit testing with current webhook service tests
- [X] Manual testing with form with fee options, both allowing the sending of pay metadata and not allowing it

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
