### PR TITLE
fix: update "how to take a good photograph" advice on image playback

### DIFF
--- a/runner/src/server/views/upload-playback.html
+++ b/runner/src/server/views/upload-playback.html
@@ -16,7 +16,7 @@
 {% set takePhotoHtml %}
   <p class="govuk-body"></p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>lay it flat on a table or for better results against a wall</li>
+    <li>lay it flat on a table</li>
     <li>make sure all information is readable</li>
     <li>position the phone parallel to the document</li>
     <li>use both hands to keep your phone steady</li>


### PR DESCRIPTION
# Description

Previously the messaging for how to take a good photograph included laying the document "against a wall". This could be confusing and frustrating for users, so this line has been removed.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [X] Manual testing to check the content has changed

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
