### PR TITLE
fix: conditionally remove additional pay metadata from queue service webhook

### DIFF
--- a/runner/src/server/services/queueStatusService.ts
+++ b/runner/src/server/services/queueStatusService.ts
@@ -48,8 +48,12 @@ export class QueueStatusService extends StatusService {
     const otherOutputs = outputs?.filter((output) => output !== firstWebhook);
     if (firstWebhook) {
       if (!queueReference) {
+        const data = { ...formData };
+        if (!firstWebhook.outputData.sendAdditionalPayMetadata) {
+          delete data?.metadata?.pay;
+        }
         const queueResults = await this.queueService?.sendToQueue(
-          formData,
+          data,
           firstWebhook.outputData.url,
           firstWebhook.outputData.allowRetry
         );


### PR DESCRIPTION
# Description

For forms using the queue service, but calling webhooks that can't handle the additional pay metadata, additional pay metadata was still being passed through, even when explicitly excluded in the webhook output configuration.

This has now been fixed so that the additional pay metadata has been removed in the same way it's removed from the standard webhook service

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [X] Manual testing with different use cases to check whether the pay metadata is removed in the correct contexts

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
