### PR TITLE
fix: allow multi-start pages to progress the form with a continue button

### DIFF
--- a/runner/src/server/views/multi-start-page.html
+++ b/runner/src/server/views/multi-start-page.html
@@ -20,13 +20,16 @@
 
     {% include "partials/heading.html" %}
 
-    {{ componentList(components) }}
+    <form method="post" enctype="multipart/form-data" autocomplete="on">
+      <input type="hidden" name="crumb" value="{{crumb}}"/>
+      {{ componentList(components) }}
 
-    {% if continueButtonText %}
-      {{ govukButton({ attributes: { is: "submit" }, text: continueButtonText })}}
-    {% endif %}
+      {% if continueButtonText %}
+        {{ govukButton({ attributes: { id: "submit" }, text: continueButtonText })}}
+      {% endif %}
 
-    {{ govukPagination(startPageNavigation) }}
+      {{ govukPagination(startPageNavigation) }}
+    </form>
 
     <pre>{{ value | dump(2) | safe }}</pre>
   </div>


### PR DESCRIPTION
# Description

Previously when a continue button is added to a page it wouldn't actually navigate to the next page of the form due to the continue button being outside of a form component. This has now been changed to put the button inside a form element to allow navigation.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Manually tested that the form can be progressed by hitting the continue button

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
