### PR TITLE
fix: allow more dynamic error messaging

### DIFF
--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -82,6 +82,7 @@ interface TextFieldBase {
     autocomplete?: string;
     exposeToContext?: boolean;
     disableChangingFromSummary?: boolean;
+    customValidationMessages?: Record<string, string>;
   };
   schema: {
     max?: number;
@@ -103,6 +104,7 @@ interface NumberFieldBase {
     suffix?: string;
     exposeToContext?: boolean;
     disableChangingFromSummary?: boolean;
+    customValidationMessages?: Record<string, string>;
   };
   schema: {
     min?: number;
@@ -126,6 +128,7 @@ interface ListFieldBase {
     exposeToContext?: boolean;
     allowPrePopulation?: boolean;
     disableChangingFromSummary?: boolean;
+    customValidationMessages?: Record<string, string>;
   };
   list: string;
   schema: {};
@@ -155,6 +158,7 @@ interface DateFieldBase {
     maxDaysInPast?: number;
     exposeToContext?: boolean;
     disableChangingFromSummary?: boolean;
+    customValidationMessages?: Record<string, string>;
   };
   schema: {};
 }

--- a/runner/src/server/plugins/engine/components/AutocompleteField.ts
+++ b/runner/src/server/plugins/engine/components/AutocompleteField.ts
@@ -8,12 +8,17 @@ import { FormSubmissionState } from "server/plugins/engine/types";
 export class AutocompleteField extends SelectField {
   constructor(def: ListComponentsDef, model: FormModel) {
     super(def, model);
-    this.formSchema = this.formSchema.messages({
+
+    let componentSchema = this.formSchema.messages({
       "any.only": "Enter {{#label}}",
     });
-    this.stateSchema = this.stateSchema.messages({
-      "any.only": "Enter {{#label}}",
-    });
+    if (def.options.customValidationMessages) {
+      componentSchema = componentSchema.messages(
+        def.options.customValidationMessages
+      );
+    }
+    this.formSchema = componentSchema;
+    this.stateSchema = componentSchema;
     addClassOptionIfNone(this.options, "govuk-input--width-20");
   }
   getDisplayStringFromState(state: FormSubmissionState): string {

--- a/runner/src/server/plugins/engine/components/AutocompleteField.ts
+++ b/runner/src/server/plugins/engine/components/AutocompleteField.ts
@@ -8,6 +8,12 @@ import { FormSubmissionState } from "server/plugins/engine/types";
 export class AutocompleteField extends SelectField {
   constructor(def: ListComponentsDef, model: FormModel) {
     super(def, model);
+    this.formSchema = this.formSchema.messages({
+      "any.only": "Enter {{#label}}",
+    });
+    this.stateSchema = this.stateSchema.messages({
+      "any.only": "Enter {{#label}}",
+    });
     addClassOptionIfNone(this.options, "govuk-input--width-20");
   }
   getDisplayStringFromState(state: FormSubmissionState): string {

--- a/runner/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/runner/src/server/plugins/engine/components/CheckboxesField.ts
@@ -8,9 +8,11 @@ export class CheckboxesField extends SelectionControlField {
   constructor(def: ListComponentsDef, model: FormModel) {
     super(def, model);
 
+    const { options } = def;
+
     let schema = joi.array().single().label(def.title.toLowerCase());
 
-    if (def.options.required === false) {
+    if (options.required === false) {
       // null or empty string is valid for optional fields
       schema = schema
         .empty(null)
@@ -19,6 +21,10 @@ export class CheckboxesField extends SelectionControlField {
       schema = schema
         .items(joi[this.listType]().allow(...this.values))
         .required();
+    }
+
+    if (options.customValidationMessages) {
+      schema = schema.messages(options.customValidationMessages);
     }
 
     this.formSchema = schema;

--- a/runner/src/server/plugins/engine/components/DatePartsField.ts
+++ b/runner/src/server/plugins/engine/components/DatePartsField.ts
@@ -36,6 +36,11 @@ export class DatePartsField extends FormComponent {
             required: isRequired,
             optionalText: optionalText,
             classes: "govuk-input--width-2",
+            customValidationMessages: {
+              "number.min": "{{#label}} must be between 1 and 31",
+              "number.max": "{{#label}} must be between 1 and 31",
+              "number.base": `${def.title} must include a day`,
+            },
           },
           hint: "",
         },
@@ -48,6 +53,11 @@ export class DatePartsField extends FormComponent {
             required: isRequired,
             optionalText: optionalText,
             classes: "govuk-input--width-2",
+            customValidationMessages: {
+              "number.min": "{{#label}} must be between 1 and 12",
+              "number.max": "{{#label}} must be between 1 and 12",
+              "number.base": `${def.title} must include a month`,
+            },
           },
           hint: "",
         },
@@ -60,6 +70,9 @@ export class DatePartsField extends FormComponent {
             required: isRequired,
             optionalText: optionalText,
             classes: "govuk-input--width-4",
+            customValidationMessages: {
+              "number.base": `${def.title} must include a year`,
+            },
           },
           hint: "",
         },
@@ -137,7 +150,10 @@ export class DatePartsField extends FormComponent {
       }
     });
 
-    const firstError = errors?.errorList?.[0];
+    const relevantErrors =
+      errors?.errorList?.filter((error) => error.path === this.name) ?? [];
+
+    const firstError = relevantErrors[0];
     const errorMessage = firstError && { text: firstError?.text };
 
     return {

--- a/runner/src/server/plugins/engine/components/DatePartsField.ts
+++ b/runner/src/server/plugins/engine/components/DatePartsField.ts
@@ -151,7 +151,8 @@ export class DatePartsField extends FormComponent {
     });
 
     const relevantErrors =
-      errors?.errorList?.filter((error) => error.path === this.name) ?? [];
+      errors?.errorList?.filter((error) => error.path.includes(this.name)) ??
+      [];
 
     const firstError = relevantErrors[0];
     const errorMessage = firstError && { text: firstError?.text };

--- a/runner/src/server/plugins/engine/components/DateTimePartsField.ts
+++ b/runner/src/server/plugins/engine/components/DateTimePartsField.ts
@@ -32,6 +32,11 @@ export class DateTimePartsField extends FormComponent {
           options: {
             required: options.required,
             classes: "govuk-input--width-2",
+            customValidationMessages: {
+              "number.min": "{{#label}} must be between 1 and 31",
+              "number.max": "{{#label}} must be between 1 and 31",
+              "number.base": `${def.title} must include a day`,
+            },
           },
         },
         {
@@ -42,6 +47,11 @@ export class DateTimePartsField extends FormComponent {
           options: {
             required: options.required,
             classes: "govuk-input--width-2",
+            customValidationMessages: {
+              "number.min": "{{#label}} must be between 1 and 12",
+              "number.max": "{{#label}} must be between 1 and 12",
+              "number.base": `${def.title} must include a month`,
+            },
           },
         },
         {
@@ -52,6 +62,9 @@ export class DateTimePartsField extends FormComponent {
           options: {
             required: options.required,
             classes: "govuk-input--width-4",
+            customValidationMessages: {
+              "number.base": `${def.title} must include a year`,
+            },
           },
         },
         {
@@ -62,6 +75,11 @@ export class DateTimePartsField extends FormComponent {
           options: {
             required: options.required,
             classes: "govuk-input--width-2",
+            customValidationMessages: {
+              "number.min": "{{#label}} must be between 0 and 23",
+              "number.max": "{{#label}} must be between 0 and 23",
+              "number.base": `${def.title} must include an hour`,
+            },
           },
         },
         {
@@ -72,6 +90,11 @@ export class DateTimePartsField extends FormComponent {
           options: {
             required: options.required,
             classes: "govuk-input--width-2",
+            customValidationMessages: {
+              "number.min": "{{#label}} must be between 0 and 59",
+              "number.max": "{{#label}} must be between 0 and 59",
+              "number.base": `${def.title} must include a minute`,
+            },
           },
         },
       ] as any,

--- a/runner/src/server/plugins/engine/components/FileUploadField.ts
+++ b/runner/src/server/plugins/engine/components/FileUploadField.ts
@@ -24,6 +24,12 @@ export class FileUploadField extends FormComponent {
       "string.empty": "Upload {{#label}}",
     });
 
+    if (options.customValidationMessages) {
+      componentSchema = componentSchema.messages(
+        options.customValidationMessages
+      );
+    }
+
     this.schema = componentSchema;
   }
   getFormSchemaKeys() {

--- a/runner/src/server/plugins/engine/components/FileUploadField.ts
+++ b/runner/src/server/plugins/engine/components/FileUploadField.ts
@@ -1,17 +1,37 @@
 import { FormData, FormSubmissionErrors } from "../types";
 import { FormComponent } from "./FormComponent";
-import * as helpers from "./helpers";
 
 import { DataType, ViewModel } from "./types";
+import { FileUploadFieldComponent } from "@xgovformbuilder/model";
+import { FormModel } from "server/plugins/engine/models";
+import joi, { Schema } from "joi";
 
 export class FileUploadField extends FormComponent {
   dataType = "file" as DataType;
+
+  constructor(def: FileUploadFieldComponent, model: FormModel) {
+    super(def, model);
+
+    const { options = {} } = def;
+
+    let componentSchema = joi.string().label(def.title.toLowerCase());
+
+    if (options.required === false) {
+      componentSchema = componentSchema.allow("").allow(null);
+    }
+
+    componentSchema = componentSchema.messages({
+      "string.empty": "Upload {{#label}}",
+    });
+
+    this.schema = componentSchema;
+  }
   getFormSchemaKeys() {
-    return helpers.getFormSchemaKeys(this.name, "string", this);
+    return { [this.name]: this.schema as Schema };
   }
 
   getStateSchemaKeys() {
-    return helpers.getStateSchemaKeys(this.name, "string", this);
+    return { [this.name]: this.schema as Schema };
   }
 
   get attributes() {

--- a/runner/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/runner/src/server/plugins/engine/components/ListFormComponent.ts
@@ -23,27 +23,34 @@ export class ListFormComponent extends FormComponent {
 
   constructor(def: ListComponentsDef, model: FormModel) {
     super(def, model);
+    const { options } = def;
     // @ts-ignore
     this.list = model.getList(def.list);
     this.listType = this.list.type ?? "string";
-    this.options = def.options;
+    this.options = options;
 
-    let schema = joi[this.listType]();
+    let componentSchema = joi[this.listType]();
 
     /**
      * Only allow a user to answer with values that have been defined in the list
      */
-    if (def.options.required === false) {
+    if (options.required === false) {
       // null or empty string is valid for optional fields
-      schema = schema.empty(null).valid(...this.values, "");
+      componentSchema = componentSchema.empty(null).valid(...this.values, "");
     } else {
-      schema = schema.valid(...this.values).required();
+      componentSchema = componentSchema.valid(...this.values).required();
     }
 
-    schema = schema.label(def.title.toLowerCase());
+    if (options.customValidationMessages) {
+      componentSchema = componentSchema.messages(
+        options.customValidationMessages
+      );
+    }
 
-    this.formSchema = schema;
-    this.stateSchema = schema;
+    componentSchema = componentSchema.label(def.title.toLowerCase());
+
+    this.formSchema = componentSchema;
+    this.stateSchema = componentSchema;
   }
 
   getFormSchemaKeys() {

--- a/runner/src/server/plugins/engine/components/MonthYearField.ts
+++ b/runner/src/server/plugins/engine/components/MonthYearField.ts
@@ -30,7 +30,11 @@ export class MonthYearField extends FormComponent {
           options: {
             required: options.required,
             classes: "govuk-input--width-2",
-            customValidationMessage: "{{label}} must be between 1 and 12",
+            customValidationMessages: {
+              "number.min": "{{#label}} must be between 1 and 12",
+              "number.max": "{{#label}} must be between 1 and 12",
+              "number.base": `${def.title} must include a month`,
+            },
           },
         },
         {
@@ -41,6 +45,9 @@ export class MonthYearField extends FormComponent {
           options: {
             required: options.required,
             classes: "govuk-input--width-4",
+            customValidationMessages: {
+              "number.base": `${def.title} must include a year`,
+            },
           },
         },
       ] as any,

--- a/runner/src/server/plugins/engine/components/MonthYearField.ts
+++ b/runner/src/server/plugins/engine/components/MonthYearField.ts
@@ -59,7 +59,13 @@ export class MonthYearField extends FormComponent {
   }
 
   getFormDataFromState(state: FormSubmissionState) {
-    return this.children.getFormDataFromState(state);
+    const name = this.name;
+    const value = state[name];
+
+    return {
+      [`${name}__month`]: value && value[`${name}__month`],
+      [`${name}__year`]: value && value[`${name}__year`],
+    };
   }
 
   getStateValueFromValidForm(payload: FormPayload) {

--- a/runner/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/runner/src/server/plugins/engine/components/MultilineTextField.ts
@@ -23,32 +23,29 @@ export class MultilineTextField extends FormComponent {
 
   constructor(def: MultilineTextFieldComponent, model: FormModel) {
     super(def, model);
-    this.options = def.options;
-    this.schema = def.schema;
-    this.formSchema = Joi.string();
-    this.formSchema = this.formSchema.label(def.title.toLowerCase());
-    const { maxWords, customValidationMessage } = def.options;
-    const isRequired = def.options.required ?? true;
+    const { schema = {}, options } = def;
+    this.options = options;
+    this.schema = schema;
+    let componentSchema = Joi.string()
+      .label(def.title.toLowerCase())
+      .required();
 
-    if (isRequired) {
-      this.formSchema = this.formSchema.required();
-    } else {
-      this.formSchema = this.formSchema.allow("").allow(null);
+    if (options.required === false) {
+      componentSchema = componentSchema.allow("").allow(null);
     }
-    this.formSchema = this.formSchema.ruleset;
 
-    if (def.schema.max) {
-      this.formSchema = this.formSchema.max(def.schema.max);
+    if (schema.max) {
+      componentSchema = componentSchema.max(schema.max);
       this.isCharacterOrWordCount = true;
     }
 
-    if (def.schema.min) {
-      this.formSchema = this.formSchema.min(def.schema.min);
+    if (schema.min) {
+      componentSchema = componentSchema.min(schema.min);
     }
 
-    if (maxWords ?? false) {
-      this.formSchema = this.formSchema.custom((value, helpers) => {
-        if (inputIsOverWordCount(value, maxWords)) {
+    if (options.maxWords ?? false) {
+      componentSchema = componentSchema.custom((value, helpers) => {
+        if (inputIsOverWordCount(value, options.maxWords)) {
           helpers.error("string.maxWords");
         }
         return value;
@@ -56,11 +53,19 @@ export class MultilineTextField extends FormComponent {
       this.isCharacterOrWordCount = true;
     }
 
-    if (customValidationMessage) {
-      this.formSchema = this.formSchema.rule({
-        message: customValidationMessage,
+    if (options.customValidationMessage) {
+      componentSchema = componentSchema.rule({
+        message: options.customValidationMessage,
       });
     }
+
+    if (options.customValidationMessages) {
+      componentSchema = componentSchema.messages(
+        options.customValidationMessages
+      );
+    }
+
+    this.formSchema = componentSchema;
   }
 
   getFormSchemaKeys() {

--- a/runner/src/server/plugins/engine/components/NumberField.ts
+++ b/runner/src/server/plugins/engine/components/NumberField.ts
@@ -9,35 +9,49 @@ export class NumberField extends FormComponent {
 
   constructor(def, model) {
     super(def, model);
-    this.schemaOptions = def.schema;
-    this.options = def.options;
-    const { min, max } = def.schema;
-    let schema = joi.number();
 
-    schema = schema.label(def.title.toLowerCase());
+    const { schema = {}, options } = def;
 
-    if (def.schema?.min && def.schema?.max) {
-      schema = schema.$;
+    this.schemaOptions = schema;
+    this.options = options;
+    const { min, max } = schema;
+    let componentSchema = joi.number();
+
+    componentSchema = componentSchema.label(def.title.toLowerCase());
+
+    if (min && max) {
+      componentSchema = componentSchema.$;
     }
-    if (def.schema?.min ?? false) {
-      schema = schema.min(min);
+    if (min ?? false) {
+      componentSchema = componentSchema.min(min);
     }
 
-    if (def.schema?.max ?? false) {
-      schema = schema.max(max);
+    if (max ?? false) {
+      componentSchema = componentSchema.max(max);
     }
 
-    if (def.options.customValidationMessage) {
-      schema = schema.rule({ message: def.options.customValidationMessage });
+    if (options.customValidationMessage) {
+      componentSchema = componentSchema.rule({
+        message: def.options.customValidationMessage,
+      });
+    }
+
+    if (options.customValidationMessages) {
+      componentSchema = componentSchema.messages(
+        options.customValidationMessages
+      );
     }
 
     if (def.options.required === false) {
       const optionalSchema = joi
         .alternatives()
-        .try(joi.string().allow(null).allow("").default("").optional(), schema);
+        .try(
+          joi.string().allow(null).allow("").default("").optional(),
+          componentSchema
+        );
       this.schema = optionalSchema;
     } else {
-      this.schema = schema;
+      this.schema = componentSchema;
     }
   }
 

--- a/runner/src/server/plugins/engine/components/TelephoneNumberField.ts
+++ b/runner/src/server/plugins/engine/components/TelephoneNumberField.ts
@@ -35,6 +35,12 @@ export class TelephoneNumberField extends FormComponent {
     if (options.isInternational) {
       componentSchema = componentSchema.custom(internationalPhoneValidator);
     }
+
+    if (options.customValidationMessages) {
+      componentSchema = componentSchema.messages(
+        options.customValidationMessages
+      );
+    }
     this.schema = componentSchema;
 
     addClassOptionIfNone(this.options, "govuk-input--width-10");

--- a/runner/src/server/plugins/engine/components/TextField.ts
+++ b/runner/src/server/plugins/engine/components/TextField.ts
@@ -47,6 +47,12 @@ export class TextField extends FormComponent {
       });
     }
 
+    if (options.customValidationMessages) {
+      componentSchema = componentSchema.messages(
+        options.customValidationMessages
+      );
+    }
+
     this.formSchema = componentSchema;
   }
 

--- a/runner/src/server/plugins/engine/components/TimeField.ts
+++ b/runner/src/server/plugins/engine/components/TimeField.ts
@@ -5,19 +5,30 @@ import { FormComponent } from "./FormComponent";
 import { FormModel } from "../models";
 import { addClassOptionIfNone } from "./helpers";
 import { FormData, FormSubmissionErrors } from "../types";
+import { Schema } from "joi";
 
 export class TimeField extends FormComponent {
   constructor(def: InputFieldsComponentsDef, model: FormModel) {
     super(def, model);
     addClassOptionIfNone(this.options, "govuk-input--width-4");
+    const { options } = def;
+    let componentSchema = helpers.getFormSchemaKeys(this.name, "string", this)[
+      this.name
+    ];
+    if (options.customValidationMessages) {
+      componentSchema = componentSchema.messages(
+        options.customValidationMessages
+      );
+    }
+    this.formSchema = componentSchema;
   }
 
   getFormSchemaKeys() {
-    return helpers.getFormSchemaKeys(this.name, "string", this);
+    return { [this.name]: this.formSchema as Schema };
   }
 
   getStateSchemaKeys() {
-    return helpers.getStateSchemaKeys(this.name, "string", this);
+    return { [this.name]: this.formSchema as Schema };
   }
 
   getViewModel(formData: FormData, errors: FormSubmissionErrors) {

--- a/runner/src/server/plugins/engine/components/YesNoField.ts
+++ b/runner/src/server/plugins/engine/components/YesNoField.ts
@@ -40,12 +40,18 @@ export class YesNoField extends ListFormComponent {
 
     const { options } = this;
 
-    this.formSchema = helpers
+    let componentSchema = helpers
       .buildFormSchema("boolean", this, options?.required !== false)
       .valid(true, false);
-    this.stateSchema = helpers
-      .buildStateSchema(this.list.type, this)
-      .valid(true, false);
+
+    if (options.customValidationMessages) {
+      componentSchema = componentSchema.messages(
+        options.customValidationMessages
+      );
+    }
+
+    this.formSchema = componentSchema;
+    this.stateSchema = componentSchema;
 
     addClassOptionIfNone(this.options, "govuk-radios--inline");
   }

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -335,24 +335,29 @@ export class PageControllerBase {
     if (validationResult && validationResult.error) {
       const isoRegex = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/;
 
+      const errorList = validationResult.error.details.map((err) => {
+        const name = err.path
+          .map((name: string, index: number) =>
+            index > 0 ? `__${name}` : name
+          )
+          .join("");
+
+        return {
+          path: err.path.join("."),
+          href: `#${name}`,
+          name: name,
+          text: err.message.replace(isoRegex, (text) => {
+            return format(parseISO(text), "d MMMM yyyy");
+          }),
+        };
+      });
+
       return {
         titleText: this.errorSummaryTitle,
-        errorList: validationResult.error.details.map((err) => {
-          const name = err.path
-            .map((name: string, index: number) =>
-              index > 0 ? `__${name}` : name
-            )
-            .join("");
-
-          return {
-            path: err.path.join("."),
-            href: `#${name}`,
-            name: name,
-            text: err.message.replace(isoRegex, (text) => {
-              return format(parseISO(text), "d MMMM yyyy");
-            }),
-          };
-        }),
+        errorList: errorList.filter(
+          ({ text }, index) =>
+            index === errorList.findIndex((err) => err.text === text)
+        ),
       };
     }
 

--- a/runner/test/cases/server/plugins/engine/datepartsfield.test.ts
+++ b/runner/test/cases/server/plugins/engine/datepartsfield.test.ts
@@ -55,7 +55,7 @@ suite("Date parts field", () => {
   });
   test("Error is displayed correctly", () => {
     const def = {
-      name: "myComponent",
+      name: "approximate",
       title: "My component",
       options: { required: false },
       schema: {},


### PR DESCRIPTION
# Description

Previously the `customValidationMessage` property was being used on a couple of fields, however this validation message would override any other messages, meaning you couldn't have different messages for different validation scenarios.

We have now added a new option, `customValidationMessages`, which can be added to most field types. This option takes the same arguments as `(joi.messages)[https://joi.dev/api/?v=17.12.2#anymessagesmessages]`, allowing you to override specific validation errors as opposed to all of them.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Manual testing with custom validation messages for different field types

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
