### PR TITLE
fix: added option to escape markdown links in notify personalisation

### DIFF
--- a/designer/client/i18n/translations/en.translation.json
+++ b/designer/client/i18n/translations/en.translation.json
@@ -342,7 +342,9 @@
   "outputEdit": {
     "notifyEdit": {
       "includeReferenceTitle": "Include webhook and payment references",
-      "includeReferenceHint": "If webhook or payment references are available, they will be included in Notify's personalisation object. The included fields are: hasWebhookReference (boolean), webhookReference: (string), hasPaymentReference: (boolean), paymentReference: string."
+      "includeReferenceHint": "If webhook or payment references are available, they will be included in Notify's personalisation object. The included fields are: hasWebhookReference (boolean), webhookReference: (string), hasPaymentReference: (boolean), paymentReference: string.",
+      "escapeURLsTitle": "Escape Notify encoded URLs",
+      "escapeURLsHint": "If you do not expect notify-encoded links to be passed through from your form, select this box to break this formatting. It is strongly recommended to enable this to prevent phishing attacks"
     }
   },
   "page": {

--- a/designer/client/outputs/__tests__/output-edit.jest.tsx
+++ b/designer/client/outputs/__tests__/output-edit.jest.tsx
@@ -104,6 +104,7 @@ describe("OutputEdit", () => {
             templateId: "NewTemplateId",
             apiKey: "NewAPIKey",
             emailField: "9WH4EX",
+            escapeURLs: false,
             addReferencesToPersonalisation: true,
           },
         },

--- a/designer/client/outputs/notify-edit.tsx
+++ b/designer/client/outputs/notify-edit.tsx
@@ -139,6 +139,24 @@ class NotifyEdit extends Component<Props, State> {
             name="add-references-to-personalisation"
           />
         </div>
+        <div className="govuk-form-group">
+          <Checkboxes
+            items={[
+              {
+                children: (
+                  <strong>
+                    {i18n("outputEdit.notifyEdit.escapeURLsTitle")}
+                  </strong>
+                ),
+                hint: {
+                  children: i18n("outputEdit.notifyEdit.escapeURLsHint"),
+                },
+                value: true,
+              },
+            ]}
+            name="escape-urls"
+          />
+        </div>
       </div>
     );
   }

--- a/designer/client/outputs/output-edit.tsx
+++ b/designer/client/outputs/output-edit.tsx
@@ -83,6 +83,7 @@ class OutputEdit extends Component<Props, State> {
           emailField: formData.get("email-field") as string,
           addReferencesToPersonalisation:
             formData.get("add-references-to-personalisation") === "true",
+          escapeURLs: formData.get("escape-urls") === "true",
         };
         break;
       case OutputType.Webhook:

--- a/designer/client/outputs/types.ts
+++ b/designer/client/outputs/types.ts
@@ -14,6 +14,7 @@ export type NotifyOutputConfiguration = {
   emailField: string;
   personalisation: string[];
   addReferencesToPersonalisation?: boolean;
+  escapeURLs?: boolean;
 };
 
 export type WebhookOutputConfiguration = {

--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -91,6 +91,7 @@ export type NotifyOutputConfiguration = {
     emailReplyToId: string;
     condition?: string | undefined;
   }[];
+  escapeURLs?: boolean;
 };
 
 export type WebhookOutputConfiguration = {

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -220,6 +220,7 @@ const notifySchema = joi.object().keys({
     .optional(),
   addReferencesToPersonalisation: joi.boolean().optional(),
   emailReplyToIdConfiguration: joi.array().items(replyToConfigurationSchema),
+  escapeURLs: joi.boolean().default(false),
 });
 
 const emailSchema = joi.object().keys({

--- a/runner/src/server/plugins/engine/models/submission/NotifyModel.ts
+++ b/runner/src/server/plugins/engine/models/submission/NotifyModel.ts
@@ -46,6 +46,7 @@ export function NotifyModel(
     personalisation: personalisationConfiguration,
     personalisationFieldCustomisation = {},
     emailReplyToIdConfiguration,
+    escapeURLs = false,
     templateId,
   } = outputConfiguration;
 
@@ -106,6 +107,7 @@ export function NotifyModel(
     emailAddress: reach(state, emailField) as string,
     apiKey: apiKey,
     addReferencesToPersonalisation,
+    escapeURLs,
     ...(emailReplyToId && { emailReplyToId }),
   };
 }

--- a/runner/src/server/services/notifyService.ts
+++ b/runner/src/server/services/notifyService.ts
@@ -32,14 +32,22 @@ export class NotifyService {
     this.logger = server.logger;
   }
 
+  /**
+   * Escapes markdown-formatted links. If a markdown-formatted link is passed
+   * through in personalisation, Notify will render it as a link. This could
+   * leave an opening to phishing attacks.
+   *
+   * @param value the personalisation value to be escaped
+   */
   escapeURLs(value: string): string {
     const specialCharactersPattern = new RegExp(/\[([^\[\]]*)]\(([^\(\)]*)\)/g);
-    const matches = [...value.matchAll(specialCharactersPattern)];
-    matches.forEach(([link, linkText, href]) => {
-      const newText = `\\[${linkText}\\]\\(${href})`;
-      value = value.replace(link, newText);
-    });
-    return value;
+
+    return value.replaceAll(
+      specialCharactersPattern,
+      (_match, linkText, href) => {
+        return `\\[${linkText}\\]\\(${href})`;
+      }
+    );
   }
 
   parsePersonalisations(

--- a/runner/src/server/services/notifyService.ts
+++ b/runner/src/server/services/notifyService.ts
@@ -78,8 +78,6 @@ export class NotifyService {
         : apiKey.test ?? apiKey.production) as string;
     }
 
-    console.log("escape urls the level up: ", escapeURLs);
-
     const parsedOptions: SendEmailOptions = {
       personalisation: this.parsePersonalisations(personalisation, escapeURLs),
       reference,

--- a/runner/src/server/services/statusService.ts
+++ b/runner/src/server/services/statusService.ts
@@ -227,6 +227,7 @@ export class StatusService {
       personalisation = {},
       addReferencesToPersonalisation = false,
       emailReplyToId,
+      escapeURLs,
     } = outputData;
 
     return {
@@ -244,6 +245,7 @@ export class StatusService {
       templateId,
       emailAddress,
       emailReplyToId,
+      escapeURLs,
     };
   }
 


### PR DESCRIPTION
# Description

Previously there was no input validation on text fields relating to markdown formatting. This meant that users could enter markdown formatted text into text fields and this would be rendered properly by GOV.UK Notify. This could lead to vulnerabilities relating to phishing / social engineering attacks.

A flag has now been added to the notify output configuration to escape these URLs. This is currently optional and will be disabled by default, however it is **strongly recommended** this is turned on for all notify outputs that do not explicitly require users to complete answers with markdown formatting.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Manual testing with custom form and custom notify template

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
