### PR TITLE
fix: date validation for maxDaysInPast and maxDaysInFuture 

### DIFF
--- a/e2e/cypress/e2e/runner/dateValidation.feature
+++ b/e2e/cypress/e2e/runner/dateValidation.feature
@@ -4,7 +4,7 @@ Feature: Date validation
     Given the form "date-validation" exists
 
   Scenario: Errors appear for missing date parts
-
+    When I navigate to the "date-validation" form
     When I enter the day "25" for "maxFiveDaysInFuture"
     And I continue
     Then I see the error "Enter a date at most 5 days in the future must include a month" for "Enter a date at most 5 days in the future"
@@ -16,6 +16,7 @@ Feature: Date validation
     Then I don't see "Enter a date at most 5 days in the future must include a year"
 
   Scenario: Errors appear for invalid date parts
+    When I navigate to the "date-validation" form
     When I enter the day "50" for "maxFiveDaysInFuture"
     When I enter the month "30" for "maxFiveDaysInFuture"
     When I enter the year "1" for "maxFiveDaysInFuture"
@@ -26,9 +27,9 @@ Feature: Date validation
 
 
   Scenario: Errors appear for max days in future and max days in past
+    When I navigate to the "date-validation" form
     When I enter a date 30 days in the future for "maxFiveDaysInFuture"
     When I enter a date 30 days in the past for "maxFiveDaysInPast"
-
     And I continue
     Then I see the date parts with a partial error string "enter a date at most 5 days in the future must be the same as or before" for "maxFiveDaysInFuture"
     Then I see the date parts with a partial error string "enter a date at most 5 days in the past must be the same as or after" for "maxFiveDaysInPast"

--- a/e2e/cypress/e2e/runner/dateValidation.feature
+++ b/e2e/cypress/e2e/runner/dateValidation.feature
@@ -2,7 +2,6 @@ Feature: Date validation
 
   Background:
     Given the form "date-validation" exists
-    Given I navigate to the "date-validation" form
 
   Scenario: Errors appear for missing date parts
 

--- a/e2e/cypress/e2e/runner/dateValidation.feature
+++ b/e2e/cypress/e2e/runner/dateValidation.feature
@@ -1,10 +1,10 @@
 Feature: Date validation
 
   Background:
-    Given the form "date-validation" exists
+    Given the form "date" exists
 
   Scenario: Errors appear for missing date parts
-    When I navigate to the "date-validation" form
+    When I navigate to the "date" form
     When I enter the day "25" for "maxFiveDaysInFuture"
     And I continue
     Then I see the error "Enter a date at most 5 days in the future must include a month" for "Enter a date at most 5 days in the future"
@@ -16,7 +16,7 @@ Feature: Date validation
     Then I don't see "Enter a date at most 5 days in the future must include a year"
 
   Scenario: Errors appear for invalid date parts
-    When I navigate to the "date-validation" form
+    When I navigate to the "date" form
     When I enter the day "50" for "maxFiveDaysInFuture"
     When I enter the month "30" for "maxFiveDaysInFuture"
     When I enter the year "1" for "maxFiveDaysInFuture"

--- a/e2e/cypress/e2e/runner/dateValidation.feature
+++ b/e2e/cypress/e2e/runner/dateValidation.feature
@@ -27,7 +27,7 @@ Feature: Date validation
 
 
   Scenario: Errors appear for max days in future and max days in past
-    When I navigate to the "date-validation" form
+    When I navigate to the "date" form
     When I enter a date 30 days in the future for "maxFiveDaysInFuture"
     When I enter a date 30 days in the past for "maxFiveDaysInPast"
     And I continue

--- a/e2e/cypress/e2e/runner/dateValidation.feature
+++ b/e2e/cypress/e2e/runner/dateValidation.feature
@@ -1,11 +1,11 @@
-Feature: Complete a form
-  As a forms user
-  I want to complete a form
-  So that I submit my form successfully
+Feature: Date validation
 
-  Scenario: Errors appear for missing date parts
+  Background:
     Given the form "date-validation" exists
     Given I navigate to the "date-validation" form
+
+  Scenario: Errors appear for missing date parts
+
     When I enter the day "25" for "maxFiveDaysInFuture"
     And I continue
     Then I see the error "Enter a date at most 5 days in the future must include a month" for "Enter a date at most 5 days in the future"
@@ -17,8 +17,6 @@ Feature: Complete a form
     Then I don't see "Enter a date at most 5 days in the future must include a year"
 
   Scenario: Errors appear for invalid date parts
-    Given the form "date-validation" exists
-    Given I navigate to the "date-validation" form
     When I enter the day "50" for "maxFiveDaysInFuture"
     When I enter the month "30" for "maxFiveDaysInFuture"
     When I enter the year "1" for "maxFiveDaysInFuture"
@@ -29,8 +27,6 @@ Feature: Complete a form
 
 
   Scenario: Errors appear for max days in future and max days in past
-    Given the form "date-validation" exists
-    Given I navigate to the "date-validation" form
     When I enter a date 30 days in the future for "maxFiveDaysInFuture"
     When I enter a date 30 days in the past for "maxFiveDaysInPast"
 

--- a/e2e/cypress/e2e/runner/dateValidation.feature
+++ b/e2e/cypress/e2e/runner/dateValidation.feature
@@ -1,0 +1,39 @@
+Feature: Complete a form
+  As a forms user
+  I want to complete a form
+  So that I submit my form successfully
+
+  Scenario: Errors appear for missing date parts
+    Given the form "date-validation" exists
+    Given I navigate to the "date-validation" form
+    When I enter the day "25" for "maxFiveDaysInFuture"
+    And I continue
+    Then I see the error "Enter a date at most 5 days in the future must include a month" for "Enter a date at most 5 days in the future"
+    When I enter the month "12" for "maxFiveDaysInFuture"
+    And I continue
+    Then I see the error "Enter a date at most 5 days in the future must include a year" for "Enter a date at most 5 days in the future"
+    When I enter the year "2000" for "maxFiveDaysInFuture"
+    And I continue
+    Then I don't see "Enter a date at most 5 days in the future must include a year"
+
+  Scenario: Errors appear for invalid date parts
+    Given the form "date-validation" exists
+    Given I navigate to the "date-validation" form
+    When I enter the day "50" for "maxFiveDaysInFuture"
+    When I enter the month "30" for "maxFiveDaysInFuture"
+    When I enter the year "1" for "maxFiveDaysInFuture"
+    And I continue
+    Then I see the date parts error "day must be between 1 and 31"
+    Then I see the date parts error "month must be between 1 and 12"
+    Then I see the date parts error "year must be 1000 or higher"
+
+
+  Scenario: Errors appear for max days in future and max days in past
+    Given the form "date-validation" exists
+    Given I navigate to the "date-validation" form
+    When I enter a date 30 days in the future for "maxFiveDaysInFuture"
+    When I enter a date 30 days in the past for "maxFiveDaysInPast"
+
+    And I continue
+    Then I see the date parts with a partial error string "enter a date at most 5 days in the future must be the same as or before" for "maxFiveDaysInFuture"
+    Then I see the date parts with a partial error string "enter a date at most 5 days in the past must be the same as or after" for "maxFiveDaysInPast"

--- a/e2e/cypress/e2e/runner/dateValidation.js
+++ b/e2e/cypress/e2e/runner/dateValidation.js
@@ -1,0 +1,78 @@
+import { When, Then } from "@badeball/cypress-cucumber-preprocessor";
+
+When("I enter the day {string} for {string}", (day, fieldName) => {
+  cy.get(`#${fieldName}`).within(() => {
+    cy.findByLabelText("Day").type(day);
+  });
+});
+
+When("I enter the month {string} for {string}", (month, fieldName) => {
+  cy.get(`#${fieldName}`).within(() => {
+    cy.findByLabelText("Month").type(month);
+  });
+});
+
+When("I enter the year {string} for {string}", (year, fieldName) => {
+  cy.get(`#${fieldName}`).within(() => {
+    cy.findByLabelText("Year").type(year);
+  });
+});
+
+Then("I see the date parts error {string}", (error) => {
+  /**
+   * Date parts only show one error at a time.
+   */
+  cy.findByText("Fix the following errors");
+  cy.findByRole("link", { name: error, exact: false });
+});
+
+Then(
+  "I see the date parts with a partial error string {string} for {string}",
+  (error, fieldName) => {
+    /**
+     * Date parts only show one error at a time.
+     */
+    cy.findByText("Fix the following errors");
+    cy.get(`#${fieldName}-error`).within(() => {
+      cy.findByText(error, { exact: false });
+    });
+  }
+);
+
+When(
+  "I enter a date {int} days in the future for {string}",
+  (days, fieldName) => {
+    const today = new Date();
+    const date = new Date(today);
+    date.setDate(today.getDate() + days);
+
+    const day = date.getDate();
+    const month = date.getMonth() + 1;
+    const year = date.getFullYear();
+
+    cy.get(`#${fieldName}`).within(() => {
+      cy.findByLabelText("Day").type(day);
+      cy.findByLabelText("Month").type(month);
+      cy.findByLabelText("Year").type(year);
+    });
+  }
+);
+
+When(
+  "I enter a date {int} days in the past for {string}",
+  (days, fieldName) => {
+    const today = new Date();
+    const date = new Date(today);
+    date.setDate(today.getDate() - days);
+
+    const day = date.getDate();
+    const month = date.getMonth() + 1;
+    const year = date.getFullYear();
+
+    cy.get(`#${fieldName}`).within(() => {
+      cy.findByLabelText("Day").type(day);
+      cy.findByLabelText("Month").type(month);
+      cy.findByLabelText("Year").type(year);
+    });
+  }
+);

--- a/e2e/cypress/fixtures/date-validation.json
+++ b/e2e/cypress/fixtures/date-validation.json
@@ -44,5 +44,10 @@
       "title": "Licence details"
     }
   ],
-  "lists": []
+  "lists": [],
+  "fees": [],
+  "outputs": [],
+  "version": 2,
+  "skipSummary": false,
+  "feeOptions": {}
 }

--- a/e2e/cypress/fixtures/date-validation.json
+++ b/e2e/cypress/fixtures/date-validation.json
@@ -1,0 +1,48 @@
+{
+  "conditions": [],
+  "startPage": "/start",
+  "pages": [
+    {
+      "path": "/start",
+      "components": [
+        {
+          "type": "DatePartsField",
+          "name": "maxFiveDaysInFuture",
+          "title": "Enter a date at most 5 days in the future",
+          "schema": {},
+          "options": {
+            "maxDaysInFuture": 5
+          }
+        },
+        {
+          "type": "DatePartsField",
+          "name": "maxFiveDaysInPast",
+          "title": "Enter a date at most 5 days in the past",
+          "schema": {},
+          "options": {
+            "maxDaysInPast": 5
+          }
+        }
+      ],
+      "section": "licenceDetails",
+      "next": [
+        {
+          "path": "/summary"
+        }
+      ]
+    },
+    {
+      "path": "/summary",
+      "controller": "./pages/summary.js",
+      "components": [],
+      "title": "Summary"
+    }
+  ],
+  "sections": [
+    {
+      "name": "licenceDetails",
+      "title": "Licence details"
+    }
+  ],
+  "lists": []
+}

--- a/e2e/cypress/fixtures/date.json
+++ b/e2e/cypress/fixtures/date.json
@@ -1,8 +1,9 @@
 {
-  "conditions": [],
+  "metadata": {},
   "startPage": "/start",
   "pages": [
     {
+      "title": "Start",
       "path": "/start",
       "components": [
         {
@@ -24,27 +25,25 @@
           }
         }
       ],
-      "section": "licenceDetails",
-      "next": [
-        {
-          "path": "/summary"
-        }
-      ]
+      "next": [{ "path": "/second-page" }]
     },
     {
+      "path": "/second-page",
+      "title": "Second page",
+      "components": [],
+      "next": [{ "path": "/summary" }]
+    },
+    {
+      "title": "Summary",
       "path": "/summary",
       "controller": "./pages/summary.js",
       "components": [],
-      "title": "Summary"
-    }
-  ],
-  "sections": [
-    {
-      "name": "licenceDetails",
-      "title": "Licence details"
+      "next": []
     }
   ],
   "lists": [],
+  "sections": [],
+  "conditions": [],
   "fees": [],
   "outputs": [],
   "version": 2,

--- a/e2e/cypress/support/step_definitions/runner/i_navigate_to_string.js
+++ b/e2e/cypress/support/step_definitions/runner/i_navigate_to_string.js
@@ -1,5 +1,7 @@
 import { When } from "@badeball/cypress-cucumber-preprocessor";
 
 When("I navigate to {string}", (url) => {
-  cy.visit(`${Cypress.env("RUNNER_URL")}${url}`);
+  cy.visit(`${Cypress.env("RUNNER_URL")}${url}`, {
+    failOnStatusCode: false,
+  });
 });

--- a/e2e/cypress/support/step_definitions/runner/i_navigate_to_the_string_form.js
+++ b/e2e/cypress/support/step_definitions/runner/i_navigate_to_the_string_form.js
@@ -1,5 +1,7 @@
 import { Given, When } from "@badeball/cypress-cucumber-preprocessor";
 
 Given("I navigate to the {string} form", (formName) => {
-  cy.visit(`${Cypress.env("RUNNER_URL")}/${formName}`);
+  cy.visit(`${Cypress.env("RUNNER_URL")}/${formName}`, {
+    failOnStatusCode: false,
+  });
 });

--- a/e2e/cypress/support/step_definitions/runner/the_form_string_exists.js
+++ b/e2e/cypress/support/step_definitions/runner/the_form_string_exists.js
@@ -11,5 +11,7 @@ Given("the form {string} exists", (formName) => {
     cy.request("POST", url, requestBody);
   });
 
-  cy.visit(`${Cypress.env("RUNNER_URL")}/${formName}`);
+  cy.visit(`${Cypress.env("RUNNER_URL")}/${formName}`, {
+    failOnStatusCode: false,
+  });
 });

--- a/runner/src/server/plugins/engine/components/DatePartsField.ts
+++ b/runner/src/server/plugins/engine/components/DatePartsField.ts
@@ -13,8 +13,6 @@ import {
 } from "../types";
 import { FormModel } from "../models";
 import { DataType } from "server/plugins/engine/components/types";
-import { addClassOptionIfNone } from "./helpers";
-import joi from "joi";
 
 export class DatePartsField extends FormComponent {
   children: ComponentCollection;
@@ -97,8 +95,12 @@ export class DatePartsField extends FormComponent {
     schema = schema.custom(
       helpers.getCustomDateValidator(maxDaysInPast, maxDaysInFuture)
     );
+    if (options.customValidationMessages) {
+      schema = schema.messages(options.customValidationMessages);
+    }
 
     this.schema = schema;
+
     return { [this.name]: schema };
   }
 

--- a/runner/src/server/plugins/engine/components/DatePartsField.ts
+++ b/runner/src/server/plugins/engine/components/DatePartsField.ts
@@ -13,6 +13,8 @@ import {
 } from "../types";
 import { FormModel } from "../models";
 import { DataType } from "server/plugins/engine/components/types";
+import { addClassOptionIfNone } from "./helpers";
+import joi from "joi";
 
 export class DatePartsField extends FormComponent {
   children: ComponentCollection;
@@ -96,6 +98,7 @@ export class DatePartsField extends FormComponent {
       helpers.getCustomDateValidator(maxDaysInPast, maxDaysInFuture)
     );
 
+    this.schema = schema;
     return { [this.name]: schema };
   }
 
@@ -153,7 +156,6 @@ export class DatePartsField extends FormComponent {
     const relevantErrors =
       errors?.errorList?.filter((error) => error.path.includes(this.name)) ??
       [];
-
     const firstError = relevantErrors[0];
     const errorMessage = firstError && { text: firstError?.text };
 


### PR DESCRIPTION
# Description

Date schema was not being properly set for maxDaysInFuture/maxDaysInPast

- set date schema so dates can be validated 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [x] smoke
- [x] manual

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
