### PR TITLE
fix: allow maxClientFileSize and maxApiFileSizeMb to be configurable

### DIFF
--- a/runner/config/custom-environment-variables.json
+++ b/runner/config/custom-environment-variables.json
@@ -56,5 +56,5 @@
   "queueServicePollingTimeout": "QUEUE_SERVICE_POLLING_TIMEOUT",
   "allowUserTemplates": "ALLOW_USER_TEMPLATES",
   "maxClientFileSize": "MAX_CLIENT_FILE_SIZE",
-  "maxApiFileSizeMb": "MAX_API_FILE_SIZE_MB"
+  "maxFileSizeStringInMb": "MAX_FILE_SIZE_STRING_IN_MB"
 }

--- a/runner/config/custom-environment-variables.json
+++ b/runner/config/custom-environment-variables.json
@@ -54,5 +54,7 @@
   "queueDatabasePassword": "QUEUE_DATABASE_PASSWORD",
   "queueServicePollingInterval": "QUEUE_SERVICE_POLLING_INTERVAL",
   "queueServicePollingTimeout": "QUEUE_SERVICE_POLLING_TIMEOUT",
-  "allowUserTemplates": "ALLOW_USER_TEMPLATES"
+  "allowUserTemplates": "ALLOW_USER_TEMPLATES",
+  "maxClientFileSize": "MAX_CLIENT_FILE_SIZE",
+  "maxApiFileSizeMb": "MAX_API_FILE_SIZE_MB"
 }

--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -142,7 +142,7 @@ module.exports = {
   queueServicePollingInterval: "500", // How frequently to check the queue for a reference number
   queueServicePollingTimeout: "2000", // Total time to wait for a reference number
 
-  allowUserTemplates: true,
+  allowUserTemplates: false,
 
   /**
    * File size errors

--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -142,5 +142,11 @@ module.exports = {
   queueServicePollingInterval: "500", // How frequently to check the queue for a reference number
   queueServicePollingTimeout: "2000", // Total time to wait for a reference number
 
-  allowUserTemplates: false,
+  allowUserTemplates: true,
+
+  /**
+   * File size errors
+   */
+  maxClientFileSize: 5 * 1024 * 1024, // 5MB
+  maxApiFileSizeErrorMb: "4", // The file size to render if the file is too large in MB
 };

--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -148,5 +148,5 @@ module.exports = {
    * File size errors
    */
   maxClientFileSize: 5 * 1024 * 1024, // 5MB
-  maxApiFileSizeErrorMb: "4", // The file size to render if the file is too large in MB
+  maxFileSizeStringInMb: "5", // The file size to render if the file is too large in MB
 };

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -586,7 +586,7 @@ export class PageControllerBase {
           path: field.name,
           href: `#${field.name}`,
           name: field.name,
-          text: "The selected file must be smaller than 5MB",
+          text: `The selected file must be smaller than ${config.maxApiFileSizeErrorMb}MB`,
         };
       });
 

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -586,7 +586,7 @@ export class PageControllerBase {
           path: field.name,
           href: `#${field.name}`,
           name: field.name,
-          text: `The selected file must be smaller than ${config.maxApiFileSizeErrorMb}MB`,
+          text: `The selected file must be smaller than ${config.maxFileSizeStringInMb}MB`,
         };
       });
 

--- a/runner/src/server/services/upload/uploadService.ts
+++ b/runner/src/server/services/upload/uploadService.ts
@@ -33,7 +33,7 @@ export class UploadService {
   }
 
   get fileSizeLimit() {
-    return 5 * 1024 * 1024; // 5mb
+    return config.maxClientFileSize;
   }
 
   get validFiletypes(): ["jpg", "jpeg", "png", "pdf"] {

--- a/runner/src/server/utils/configSchema.ts
+++ b/runner/src/server/utils/configSchema.ts
@@ -133,6 +133,8 @@ export const configSchema = Joi.object({
     otherwise: Joi.optional(),
   }),
   allowUserTemplates: Joi.boolean().optional(),
+  maxClientFileSize: Joi.number().default(5 * 1024 * 1024),
+  maxApiFileSizeMb: Joi.number().default(5),
 });
 
 export function buildConfig(config) {

--- a/runner/src/server/utils/configSchema.ts
+++ b/runner/src/server/utils/configSchema.ts
@@ -133,7 +133,7 @@ export const configSchema = Joi.object({
     otherwise: Joi.optional(),
   }),
   allowUserTemplates: Joi.boolean().optional(),
-  maxClientFileSize: Joi.number().default("2097152"),
+  maxClientFileSize: Joi.number().default("5242880"), // 5MB
   maxFileSizeStringInMb: Joi.string().default("5"),
 });
 

--- a/runner/src/server/utils/configSchema.ts
+++ b/runner/src/server/utils/configSchema.ts
@@ -133,8 +133,8 @@ export const configSchema = Joi.object({
     otherwise: Joi.optional(),
   }),
   allowUserTemplates: Joi.boolean().optional(),
-  maxClientFileSize: Joi.number().default(5 * 1024 * 1024),
-  maxApiFileSizeMb: Joi.number().default(5),
+  maxClientFileSize: Joi.number().default("2097152"),
+  maxFileSizeStringInMb: Joi.string().default("5"),
 });
 
 export function buildConfig(config) {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

- add `maxClientFileSize` / `"MAX_CLIENT_FILE_SIZE"` - the runner will reject requests larger than this size (b)
- add `maxFileSizeStringInMb` / `"MAX_FILE_SIZE_STRING_IN_MB"` - which is what is *rendered* in errors. This error could originate from the runner _or_ the document upload API  
<img width="656" alt="image" src="https://github.com/XGovFormBuilder/digital-form-builder/assets/22080510/4a782c40-8a5a-4278-a843-744f7646b94b">
 



## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [x] Manual

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
