### PR TITLE
feature: allow html to be rendered in next steps and payment skipped text

### DIFF
--- a/runner/src/server/views/confirmation.html
+++ b/runner/src/server/views/confirmation.html
@@ -42,12 +42,12 @@
       }) }}
       {% if paymentSkipped and customText.paymentSkipped %}
         <p class="govuk-body">
-          {{ customText.paymentSkipped }}
+          {{ customText.paymentSkipped | safe }}
         </p>
       {% else %}
         {% if customText.nextSteps %}
           <p class="govuk-body">
-            {{ customText.nextSteps }}
+            {{ customText.nextSteps | safe }}
           </p>
         {% endif %}
       {% endif %}


### PR DESCRIPTION
# Description

Sometimes it might be necessary to render html, such as links, in payment skipped and next steps text. To solve this, a change has been made to the confirmation template so that html should now be rendered properly.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] manual testing with a form to make sure the html is being rendered properly

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
