### PR TITLE
fix: group exposed components by section to expose to context

### DIFF
--- a/e2e/cypress/fixtures/html-templating-example.json
+++ b/e2e/cypress/fixtures/html-templating-example.json
@@ -22,13 +22,13 @@
     },
     {
       "path": "/second-page",
-      "title": "Dynamic page based on your answers: {{ contentToDisplay }}",
+      "title": "Dynamic page based on your answers: {{ gcdSFb.contentToDisplay }}",
       "components": [
         {
           "name": "azSyOn",
           "options": {},
           "type": "Html",
-          "content": "<p class=\"govuk-body\">This page demonstrates how templating works.</p>\n<p class=\"govuk-body\">Depending on the answer you chose for the first question, you should see different content displayed below.</p>\n<p class=\"govuk-body\">You chosen the option: {{contentToDisplay}}</p>\n{{additionalContexts.example[contentToDisplay].additionalInfo | safe}}\n<p class=\"govuk-body\">The following list will have different items</p>\n<ul class=\"govuk-list govuk-list--bullet\">\n{{additionalContexts.example[contentToDisplay].listItems | safe }}\n</ul>",
+          "content": "<p class=\"govuk-body\">This page demonstrates how templating works.</p>\n<p class=\"govuk-body\">Depending on the answer you chose for the first question, you should see different content displayed below.</p>\n<p class=\"govuk-body\">You chosen the option: {{gcdSFb.contentToDisplay}}</p>\n{{additionalContexts.example[gcdSFb.contentToDisplay].additionalInfo | safe}}\n<p class=\"govuk-body\">The following list will have different items</p>\n<ul class=\"govuk-list govuk-list--bullet\">\n{{additionalContexts.example[gcdSFb.contentToDisplay].listItems | safe }}\n</ul>",
           "schema": {}
         }
       ],

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -23,6 +23,7 @@ export enum ComponentTypeEnum {
   Details = "Details",
   FlashCard = "FlashCard",
   List = "List",
+  ContextComponent = "ContextComponent",
 }
 
 export type ComponentType =
@@ -50,7 +51,8 @@ export type ComponentType =
   | "Details"
   | "FlashCard"
   | "List"
-  | "WebsiteField";
+  | "WebsiteField"
+  | "ContextComponent";
 
 export type ComponentSubType = "field" | "content";
 
@@ -310,6 +312,12 @@ export interface SelectFieldComponent extends ListFieldBase {
   subType?: "listField";
 }
 
+export interface ContextComponent extends ListFieldBase {
+  type: "ContextComponent";
+  options: ListFieldBase["options"];
+  section?: string;
+}
+
 export type ComponentDef =
   | InsetTextComponent
   | AutocompleteFieldComponent
@@ -335,7 +343,8 @@ export type ComponentDef =
   | TimeFieldComponent
   | UkAddressFieldComponent
   | YesNoFieldComponent
-  | WebsiteFieldComponent;
+  | WebsiteFieldComponent
+  | ContextComponent;
 
 // Components that render inputs.
 export type InputFieldsComponentsDef =

--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -14,7 +14,7 @@ export interface Page {
   path: string;
   controller: string;
   components?: ComponentDef[];
-  section: string; // the section ID
+  section?: string; // the section ID
   next?: { path: string; condition?: string }[];
 }
 

--- a/runner/src/server/forms/html-templating-example.json
+++ b/runner/src/server/forms/html-templating-example.json
@@ -22,13 +22,13 @@
     },
     {
       "path": "/second-page",
-      "title": "Dynamic page based on your answers: {{ contentToDisplay }}",
+      "title": "Dynamic page based on your answers: {{ gcdSFb.contentToDisplay }}",
       "components": [
         {
           "name": "azSyOn",
           "options": {},
           "type": "Html",
-          "content": "<p class=\"govuk-body\">This page demonstrates how templating works.</p>\n<p class=\"govuk-body\">Depending on the answer you chose for the first question, you should see different content displayed below.</p>\n<p class=\"govuk-body\">You chosen the option: {{contentToDisplay}}</p>\n{{additionalContexts.example[contentToDisplay].additionalInfo | safe}}\n<p class=\"govuk-body\">The following list will have different items</p>\n<ul class=\"govuk-list govuk-list--bullet\">\n{{additionalContexts.example[contentToDisplay].listItems | safe }}\n</ul>",
+          "content": "<p class=\"govuk-body\">This page demonstrates how templating works.</p>\n<p class=\"govuk-body\">Depending on the answer you chose for the first question, you should see different content displayed below.</p>\n<p class=\"govuk-body\">You chosen the option: {{gcdSFb.contentToDisplay}}</p>\n{{additionalContexts.example[gcdSFb.contentToDisplay].additionalInfo | safe}}\n<p class=\"govuk-body\">The following list will have different items</p>\n<ul class=\"govuk-list govuk-list--bullet\">\n{{additionalContexts.example[gcdSFb.contentToDisplay].listItems | safe }}\n</ul>",
           "schema": {}
         }
       ],

--- a/runner/src/server/plugins/engine/components/ContextComponent.ts
+++ b/runner/src/server/plugins/engine/components/ContextComponent.ts
@@ -1,0 +1,33 @@
+import { FormComponent } from "server/plugins/engine/components/FormComponent";
+import { ComponentDef } from "@xgovformbuilder/model";
+import { FormModel } from "server/plugins/engine/models";
+import { FormSubmissionState } from "server/plugins/engine/types";
+
+export class ContextComponent extends FormComponent {
+  section: string;
+  constructor(def: ComponentDef, model: FormModel) {
+    super(def, model);
+    this.section = def.section;
+  }
+
+  getFormDataFromState(state: FormSubmissionState) {
+    const name = this.name;
+    const section = this.section;
+    let path = "";
+
+    if (section && section in state) {
+      path = `${section}.`;
+      state = {
+        ...state[section],
+      };
+    }
+
+    if (name in state) {
+      return {
+        [`${path}${name}`]: this.getFormValueFromState(state),
+      };
+    }
+
+    return undefined;
+  }
+}

--- a/runner/src/server/plugins/engine/components/ContextComponent.ts
+++ b/runner/src/server/plugins/engine/components/ContextComponent.ts
@@ -5,7 +5,7 @@ import { FormSubmissionState } from "server/plugins/engine/types";
 import _ from "lodash";
 
 export class ContextComponent extends FormComponent {
-  section: string;
+  section: string | undefined;
   constructor(def: ComponentDef, model: FormModel) {
     super(def, model);
     this.section = def.section;

--- a/runner/src/server/plugins/engine/components/ContextComponent.ts
+++ b/runner/src/server/plugins/engine/components/ContextComponent.ts
@@ -2,6 +2,7 @@ import { FormComponent } from "server/plugins/engine/components/FormComponent";
 import { ComponentDef } from "@xgovformbuilder/model";
 import { FormModel } from "server/plugins/engine/models";
 import { FormSubmissionState } from "server/plugins/engine/types";
+import _ from "lodash";
 
 export class ContextComponent extends FormComponent {
   section: string;
@@ -14,6 +15,7 @@ export class ContextComponent extends FormComponent {
     const name = this.name;
     const section = this.section;
     let path = "";
+    const result = {};
 
     if (section && section in state) {
       path = `${section}.`;
@@ -23,9 +25,8 @@ export class ContextComponent extends FormComponent {
     }
 
     if (name in state) {
-      return {
-        [`${path}${name}`]: this.getFormValueFromState(state),
-      };
+      _.set(result, `${path}${name}`, this.getFormValueFromState(state));
+      return result;
     }
 
     return undefined;

--- a/runner/src/server/plugins/engine/components/ContextComponent.ts
+++ b/runner/src/server/plugins/engine/components/ContextComponent.ts
@@ -1,11 +1,11 @@
 import { FormComponent } from "server/plugins/engine/components/FormComponent";
-import { ComponentDef } from "@xgovformbuilder/model";
+import { ComponentDef, Page } from "@xgovformbuilder/model";
 import { FormModel } from "server/plugins/engine/models";
 import { FormSubmissionState } from "server/plugins/engine/types";
 import _ from "lodash";
 
 export class ContextComponent extends FormComponent {
-  section: string | undefined;
+  section: Page["section"];
   constructor(def: ComponentDef, model: FormModel) {
     super(def, model);
     this.section = def.section;

--- a/runner/src/server/plugins/engine/components/ContextComponentCollection.ts
+++ b/runner/src/server/plugins/engine/components/ContextComponentCollection.ts
@@ -34,13 +34,7 @@ export class ContextComponentCollection extends ComponentCollection {
     const formData = {};
 
     this.items.forEach((item: ContextComponent) => {
-      const path = `${item.section ?? ""}${item.section ? "." : ""}${
-        item.name
-      }`;
-      const value = reach(state, path);
-      if (value) {
-        _.set(formData, path, value);
-      }
+      Object.assign(formData, item.getFormDataFromState(state));
     });
 
     return formData;

--- a/runner/src/server/plugins/engine/components/ContextComponentCollection.ts
+++ b/runner/src/server/plugins/engine/components/ContextComponentCollection.ts
@@ -1,0 +1,48 @@
+import { ComponentCollection } from "server/plugins/engine/components/ComponentCollection";
+import { FormModel } from "server/plugins/engine/models";
+import { FormSubmissionState } from "server/plugins/engine/types";
+import { FormComponent } from "server/plugins/engine/components/FormComponent";
+import { reach } from "@hapi/hoek";
+import _ from "lodash";
+import { ContextComponent } from "server/plugins/engine/components/ContextComponent";
+import { ComponentBase } from "server/plugins/engine/components/ComponentBase";
+
+export class ContextComponentCollection extends ComponentCollection {
+  items: (
+    | ComponentBase
+    | ComponentCollection
+    | FormComponent
+    | ContextComponent
+  )[];
+  constructor(model: FormModel) {
+    const exposedComponentDefs = model.def.pages.flatMap((page) => {
+      return (
+        page.components
+          ?.filter((component) => component.options?.exposeToContext)
+          .map((component) => ({
+            ...component,
+            type: "ContextComponent",
+            section: page.section,
+          })) ?? []
+      );
+    });
+
+    super(exposedComponentDefs, model);
+  }
+
+  getFormDataFromState(state: FormSubmissionState): any {
+    const formData = {};
+
+    this.items.forEach((item: ContextComponent) => {
+      const path = `${item.section ?? ""}${item.section ? "." : ""}${
+        item.name
+      }`;
+      const value = reach(state, path);
+      if (value) {
+        _.set(formData, path, value);
+      }
+    });
+
+    return formData;
+  }
+}

--- a/runner/src/server/plugins/engine/components/index.ts
+++ b/runner/src/server/plugins/engine/components/index.ts
@@ -33,3 +33,4 @@ export { UkAddressField } from "./UkAddressField";
 export { WebsiteField } from "./WebsiteField";
 export { YesNoField } from "./YesNoField";
 export { MonthYearField } from "./MonthYearField";
+export { ContextComponent } from "./ContextComponent";

--- a/runner/src/server/plugins/engine/models/FormModel.ts
+++ b/runner/src/server/plugins/engine/models/FormModel.ts
@@ -17,6 +17,7 @@ import { PageController } from "../pageControllers/PageController";
 import { ExecutableCondition } from "server/plugins/engine/models/types";
 import { DEFAULT_FEE_OPTIONS } from "server/plugins/engine/models/FormModel.feeOptions";
 import { ComponentCollection } from "server/plugins/engine/components";
+import { ContextComponentCollection } from "server/plugins/engine/components/ContextComponentCollection";
 
 class EvaluationContext {
   constructor(conditions, value) {
@@ -49,7 +50,7 @@ export class FormModel {
   /** the id of the form used for the first url parameter eg localhost:3009/test */
   basePath: string;
   conditions: Record<string, ExecutableCondition> | {};
-  fieldsForContext: ComponentCollection;
+  fieldsForContext: ContextComponentCollection;
   fieldsForPrePopulation: Record<string, any>;
   pages: any;
   startPage: any;
@@ -105,13 +106,7 @@ export class FormModel {
       const condition = this.makeCondition(conditionDef);
       this.conditions[condition.name] = condition;
     });
-
-    const exposedComponentDefs = def.pages.flatMap((page) => {
-      return page.components.filter(
-        (component) => component.options?.exposeToContext
-      );
-    });
-    this.fieldsForContext = new ComponentCollection(exposedComponentDefs, this);
+    this.fieldsForContext = new ContextComponentCollection(this);
     this.fieldsForPrePopulation = {};
 
     // @ts-ignore
@@ -258,19 +253,6 @@ export class FormModel {
   }
 
   getContextState(state: FormSubmissionState) {
-    const contextState = Object.keys(state).reduce((acc, curr) => {
-      if (typeof state[curr] === "object") {
-        return {
-          ...acc,
-          ...state[curr],
-        };
-      }
-      return {
-        ...acc,
-        [curr]: state[curr],
-      };
-    }, {});
-
-    return this.fieldsForContext.getFormDataFromState(contextState);
+    return this.fieldsForContext.getFormDataFromState(state);
   }
 }

--- a/runner/src/server/views/confirmation.html
+++ b/runner/src/server/views/confirmation.html
@@ -42,12 +42,12 @@
       }) }}
       {% if paymentSkipped and customText.paymentSkipped %}
         <p class="govuk-body">
-          {{ customText.paymentSkipped }}
+          {{ customText.paymentSkipped | safe }}
         </p>
       {% else %}
         {% if customText.nextSteps %}
           <p class="govuk-body">
-            {{ customText.nextSteps }}
+            {{ customText.nextSteps | safe }}
           </p>
         {% endif %}
       {% endif %}


### PR DESCRIPTION
# Description

Previously fields that had been exposed to context would become available throughout the form, however would only be available by their component name, and not by the `${section}.${name}` path. This would cause issues if there were two exposed components with the same name.

This has been fixed by creating a new `ContextComponentCollection` and `ContextComponent` which can pass the section name to the exposed components, therefore allowing them to be grouped by their section name.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] e2e tests to make sure values are being pulled through properly
- [X] Manual testing of a more complex form to test a real world use case

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
