### PR TITLE
Bug: multiple exposed fields in a section causes context to be overwritten

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -52,7 +52,7 @@ jobs:
         run: yarn ${{inputs.workspace}} test-cov
 
       - name: Upload test results artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: ${{ success() || failure() }}
         with:
           name: test-results-${{inputs.workspace}}
@@ -60,7 +60,7 @@ jobs:
           retention-days: 14
 
       - name: Upload test coverage artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: ${{ success() || failure() }}
         with:
           name: test-coverage-${{inputs.workspace}}

--- a/e2e/cypress/fixtures/html-templating-example.json
+++ b/e2e/cypress/fixtures/html-templating-example.json
@@ -32,7 +32,8 @@
           "schema": {}
         }
       ],
-      "next": [{ "path": "/summary" }]
+      "next": [{ "path": "/summary" }],
+      "section": "gcdSFb"
     },
     {
       "title": "Summary",

--- a/runner/src/server/plugins/engine/components/ContextComponent.ts
+++ b/runner/src/server/plugins/engine/components/ContextComponent.ts
@@ -26,9 +26,8 @@ export class ContextComponent extends FormComponent {
 
     if (name in state) {
       _.set(result, `${path}${name}`, this.getFormValueFromState(state));
-      return result;
     }
 
-    return undefined;
+    return result;
   }
 }

--- a/runner/src/server/plugins/engine/components/ContextComponentCollection.ts
+++ b/runner/src/server/plugins/engine/components/ContextComponentCollection.ts
@@ -2,8 +2,7 @@ import { ComponentCollection } from "server/plugins/engine/components/ComponentC
 import { FormModel } from "server/plugins/engine/models";
 import { FormSubmissionState } from "server/plugins/engine/types";
 import { FormComponent } from "server/plugins/engine/components/FormComponent";
-import { reach } from "@hapi/hoek";
-import _ from "lodash";
+import { merge } from "@hapi/hoek";
 import { ContextComponent } from "server/plugins/engine/components/ContextComponent";
 import { ComponentBase } from "server/plugins/engine/components/ComponentBase";
 
@@ -34,7 +33,7 @@ export class ContextComponentCollection extends ComponentCollection {
     const formData = {};
 
     this.items.forEach((item: ContextComponent) => {
-      Object.assign(formData, item.getFormDataFromState(state));
+      merge(formData, item.getFormDataFromState(state));
     });
 
     return formData;


### PR DESCRIPTION
# Description

Previously when fields were exposed to context, if two fields were in the same section, the second field would overwrite the value of the first field. This is due to the way the value object is built for fields in sections, and how `Object.assign` works.

The `ContextComponentCollection.getFormDataFromState` function has now been changed so that the context state does not get overwritten anymore.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [X] Smoke test for html templating has been updated to include both fields in the same section
- [X] Manual testing with form in development

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation and versioning
- [X] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
