### PR TITLE
feature: allow schema name to be configured

### DIFF
--- a/docs/runner/submission-queue.md
+++ b/docs/runner/submission-queue.md
@@ -34,7 +34,7 @@ support that is required.
 
 #### PGBOSS Prerequisites
 
-- PostgreSQL database >=v11
+- PostgreSQL database >=v13
 - A worker process which can connect to the PostgreSQL database, via PgBoss. Your implementation should look something like this
 
 ```ts
@@ -80,15 +80,16 @@ When using pgboss, it is important that successful work returns `{ reference }` 
 
 ### Environment variables
 
-| Variable name                  | Definition                                                                               | Default | Example                                     |
-| ------------------------------ | ---------------------------------------------------------------------------------------- | ------- | ------------------------------------------- |
-| ENABLE_QUEUE_SERVICE           | Whether the queue service is enabled or not                                              | `false` |                                             |
-| QUEUE_DATABASE_TYPE            | PGBOSS or MYSQL                                                                          |         |                                             |
-| QUEUE_DATABASE_URL             | Used for configuring the endpoint of the database instance                               |         | mysql://username:password@endpoint/database |
-| QUEUE_DATABASE_USERNAME        | Used for configuring the user being used to access the database                          |         | root                                        |
-| QUEUE_DATABASE_PASSWORD        | Used for configuring the password used for accessing the database                        |         | password                                    |
-| QUEUE_SERVICE_POLLING_INTERVAL | The amount of time, in milliseconds, between poll requests for updates from the database | 500     |                                             |
-| QUEUE_SERVICE_POLLING_TIMEOUT  | The total amount of time, in milliseconds, to poll requests for from the database        | 2000    |                                             |
+| Variable name                  | Definition                                                                               | Default  | Example                                     |
+| ------------------------------ | ---------------------------------------------------------------------------------------- | -------- | ------------------------------------------- |
+| ENABLE_QUEUE_SERVICE           | Whether the queue service is enabled or not                                              | `false`  |                                             |
+| QUEUE_DATABASE_TYPE            | PGBOSS or MYSQL                                                                          |          |                                             |
+| QUEUE_DATABASE_URL             | Used for configuring the endpoint of the database instance                               |          | mysql://username:password@endpoint/database |
+| QUEUE_DATABASE_USERNAME        | Used for configuring the user being used to access the database                          |          | root                                        |
+| QUEUE_DATABASE_PASSWORD        | Used for configuring the password used for accessing the database                        |          | password                                    |
+| QUEUE_DATABASE_SCHEMA_NAME     | Used for configuring the schema name that pgboss should use                              | `pgboss` |                                             |
+| QUEUE_SERVICE_POLLING_INTERVAL | The amount of time, in milliseconds, between poll requests for updates from the database | 500      |                                             |
+| QUEUE_SERVICE_POLLING_TIMEOUT  | The total amount of time, in milliseconds, to poll requests for from the database        | 2000     |                                             |
 
 Webhooks can be configured so that the submitter only attempts to post to the webhook URL once.
 

--- a/runner/config/custom-environment-variables.json
+++ b/runner/config/custom-environment-variables.json
@@ -55,6 +55,7 @@
   "queueDatabaseUrl": "QUEUE_DATABASE_URL",
   "queueDatabaseUsername": "QUEUE_DATABASE_USERNAME",
   "queueDatabasePassword": "QUEUE_DATABASE_PASSWORD",
+  "queueDatabaseSchemaName": "QUEUE_DATABASE_SCHEMA_NAME",
   "queueServicePollingInterval": "QUEUE_SERVICE_POLLING_INTERVAL",
   "queueServicePollingTimeout": "QUEUE_SERVICE_POLLING_TIMEOUT",
   "allowUserTemplates": "ALLOW_USER_TEMPLATES",

--- a/runner/src/server/services/pgBossQueueService.ts
+++ b/runner/src/server/services/pgBossQueueService.ts
@@ -25,7 +25,11 @@ export class PgBossQueueService extends QueueService {
     this.pollingInterval = parseInt(config.queueServicePollingInterval);
     this.pollingTimeout = parseInt(config.queueServicePollingTimeout);
 
-    const boss = new PgBoss(config.queueDatabaseUrl);
+    const schema = config.queueDatabaseSchemaName;
+    const boss = new PgBoss({
+      connectionString: config.queueDatabaseUrl,
+      schema,
+    });
     this.queue = boss;
     boss.on("error", this.logger.error);
     boss.start().catch((e) => {
@@ -37,9 +41,7 @@ export class PgBossQueueService extends QueueService {
   }
 
   /**
-   * Fetches a reference number from `this.queueReferenceApiUrl/{jobId}`.
-   * If a reference number for `jobId` exists, the response body must be {@link QueueReferenceApiResponse}.
-   * This request will happen once, and timeout in 2s.
+   * Fetches a reference number from the database.
    */
   async getReturnRef(
     jobId: string

--- a/runner/src/server/utils/configSchema.ts
+++ b/runner/src/server/utils/configSchema.ts
@@ -132,6 +132,7 @@ export const configSchema = Joi.object({
     then: Joi.number().required(),
     otherwise: Joi.optional(),
   }),
+  queueDatabaseSchemaName: Joi.string().optional(),
   allowUserTemplates: Joi.boolean().optional(),
   maxClientFileSize: Joi.number().default("5242880"), // 5MB
   maxFileSizeStringInMb: Joi.string().default("5"),


### PR DESCRIPTION
# Description

This is part of pgboss v9 to v10 migration. 


- Allow `QUEUE_DATABASE_SCHEMA_NAME` to be configured

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [x] Manual


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
