### PR TITLE
fix: trim leading `.` so conditions render

### DIFF
--- a/designer/client/conditions/SelectConditions.tsx
+++ b/designer/client/conditions/SelectConditions.tsx
@@ -202,7 +202,9 @@ class SelectConditions extends React.Component<Props, State> {
     conditions: any[]
   ) {
     if (isDuplicateCondition(conditions, conditionToAdd.name)) return;
-    if (fieldName === conditionFieldName) conditions.push(conditionToAdd);
+
+    if (fieldName === this.trimSectionName(conditionFieldName))
+      conditions.push(conditionToAdd);
   }
 
   trimSectionName(fieldName: string) {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

- Trim the leading `.` so conditions render in the select a condition dropdown 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [x] Manual

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
