### PR TITLE
fix: align with guidance on input type for numbers (NumberField)

### DIFF
--- a/runner/src/server/plugins/engine/components/NumberField.ts
+++ b/runner/src/server/plugins/engine/components/NumberField.ts
@@ -71,7 +71,8 @@ export class NumberField extends FormComponent {
     const viewModelSuffix = { suffix: { text: suffix } };
     const viewModel = {
       ...super.getViewModel(formData, errors),
-      type: "number",
+      type: "text",
+      inputmode: "numeric",
       // ...False returns nothing, so only adds content when
       // the given options are present.
       ...(options.prefix && viewModelPrefix),
@@ -80,6 +81,11 @@ export class NumberField extends FormComponent {
 
     if (this.schemaOptions.precision) {
       viewModel.attributes.step = "0." + "1".padStart(schema.precision, "0");
+
+      // the `step` attribute will not work with input type "text"
+      // only set to "number" if we need to support existing `precision` config
+      // https://design-system.service.gov.uk/components/text-input/#avoid-using-inputs-with-a-type-of-number
+      viewModel.type = "number";
     }
 
     return viewModel;

--- a/runner/test/cases/server/plugins/engine/datepartsfield.test.ts
+++ b/runner/test/cases/server/plugins/engine/datepartsfield.test.ts
@@ -86,7 +86,11 @@ function dateComponent(name, width) {
     name: `myComponent__${name.toLowerCase()}`,
     value: undefined,
     classes: `govuk-input--width-${width}`,
-    type: "number",
+
+    // note that the DatePartsField creates NumberFields which are mapped to `items` and passed to the
+    // govukdateinput macro, the type and inputmode are therefore not used
+    type: "text",
+    inputmode: "numeric",
     attributes: {},
   };
 }

--- a/runner/test/cases/server/plugins/engine/datetimepartsfield.test.ts
+++ b/runner/test/cases/server/plugins/engine/datetimepartsfield.test.ts
@@ -66,7 +66,11 @@ function dateComponent(name, width) {
     name: `myComponent__${name.toLowerCase()}`,
     value: undefined,
     classes: `govuk-input--width-${width}`,
-    type: "number",
+
+    // note that the DateTimePartsField creates NumberFields which are mapped to `items` and passed to the
+    // govukdateinput macro, the type and inputmode are therefore not used
+    type: "text",
+    inputmode: "numeric",
     attributes: {},
   };
 }

--- a/runner/test/cases/server/plugins/engine/numberField.test.ts
+++ b/runner/test/cases/server/plugins/engine/numberField.test.ts
@@ -59,4 +59,28 @@ test("Prefix and suffix are passed to view model", () => {
     prefix: { text: "@£%" },
     suffix: { text: "&^%%" },
   });
+
+  test("Text type and numeric inputmode are used by default", () => {
+    const numberFieldPrefixSuffix = new NumberField(baseDef);
+
+    expect(numberFieldPrefixSuffix.getViewModel({})).to.contain({
+      type: "text",
+      inputmode: "numeric",
+    });
+  });
+
+  test("Number type is used is precision is specified", () => {
+    const def = {
+      ...baseDef,
+      schema: { precision: "0" },
+    };
+    const numberFieldPrefixSuffix = new NumberField(def);
+
+    expect(numberFieldPrefixSuffix.getViewModel({})).to.contain({
+      type: "number",
+      attributes: {
+        step: "0.1",
+      },
+    });
+  });
 });


### PR DESCRIPTION
# Description

Bring the NumberField component inline with the GOV.UK design system guidance on how to ask for numbers.

Update the HTML attribute `type` from `"number"` to `"text"` which stops the browser from restricting which type of characters can be entered into the input - this restriction can be [confusing for users](https://design-system.service.gov.uk/components/text-input/#avoid-using-inputs-with-a-type-of-number), limit the ability to copy & paste and has [proven problematic for screen readers](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/).

As the current NumberField component uses `joi.number()` as the base schema there will already be server side validation ensuring that if anything that can't be parsed by `Number()` is entered (text or invalid decimals) the user will be prompted to enter a number.

| New behaviour: component already validates the input value against Joi number schema, even if the form allows the user to submit  |
| ------------- |
| <img width="1236" alt="Screenshot 2024-11-12 at 15 23 54" src="https://github.com/user-attachments/assets/48ec8463-ddf8-4b43-a690-2266a728970c"> |


Setting the `inputmode` attribute to "numeric" will still prompt mobile browsers to provide a keyboard specifically for numbers and decimals (note on the mobile browsers I've tried this change against the keyboard behaviour is currently identical to if the `type` attribute was set to `number`).

| Current behaviour: mobile keyboard   | New behaviour: mobile keyboard |
| ------------- | ------------- |
| ![mobile-current-version](https://github.com/user-attachments/assets/ba7f4066-7742-4dd8-9ad9-c31bbbb00801) | ![mobile-proposed-version](https://github.com/user-attachments/assets/d3eed1c5-23af-4460-9916-90a3031e9e72)  |



This change does still fallback to the `type` `"number"` if the `precision` option is set on the components schema. Although I wouldn't advise this was used the `step` attribute which is set on the HTML input will not work if the `type` is set to `"text"`. Adding custom server side validation to validate and clearly feedback on incorrect decimal precision seemed well out of the scope of this fix and this should allow existing configurations to work as-is. (Note from an early review it looks like setting the `precision` option doesn't actually appropriately set different granularities of `step` but I'll look to raise that as a separate issue).

This change aims to bring the NumberField inline with the guidance found here: https://design-system.service.gov.uk/components/text-input/#numbers

Specifically attempting to fix the issues described by: https://design-system.service.gov.uk/components/text-input/#avoid-using-inputs-with-a-type-of-number

A more detailed description of why the guidance was set was published in Feb 2020:
https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/

---

Note that because the date part and date time part components use the `govuk-frontend` macro `govukDateInput` directly (by passing `items` into the macro options) those components are already asking for numbers using the appropriate `type` "text" and `inputmode` "numeric".

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Although the form builder is used in my department this issue was identified during an internal demo between designers and developers. It was not flagged as an issue by end users.

This commit updates to try and align the code to the design system guidance but has not been tried in a real world scenario with users submitting data.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
