### PR TITLE
feature: update govuk-frontend to v4.10.0 for rebrand

### DIFF
--- a/designer/package.json
+++ b/designer/package.json
@@ -116,7 +116,7 @@
     "eslint-plugin-tsdoc": "^0.2.14",
     "file-loader": "^6.2.0",
     "flat": "5.0.2",
-    "govuk-frontend": "^4.9.0",
+    "govuk-frontend": "^4.10.0",
     "hoek": "^6.1.3",
     "html-webpack-plugin": "^4.5.2",
     "i18next-parser": "^3.3.0",

--- a/model/package.json
+++ b/model/package.json
@@ -31,7 +31,7 @@
     "@babel/runtime": "^7.23.3",
     "boom": "7.3.0",
     "btoa": "^1.2.1",
-    "govuk-frontend": "^4.9.0",
+    "govuk-frontend": "^4.10.0",
     "joi": "17.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.21.0",
-    "govuk-frontend": "^4.9.0",
+    "govuk-frontend": "^4.10.0",
     "hmpo-components": "^5.2.1"
   },
   "resolutions": {

--- a/runner/package.json
+++ b/runner/package.json
@@ -61,7 +61,7 @@
     "dotenv": "8.2.0",
     "expr-eval": "^2.0.2",
     "google-libphonenumber": "^3.2.34",
-    "govuk-frontend": "^4.9.0",
+    "govuk-frontend": "^4.10.0",
     "hapi-pino": "8.0.0",
     "hapi-pulse": "3.0.0",
     "hapi-rate-limit": "4.1.0",

--- a/runner/src/client/sass/_govuk.scss
+++ b/runner/src/client/sass/_govuk.scss
@@ -1,4 +1,4 @@
 $govuk-global-styles: true;
 $govuk-rebrand-background-colour: #f4f8fb;
 $govuk-canvas-background-colour: $govuk-rebrand-background-colour;
-@import "node_modules/govuk-frontend/govuk/all";
+@import "./../../../node_modules/govuk-frontend/govuk/all";

--- a/runner/src/client/sass/_govuk.scss
+++ b/runner/src/client/sass/_govuk.scss
@@ -1,3 +1,4 @@
 $govuk-global-styles: true;
-
+$govuk-rebrand-background-colour: #f4f8fb;
+$govuk-canvas-background-colour: $govuk-rebrand-background-colour;
 @import "node_modules/govuk-frontend/govuk/all";

--- a/runner/src/client/sass/_upload-dialog.scss
+++ b/runner/src/client/sass/_upload-dialog.scss
@@ -1,4 +1,4 @@
-@import "../../../../node_modules/govuk-frontend/govuk/helpers/colour";
+@import "./../../../node_modules/govuk-frontend/govuk/helpers/colour";
 
 .upload-dialog {
   display: none;

--- a/runner/src/client/sass/application.scss
+++ b/runner/src/client/sass/application.scss
@@ -1,5 +1,5 @@
 @import "govuk";
-@import "node_modules/accessible-autocomplete/src/autocomplete";
+@import "./../../../node_modules/accessible-autocomplete/src/autocomplete";
 @import "hmpo";
 @import "modal-dialog";
 @import "upload-dialog";

--- a/runner/src/server/plugins/views.ts
+++ b/runner/src/server/plugins/views.ts
@@ -56,8 +56,8 @@ export default {
        */
       `${path.join(__dirname, "..", "views")}`,
       `${path.join(__dirname, "engine", "views")}`,
-      `${path.dirname(resolve.sync("govuk-frontend", { basedir }))}`,
-      `${path.dirname(resolve.sync("govuk-frontend", { basedir }))}/components`,
+      `${path.dirname(resolve.sync("govuk-frontend"))}`,
+      `${path.dirname(resolve.sync("govuk-frontend"))}/components`,
       `${path.dirname(resolve.sync("hmpo-components"))}/components`,
     ],
     isCached: !config.isDev,

--- a/runner/src/server/routes/public.ts
+++ b/runner/src/server/routes/public.ts
@@ -1,7 +1,12 @@
 import path from "path";
 
 const runnerFolder = path.join(__dirname, "..", "..", "..");
-const rootNodeModules = path.join(runnerFolder, "..", "node_modules");
+const govukFolder = path.join(
+  runnerFolder,
+  "node_modules",
+  "govuk-frontend",
+  "govuk"
+);
 
 export default [
   {
@@ -13,8 +18,9 @@ export default [
           path: [
             path.join(runnerFolder, "public", "static"),
             path.join(runnerFolder, "public", "build"),
-            path.join(rootNodeModules, "govuk-frontend", "govuk"),
-            path.join(rootNodeModules, "govuk-frontend", "govuk", "assets"),
+            govukFolder,
+            path.join(govukFolder, "assets"),
+            path.join(govukFolder, "assets", "rebrand"),
             path.join(
               runnerFolder,
               "node_modules",

--- a/runner/src/server/views/layout.html
+++ b/runner/src/server/views/layout.html
@@ -1,3 +1,4 @@
+{% set govukRebrand = true %}
 {% extends "template.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
@@ -6,7 +7,16 @@
 {% from "skip-link/macro.njk" import govukSkipLink -%}
 {% from "cookie-banner/macro.njk" import govukCookieBanner %}
 
-{% set govukRebrand = true %}
+
+{% block headIcons %}
+{# TODO: remove this block when rebrand assets are no longer in /rebrand (likely in v5 upgrade) #}
+  <link rel="icon" sizes="48x48" href="{{ assetPath }}/rebrand/images/favicon.ico">
+  <link rel="icon" sizes="any" href="{{ assetPath }}/rebrand/images/favicon.svg" type="image/svg+xml">
+  <link rel="mask-icon" href="{{ assetPath }}/rebrand/images/govuk-icon-mask.svg" color="{{ themeColor }}">
+  <link rel="apple-touch-icon" href="{{ assetPath }}/rebrand/images/govuk-icon-180.png">
+  <link rel="manifest" href="{{ assetPath }}/manifest.json">
+{% endblock %}
+
 
 {% block head %}
   <!--[if !IE 8]><!-->
@@ -94,6 +104,7 @@
     useTudorCrown: true,
     rebrand: true
 }) }}
+
 
 {% endblock %}
 

--- a/runner/src/server/views/layout.html
+++ b/runner/src/server/views/layout.html
@@ -5,6 +5,9 @@
 {% from "phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "skip-link/macro.njk" import govukSkipLink -%}
 {% from "cookie-banner/macro.njk" import govukCookieBanner %}
+
+{% set govukRebrand = true %}
+
 {% block head %}
   <!--[if !IE 8]><!-->
     <link rel="preload" as="font" href="{{ assetPath }}/fonts/light-94a07e06a1-v2.woff2" type="font/woff2" crossorigin="anonymous">
@@ -72,6 +75,7 @@
   {{ pageTitle }}
 {% endblock %}
 
+
 {% block skipLink %}
   {{ govukSkipLink({
     href: '#main-content',
@@ -87,7 +91,8 @@
     serviceName: name if name else serviceName,
     serviceUrl: serviceStartPage,
     navigation: navigation,
-    useTudorCrown: true
+    useTudorCrown: true,
+    rebrand: true
 }) }}
 
 {% endblock %}
@@ -172,6 +177,7 @@
 
 {% block footer %}
     {{ govukFooter({
+        rebrand: true,
         meta: {
             items: [{
                 href: privacyPolicyUrl,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4963,7 +4963,7 @@ __metadata:
     flagg: ^1.1.2
     flat: 5.0.2
     focus-trap-react: ^8.9.2
-    govuk-frontend: ^4.9.0
+    govuk-frontend: ^4.10.0
     hapi-pino: ^8.0.1
     hoek: ^6.1.3
     html-webpack-plugin: ^4.5.2
@@ -5058,7 +5058,7 @@ __metadata:
     eslint-plugin-import: ^2.25.4
     eslint-plugin-tsdoc: ^0.2.14
     expr-eval: 2.0.2
-    govuk-frontend: ^4.9.0
+    govuk-frontend: ^4.10.0
     hmpo-components: 5.2.1
     jest: ^29.2.0
     joi: 17.2.1
@@ -5160,7 +5160,7 @@ __metadata:
     flat: 5.0.2
     form-data: ^4.0.0
     google-libphonenumber: ^3.2.34
-    govuk-frontend: ^4.9.0
+    govuk-frontend: ^4.10.0
     hapi-pino: 8.0.0
     hapi-pulse: 3.0.0
     hapi-rate-limit: 4.1.0
@@ -8618,7 +8618,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     eslint-plugin-promise: ^4.2.1
     eslint-plugin-tsdoc: ^0.2.14
-    govuk-frontend: ^4.9.0
+    govuk-frontend: ^4.10.0
     hmpo-components: ^5.2.1
     husky: ^4.3.0
     lint-staged: ^10.4.2
@@ -11407,10 +11407,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"govuk-frontend@npm:^4.9.0":
-  version: 4.9.0
-  resolution: "govuk-frontend@npm:4.9.0"
-  checksum: f70cf65d91e00669b6b818e82b343df8dc40fef1ffdda02ad4394291bdb184aca3593e610f5399ee01b1c921a5226f13cd537606a7755a4e882864852fd2e18c
+"govuk-frontend@npm:^4.10.0":
+  version: 4.10.0
+  resolution: "govuk-frontend@npm:4.10.0"
+  checksum: 2c0b0be3b6661173839057bd025bda181d99f4d93678be4e9640c67bfb4a63a4f7a366fdbde3f1c634dd45ca48a3dc4c095e625af45e4b30d2c18378a2e5857c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

- Update govuk-frontend to 4.10.0 for GDS rebrand
- Add rebrand background colour 
  <details><summary>Screenshot without updated background colour (see below footer)</summary>
  <p><img width="1466" alt="Screenshot 2025-06-10 at 13 45 22" src="https://github.com/user-attachments/assets/8dca06ac-e399-42ad-8dae-5fb254840431" />
  </p>
  </details> 
  <details><summary>Screenshot with updated background colour (see below footer)</summary>
  <p><img width="1466" alt="Screenshot 2025-06-10 at 13 45 44" src="https://github.com/user-attachments/assets/8112841a-a6d5-45d4-99be-ebf4fce2fe76" />

  </p>
  </details> 
- Update asset routes for favicons

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [x] Manual, visual 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [x] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
