### PR TITLE
RepeatingSectionSummaryPageController and summary cards

### DIFF
--- a/runner/src/client/sass/application.scss
+++ b/runner/src/client/sass/application.scss
@@ -101,3 +101,7 @@
     }
   }
 }
+
+.govuk-summary-card .govuk-summary-list__actions {
+  display: none;
+}

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -57,6 +57,7 @@ export class PageControllerBase {
   hasFormComponents: boolean;
   hasConditionalFormComponents: boolean;
   backLinkFallback?: string;
+  details?: any;
 
   // TODO: pageDef type
   constructor(model: FormModel, pageDef: { [prop: string]: any } = {}) {
@@ -136,6 +137,7 @@ export class PageControllerBase {
     startPage?: HapiResponseObject;
     backLink?: string;
     phaseTag?: string | undefined;
+    details?: any;
   } {
     let showTitle = true;
     let pageTitle = this.title;
@@ -180,6 +182,7 @@ export class PageControllerBase {
       components,
       errors,
       isStartPage: false,
+      details: this.details || undefined,
     };
   }
 

--- a/runner/src/server/plugins/engine/pageControllers/RepeatingSectionSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/RepeatingSectionSummaryPageController.ts
@@ -1,0 +1,54 @@
+import { HapiRequest, HapiResponseToolkit } from "server/types";
+import { SummaryViewModel } from "../models";
+import { PageController } from "./PageController";
+
+/**
+ * RepeatingSectionSummaryPageController is for pages summarising a set of sections
+ */
+export class RepeatingSectionSummaryPageController extends PageController {
+  makeGetRouteHandler() {
+    return async (request: HapiRequest, h: HapiResponseToolkit) => {
+      const { remove } = request.query;
+      const { cacheService } = request.services([]);
+      const state = await cacheService.getState(request);
+      const noInt = (str: string) => str.replace(/\d+/g, "");
+      const int = (str: string) => parseInt(str.replace(/^\D+/g, ""));
+
+      const { title, model } = this;
+      const summary = new SummaryViewModel(title, model, state, request);
+      const summaryFiltered = summary.details.filter(
+        (detail) =>
+          detail.title &&
+          detail.title.match(new RegExp(`${title} \\d`)) &&
+          detail.items[0].value
+      );
+
+      if (remove && state[remove] && summaryFiltered.length !== 1) {
+        const newState = {};
+        Object.entries(state).forEach(([key, value]) => {
+          if (key.includes(noInt(remove))) {
+            const nextSection = state[noInt(key) + (int(key) + 1)];
+            if (int(key) < int(remove)) newState[key] = value;
+            else if (nextSection) newState[key] = nextSection;
+            else newState[key] = null;
+          }
+        });
+        await cacheService.mergeState(request, newState);
+
+        if (int(this.path) === summaryFiltered.length) {
+          return h.redirect(
+            `/${this.model.basePath}${noInt(this.path)}${int(this.path) - 1}`
+          );
+        }
+        return h.redirect(`/${this.model.basePath}${this.path}`);
+      }
+
+      this.details = summaryFiltered;
+      return super.makeGetRouteHandler()(request, h);
+    };
+  }
+
+  get viewName() {
+    return "repeating-section-summary";
+  }
+}

--- a/runner/src/server/plugins/engine/pageControllers/helpers.ts
+++ b/runner/src/server/plugins/engine/pageControllers/helpers.ts
@@ -11,6 +11,7 @@ import { RepeatingFieldPageController } from "./RepeatingFieldPageController";
 import { Page } from "@xgovformbuilder/model";
 import { UploadPageController } from "server/plugins/engine/pageControllers/UploadPageController";
 import { MultiStartPageController } from "server/plugins/engine/pageControllers/MultiStartPageController";
+import { RepeatingSectionSummaryPageController } from "./RepeatingSectionSummaryPageController";
 
 const PageControllers = {
   DobPageController,
@@ -23,6 +24,7 @@ const PageControllers = {
   RepeatingFieldPageController,
   UploadPageController,
   MultiStartPageController,
+  RepeatingSectionSummaryPageController,
 };
 
 export const controllerNameFromPath = (filePath: string) => {

--- a/runner/src/server/plugins/engine/pageControllers/index.ts
+++ b/runner/src/server/plugins/engine/pageControllers/index.ts
@@ -5,4 +5,5 @@ export { StartDatePageController } from "./StartDatePageController";
 export { StartPageController } from "./StartPageController";
 export { SummaryPageController } from "./SummaryPageController";
 export { PageControllerBase } from "./PageControllerBase";
+export { RepeatingSectionSummaryPageController } from "./RepeatingSectionSummaryPageController";
 export { getPageController, controllerNameFromPath } from "./helpers";

--- a/runner/src/server/views/partials/summary-card.html
+++ b/runner/src/server/views/partials/summary-card.html
@@ -1,0 +1,40 @@
+{% from "./summary-row.html" import summaryRow %} {% macro summaryCard(data, hideRemove)
+%} {% set isRepeatableSection = (data.items[0] | isArray) %}
+
+<div class="govuk-summary-card">
+  {% if not isRepeatableSection %}
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-summary-card__title" name="{{data.title}}" id="{{data.title}}">{{ data.title }}</h2>
+      <ul class="govuk-summary-card__actions">
+        <li class="govuk-summary-card__action">
+          <a class="govuk-link" href="{{ data.card }}">
+            Change<span class="govuk-visually-hidden"> {{data.title}}</span>
+          </a>
+        </li>
+        {% if not hideRemove %}
+          <li class="govuk-summary-card__action">
+            <a class="govuk-link" href="?remove={{ data.name }}">
+              Remove<span class="govuk-visually-hidden"> {{data.title}}</span>
+            </a>
+          </li>
+        {% endif %}
+      </ul>
+    </div>
+  {% endif %}
+
+  <div class="govuk-summary-card__content">
+    <dl class="govuk-summary-list">
+      {% for item in data.items %} {% if not hide %} {%- if item | isArray %}
+        <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-0">
+          {{ data.title }}
+        </h2>
+        {% for repeated in item %}
+          {{ summaryRow(repeated) }}
+        {% endfor %} {% else %}
+          {{ summaryRow(item) }}
+      {% endif %} {% endif %} {% endfor %}
+    </dl>
+  </div>
+</div>
+
+{% endmacro %}

--- a/runner/src/server/views/partials/summary-row.html
+++ b/runner/src/server/views/partials/summary-row.html
@@ -8,7 +8,7 @@
             {% if item.type == 'FileUploadField' %}
                 {{ item.filename if item.filename else "Uploaded" }}
             {% else %}
-                {{item.value}}
+                {{ item.value | striptags(true) | escape | nl2br }}
             {% endif %}
         {% else %}
             Not supplied

--- a/runner/src/server/views/repeating-section-summary.html
+++ b/runner/src/server/views/repeating-section-summary.html
@@ -1,0 +1,27 @@
+{% extends 'layout.html' %}
+
+{% block templateImports %}
+  {{ super() }}
+{% endblock %}}
+
+{% from "error-summary/macro.njk" import govukErrorSummary %}
+{% from "partials/components.html" import componentList with context %}
+{% from "partials/summary-card.html" import summaryCard %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errors %}
+        {{ govukErrorSummary(errors) }}
+      {% endif %}
+
+      {% include "partials/heading.html" %}
+
+      {% for detail in details %}
+        {{ summaryCard(detail) }}
+      {% endfor %}
+
+      {% include "partials/form.html" %}
+    </div>
+  </div>
+{% endblock %}

--- a/runner/src/server/views/summary.html
+++ b/runner/src/server/views/summary.html
@@ -25,7 +25,20 @@
         {% endif %}
 
         {% for detail in details %}
-          {{ summaryDetail(detail) }}
+          {% if detail.card %}
+            {{ summaryCard(detail, true) }}
+            {% if not details[loop.index].card %}
+              {% set splitDash = detail.items[0].pageId.split("-") %}
+              {% set toAdd = ["added", splitDash[splitDash.length - 1]] %}
+              {% set addOrRemoveLink = splitDash.slice(0, -1).concat(toAdd).join("-") %}
+
+              <a href="{{ addOrRemoveLink }}" class="govuk-button govuk-button--secondary">
+                Add or remove {{ detail.title.split(" ").slice(0, -1).join(" ") | lower }}
+              </a>
+            {% endif %}
+          {% else %}
+            {{ summaryDetail(detail) }}
+          {% endif %}
         {% endfor %}
 
         {% if fees and fees.details|length %}


### PR DESCRIPTION
# Description

- New page controller, which displays a summary of sections whose title matches the page title followed by a number. (E.g. if the page has the title 'Close contact', sections with titles 'Close contact 1', 'Close contact 2' etc. would display). It also gives you the option to remove sections.
- Details are displayed as summary cards in the associated view file. I've also developed the ability to display sections as cards in the summary page.

## Type of change

New feature (non-breaking change which adds functionality)