### PR TITLE
fix: summary feedback link bug fix

### DIFF
--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -264,15 +264,20 @@ export class SummaryPageController extends PageController {
   }
 
   feedbackUrlFromRequest(request: HapiRequest) {
-    if (this.model.def.feedback?.url) {
-      let feedbackLink = new RelativeUrl(this.model.def.feedback.url);
+    const feedbackUrl = this.model.def.feedback?.url;
+    if (feedbackUrl) {
+      if (feedbackUrl.startsWith("http")) {
+        return feedbackUrl;
+      }
+
+      const relativeFeedbackUrl = new RelativeUrl(feedbackUrl);
       const returnInfo = new FeedbackContextInfo(
         this.model.name,
         "Summary",
         `${request.url.pathname}${request.url.search}`
       );
-      feedbackLink.setParam(feedbackReturnInfoKey, returnInfo.toString());
-      return feedbackLink.toString();
+      relativeFeedbackUrl.setParam(feedbackReturnInfoKey, returnInfo.toString());
+      return relativeFeedbackUrl.toString();
     }
 
     return undefined;


### PR DESCRIPTION
# Description

Fixing bug where summary page controller is overriding PageControllerBase, and doesn't allow external feedback links on the summary page, preventing submission

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Local testing on chrome

# Checklist:

- [X] I have performed a self-review of my own code
