### PR TITLE
chore: fix smoke test pull image error

### DIFF
--- a/.github/workflows/branch--lint-unit-and-smoke-test.yml
+++ b/.github/workflows/branch--lint-unit-and-smoke-test.yml
@@ -47,7 +47,4 @@ jobs:
 
   smoke-test:
     uses: ./.github/workflows/smoke-test.yml
-    with:
-      runner-cache-ref: ${{needs.build-runner.outputs.tag}}
-      designer-cache-ref: ${{needs.build-designer.outputs.tag}}
     secrets: inherit

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,6 +19,4 @@ jobs:
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v2
         with:
-          allow-ghsas:
-            - GHSA-c429-5p7v-vgjp
-            - GHSA-7fh5-64p2-3v2j
+          allow-ghsas: GHSA-c429-5p7v-vgjp,GHSA-7fh5-64p2-3v2j

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -3,7 +3,11 @@ name: smoke tests
 on:
   workflow_call:
     inputs:
-        type: string
+      build:
+        description: whether or not to build the images. Defaults to true
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   smoke-test:
@@ -51,6 +55,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build containers
+        # if inputs.build is set to false, the latest images will be pulled from ghcr.io (see docker-compose.smoke.yml)
+        if: ${{ inputs.build }}
+        run: docker compose -f docker-compose.smoke.yml build designer runner
 
       - name: start containers
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -3,13 +3,6 @@ name: smoke tests
 on:
   workflow_call:
     inputs:
-      runner-cache-ref:
-        description: cache ref for the runner app
-        required: true
-        type: string
-      designer-cache-ref:
-        description: cache ref for the designer app
-        required: true
         type: string
 
 jobs:

--- a/docker-compose.smoke.yml
+++ b/docker-compose.smoke.yml
@@ -1,9 +1,8 @@
 # This file is used for the smoke tests
-version: "3.9"
 services:
   designer:
     container_name: designer
-    image: digital-form-builder-designer
+    image: ghcr.io/xgovformbuilder/digital-form-builder-designer:latest
     build:
       context: .
       dockerfile: ./designer/Dockerfile
@@ -22,7 +21,7 @@ services:
       - runner
   runner:
     container_name: runner
-    image: digital-form-builder-runner
+    image: ghcr.io/xgovformbuilder/digital-form-builder-runner:latest
     build:
       context: .
       dockerfile: ./runner/Dockerfile


### PR DESCRIPTION
# Description

#1336 is blocked by CI failing to run the smoke test workflow. https://github.com/XGovFormBuilder/digital-form-builder/actions/runs/16147889277/job/45571894905?pr=1336#step:10:5625

How GitHub actions deal with missing images/repos seems to have changed. I also got the same error when opening a PR to verify it is not an issue with git repository permissions.

**changes made**
- update smoke-test.yml to build the required containers (runner and designer)
- add `build` parameter to smoke-test.yml, so build behaviour can be toggled. 
  - We can consider setting to false if we're running this on the main branch for example. On main we can just pull the published latest images
- update docker-compose.smoke.yml to pull from our ghcr 
- remove unused runner-cache-ref and designer-cache-ref since they are unused
- update dependency-review.yml to use the correct GHSA ignore snytax

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

On #1339 I have tested with build set to true, and false and is running successfully  

- `build` defaulting to true
  - [commit with success status](https://github.com/XGovFormBuilder/digital-form-builder/pull/1339/commits/5bf717a2ebffbf5315198386b6d2166435994e5c)
  -  [successful action](https://github.com/XGovFormBuilder/digital-form-builder/actions/runs/16153616945/job/45590749890)
- `build` defaulting to false 
  - [commit with success status](https://github.com/XGovFormBuilder/digital-form-builder/pull/1339/commits/335f096829c3106f54bac3f129c995bfd0c6edb4)
  - [successful action with build step disabled](https://github.com/XGovFormBuilder/digital-form-builder/actions/runs/16153866510/job/45591589346). This workflow also has a shorter run time as expected (6m vs 11m)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [N/A] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
