### PR TITLE
chore(ci): use GITHUB_TOKEN instead of GHCR_PAT

### DIFF
--- a/.github/workflows/beta--lint-unit-build-and-publish-images.yml
+++ b/.github/workflows/beta--lint-unit-build-and-publish-images.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GHCR_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Tag branch with run number
         run: |
           git tag ${{ env.SEMVER }}

--- a/.github/workflows/main--lint-unit-build-and-publish-images.yml
+++ b/.github/workflows/main--lint-unit-build-and-publish-images.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GHCR_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Tag branch with run number
         run: |
           git tag ${{ env.SEMVER }}


### PR DESCRIPTION
# Description

Remove use of GHCR_PAT which is a personal access token (used before GITHUB_TOKEN was added to GitHub actions by default). Workflows should not be tied to a single user

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

Not required - GITHUB_TOKEN is used in GitHub actions already

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and versioning
- [ ] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
