### PR TITLE
fix: MiniSummaryPageController change link issue

### DIFF
--- a/e2e/cypress/e2e/runner/MiniSummaryPageController.feature
+++ b/e2e/cypress/e2e/runner/MiniSummaryPageController.feature
@@ -14,5 +14,6 @@ Feature: New page controller that display summaries of parts of the form data
     And I see "Confirm and continue"
     Then I click the link "Change First name"
     And I enter "Joel{enter}" for "First name"
+    And I see "Joel"
     Then I continue
     And I see "Fourth page"

--- a/e2e/cypress/e2e/runner/MiniSummaryPageController.feature
+++ b/e2e/cypress/e2e/runner/MiniSummaryPageController.feature
@@ -12,7 +12,7 @@ Feature: New page controller that display summaries of parts of the form data
     And I see "Bloggs"
     And I don't see "123"
     And I see "Confirm and continue"
-    Then I click the link "Change"
+    Then I click the link "Change First name"
     And I enter "Joel{enter}" for "First name"
     And I see "Joel"
     Then I continue

--- a/e2e/cypress/e2e/runner/MiniSummaryPageController.feature
+++ b/e2e/cypress/e2e/runner/MiniSummaryPageController.feature
@@ -4,16 +4,18 @@ Feature: New page controller that display summaries of parts of the form data
   Scenario: MiniSummaryPageController works as expected
     Given the form "mini-summary-fields" exists
     And I navigate to the "mini-summary-fields" form
-    When I enter "Joe{enter}" for "First name"
-    And I enter "Bloggs{enter}" for "Last name"
-    And I enter "123{enter}" for "Code"
+    When I enter "Joe" for "First name"
+    And I enter "Bloggs" for "Last name"
+    And I enter "123" for "Code"
+    And I continue
     Then I see "Check these details are correct before continuing"
     And I see "Joe"
     And I see "Bloggs"
     And I don't see "123"
     And I see "Confirm and continue"
-    Then I click the link "Change First name"
-    And I enter "Joel{enter}" for "First name"
-    And I see "Joel"
-    Then I continue
-    And I see "Fourth page"
+    Then I click the link "Change"
+    And I enter "Joel" for "First name"
+    And I continue
+    Then I see "Joel"
+    And I continue
+    Then I see "Fourth page"

--- a/e2e/cypress/e2e/runner/MiniSummaryPageController.feature
+++ b/e2e/cypress/e2e/runner/MiniSummaryPageController.feature
@@ -12,5 +12,8 @@ Feature: New page controller that display summaries of parts of the form data
     And I see "Bloggs"
     And I don't see "123"
     And I see "Confirm and continue"
+    Then I click the link "Change"
+    And I enter "Joel{enter}" for "First name"
+    And I see "Joel"
     Then I continue
     And I see "Fourth page"

--- a/e2e/cypress/e2e/runner/MiniSummaryPageController.feature
+++ b/e2e/cypress/e2e/runner/MiniSummaryPageController.feature
@@ -14,6 +14,5 @@ Feature: New page controller that display summaries of parts of the form data
     And I see "Confirm and continue"
     Then I click the link "Change First name"
     And I enter "Joel{enter}" for "First name"
-    And I see "Joel"
     Then I continue
     And I see "Fourth page"

--- a/e2e/cypress/e2e/runner/MiniSummaryPageController.feature
+++ b/e2e/cypress/e2e/runner/MiniSummaryPageController.feature
@@ -14,7 +14,7 @@ Feature: New page controller that display summaries of parts of the form data
     And I see "Bloggs"
     And I don't see "123"
     And I see "Confirm and continue"
-    Then I click the link "Change"
+    Then I click the link "Change First name"
     And I enter "Joel" for "First name"
     And I continue
     Then I see "Joel"

--- a/e2e/cypress/e2e/runner/MiniSummaryPageController.feature
+++ b/e2e/cypress/e2e/runner/MiniSummaryPageController.feature
@@ -6,6 +6,7 @@ Feature: New page controller that display summaries of parts of the form data
     And I navigate to the "mini-summary-fields" form
     When I enter "Joe" for "First name"
     And I enter "Bloggs" for "Last name"
+    And I continue
     And I enter "123" for "Code"
     And I continue
     Then I see "Check these details are correct before continuing"

--- a/runner/src/server/plugins/engine/pageControllers/MiniSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/MiniSummaryPageController.ts
@@ -21,7 +21,7 @@ export class MiniSummaryPageController extends PageController {
 
       const items = sectionDetails.items.map((item) => {
         const returnURL = encodeURIComponent(`/${model.basePath}${this.path}`);
-        return { ...item, url: `${item.pageId}?returnTo=${returnURL}` };
+        return { ...item, url: `${item.pageId}?returnUrl=${returnURL}` };
       });
       this.details = [{ items }];
 

--- a/runner/src/server/plugins/engine/pageControllers/MiniSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/MiniSummaryPageController.ts
@@ -20,8 +20,8 @@ export class MiniSummaryPageController extends PageController {
         : summary.details[0];
 
       const items = sectionDetails.items.map((item) => {
-        const itemURL = item.url.split("%2F").slice(0, -1).join("%2F");
-        return { ...item, url: `${itemURL}%2F${this.path.substring(1)}` };
+        const returnURL = encodeURIComponent(`/${model.basePath}${this.path}`);
+        return { ...item, url: `${item.pageId}?returnTo=${returnURL}` };
       });
       this.details = [{ items }];
 

--- a/runner/src/server/plugins/engine/pageControllers/MiniSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/MiniSummaryPageController.ts
@@ -20,7 +20,8 @@ export class MiniSummaryPageController extends PageController {
         : summary.details[0];
 
       const items = sectionDetails.items.map((item) => {
-        return { ...item, url: `${item.pageId}?returnUrl=${this.path}` };
+        const url = `${item.pageId}?returnUrl=${this.path.substring(1)}`;
+        return { ...item, url };
       });
       this.details = [{ items }];
 

--- a/runner/src/server/plugins/engine/pageControllers/MiniSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/MiniSummaryPageController.ts
@@ -20,8 +20,8 @@ export class MiniSummaryPageController extends PageController {
         : summary.details[0];
 
       const items = sectionDetails.items.map((item) => {
-        const url = `${item.pageId}?returnUrl=${this.path.substring(1)}`;
-        return { ...item, url };
+        const itemURL = item.url.split("%2F").slice(0, -1).join("%2F");
+        return { ...item, url: `${itemURL}%2F${this.path.substring(1)}` };
       });
       this.details = [{ items }];
 


### PR DESCRIPTION
# Description

Mini summary change links weren't working correctly

## Context

Change links did not successfully redirect to the mini summary page after an edit has been made

## Changes

- Changed approach for altering the change link URL
- E2E test updated to include change link functionality

## Type of change

What is the type of change you are making?

- [ ] Chore or documentation (non-breaking change that does not add functionality)
- [ ] ADR (Architectural Decision Record, non-breaking change that documents or proposes a decision)
- [ ] Refactor (non-breaking change that improves code quality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### PR title

PR titles should be prefixed with the type of change you are making, based on the [README.md#versioning](https://github.com/XGovFormBuilder/digital-form-builder?tab=readme-ov-file#versioning).
This is so that when performing a squash merge, the PR title is automatically used as the commit message.

Have you updated the PR title to match the type of change you are making?

- [x] Yes
- [ ] No, I need help or guidance

# Testing

<!--
Several departments use XGovFormBuilder in production.
Automated tests help ensure that changes do not break existing functionality for another department.

Maintainers are sympathetic to the time constraints of government departments, but please try to be good citizens and add tests when possible.
-->

## Automated tests

Have you added automated tests?

- [ ] Yes, unit or integration tests
- [x] Yes, end-to-end (cypress) tests
- [ ] No, tests are not required for this change
- [ ] No, I need help or guidance
- [ ] No (explain why tests are not required or can't be added at this time)

## Manual tests

Have you manually tested your changes?

- [ ] Yes
- [x] No, manual tests are not required or sufficiently covered by automated tests

Have you attached an example form JSON or snippet for the reviewer in this PR?

- [ ] Yes
- [ ] No, any existing form can be used
- [x] No, it is not required or not applicable

### Steps to test

<!--
Only fill out this section if you answered "Yes" to manually testing your changes.

In this section
- describe the tests that you ran to verify your changes
- provide instructions and a form JSON or snippet so we can reproduce the test if necessary

If uploading a form JSON, use the "attach files" feature in GitHub PR.
-->

N/A

# Documentation

Have you updated the documentation?

- [ ] Yes, I have updated [./docs](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs) for this change since additional explanation or steps to use/configure the feature is required
- [ ] Yes, I have added or updated an [ADR](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs/adr) for this change since it is large, complex, or has significant architectural implications
- [ ] Yes, I have added inline comments for hard-to-understand areas
- [ ] No, I am not sure if documentation is required
- [x] No, documentation is not required for this change

# Discussion

> [!WARNING]
>
> Large or complex changes may require discussion with the maintainers before they can be merged. If it has not yet been discussed, it may delay the review process

Have you discussed this change with the maintainers?

- [ ] Yes, I have discussed this change with the maintainers on slack, email or via GitHub issues
- [ ] Yes, this change is an ADR to help kick-off discussion
- [x] No, this change is small and does not require discussion
- [ ] No, I am not sure if one is required
