### PR TITLE
fix: Set base tag to Alpine and add symlink to fix SSL issue

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -2,9 +2,10 @@
 # Stage 1
 # Base image contains the updated OS and
 # It also configures the non-root user that will be given permission to copied files/folders in every subsequent stages
-# alpine3.20 is required due to openssl location changing in later versions of alpine, causing prisma to panic
+FROM node:20-alpine AS base
+# Symlink below is required due to openssl location changing in later versions of alpine, causing prisma to panic. See https://github.com/prisma/prisma/issues/25817#issuecomment-2533685958 for details.
 # Prisma and queue-model will be removed in subsequent versions
-FROM node:20-alpine3.20 AS base
+RUN [ ! -e /lib/libssl.so.3 ] && ln -s /usr/lib/libssl.so.3 /lib/libssl.so.3 || true
 RUN npm install -g npm@^9.x.x && \
     mkdir -p /usr/src/app && \
     addgroup -g 1001 appuser && \


### PR DESCRIPTION
# Description

The Docker image node:20-alpine3.20 is no longer being updated so pinning to it means that you have not been receiving any security updates for the last 5 months.

Pinning to 3.20 is not necessary as the issue with Prisma can be resolved by adding a symlink as per https://github.com/prisma/prisma/issues/25817#issuecomment-2533685958

## Context

Ensures that base image receives security updates. 

## Changes

- Update image to noode:20-alpine and add symlink to resolve Prisma issue

## Type of change

What is the type of change you are making?

- [ ] Chore or documentation (non-breaking change that does not add functionality)
- [ ] ADR (Architectural Decision Record, non-breaking change that documents or proposes a decision)
- [ ] Refactor (non-breaking change that improves code quality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### PR title

Have you updated the PR title to match the type of change you are making?

- [X] Yes
- [ ] No, I need help or guidance

# Testing

## Automated tests

Have you added automated tests?

- [ ] Yes, unit or integration tests
- [ ] Yes, end-to-end (cypress) tests
- [X] No, tests are not required for this change
- [ ] No, I need help or guidance
- [ ] No (explain why tests are not required or can't be added at this time)

## Manual tests

Have you manually tested your changes?

- [X] Yes
- [ ] No, manual tests are not required or sufficiently covered by automated tests

Have you attached an example form JSON or snippet for the reviewer in this PR?

- [ ] Yes
- [ ] No, any existing form can be used
- [ X] No, it is not required or not applicable

### Steps to test

Ensure that runner container starts up correctly and does not error out.

# Documentation

Have you updated the documentation?

- [ ] Yes, I have updated [./docs](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs) for this change since additional explanation or steps to use/configure the feature is required
- [ ] Yes, I have added or updated an [ADR](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs/adr) for this change since it is large, complex, or has significant architectural implications
- [ ] Yes, I have added inline comments for hard-to-understand areas
- [ ] No, I am not sure if documentation is required
- [X] No, documentation is not required for this change

# Discussion

Have you discussed this change with the maintainers?

- [ ] Yes, I have discussed this change with the maintainers on slack, email or via GitHub issues
- [ ] Yes, this change is an ADR to help kick-off discussion
- [X] No, this change is small and does not require discussion
- [ ] No, I am not sure if one is required
