### PR TITLE
fix: Summary card button accessibility and consistency issues

### DIFF
--- a/runner/src/server/views/summary.html
+++ b/runner/src/server/views/summary.html
@@ -29,12 +29,14 @@
             {{ summaryCard(detail, true) }}
             {% if not details[loop.index].card %}
               {% set splitDash = detail.items[0].pageId.split("-") %}
-              {% set toAdd = ["added", splitDash[splitDash.length - 1]] %}
-              {% set addOrRemoveLink = splitDash.slice(0, -1).concat(toAdd).join("-") %}
+              {% set lastEntry = splitDash.slice(-1)[0] %}
 
-              <a href="{{ addOrRemoveLink }}" class="govuk-button govuk-button--secondary">
-                Add or remove {{ detail.title.split(" ").slice(0, -1).join(" ") | lower }}
-              </a>
+              <form action="{{ splitDash.slice(0, -1).concat(["added", lastEntry]).join("-") }}" method="get">
+                <button class="govuk-button govuk-button--secondary">
+                  Add {% if lastEntry !== "1" %} or delete {% endif %}
+                  {{ detail.title.split(" ").slice(0, -1).join(" ") | lower }}
+                </button>
+              </form>
             {% endif %}
           {% else %}
             {{ summaryDetail(detail) }}


### PR DESCRIPTION
# Description

The 'Add or remove...' button on the summary page has an accessibility issue. While fixing this, I've made a couple of other changes so that the wording is consistent with the page the button redirects to.

## Changes

- The button was technically a link, which meant how it looked and how screen readers treated it was inconsistent. I have changed it so that it's a button that does a GET request to the page when clicked.
- The word 'remove' has been changed to 'delete'.
- The button text will now just say 'Add...' if there's only one entry, which is consistent with the functionality where you can't delete entries if only one is present.

## Type of change

What is the type of change you are making?

- [ ] Chore or documentation (non-breaking change that does not add functionality)
- [ ] ADR (Architectural Decision Record, non-breaking change that documents or proposes a decision)
- [ ] Refactor (non-breaking change that improves code quality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### PR title

PR titles should be prefixed with the type of change you are making, based on the [README.md#versioning](https://github.com/XGovFormBuilder/digital-form-builder?tab=readme-ov-file#versioning).
This is so that when performing a squash merge, the PR title is automatically used as the commit message.

Have you updated the PR title to match the type of change you are making?

- [x] Yes
- [ ] No, I need help or guidance

# Testing

<!--
Several departments use XGovFormBuilder in production.
Automated tests help ensure that changes do not break existing functionality for another department.

Maintainers are sympathetic to the time constraints of government departments, but please try to be good citizens and add tests when possible.
-->

## Automated tests

Have you added automated tests?

- [ ] Yes, unit or integration tests
- [ ] Yes, end-to-end (cypress) tests
- [x] No, tests are not required for this change
- [ ] No, I need help or guidance
- [ ] No (explain why tests are not required or can't be added at this time)

## Manual tests

Have you manually tested your changes?

- [x] Yes
- [ ] No, manual tests are not required or sufficiently covered by automated tests

Have you attached an example form JSON or snippet for the reviewer in this PR?

- [ ] Yes
- [ ] No, any existing form can be used
- [x] No, it is not required or not applicable

# Documentation

Have you updated the documentation?

- [ ] Yes, I have updated [./docs](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs) for this change since additional explanation or steps to use/configure the feature is required
- [ ] Yes, I have added or updated an [ADR](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs/adr) for this change since it is large, complex, or has significant architectural implications
- [ ] Yes, I have added inline comments for hard-to-understand areas
- [ ] No, I am not sure if documentation is required
- [x] No, documentation is not required for this change

# Discussion

> [!WARNING]
>
> Large or complex changes may require discussion with the maintainers before they can be merged. If it has not yet been discussed, it may delay the review process

Have you discussed this change with the maintainers?

- [ ] Yes, I have discussed this change with the maintainers on slack, email or via GitHub issues
- [ ] Yes, this change is an ADR to help kick-off discussion
- [x] No, this change is small and does not require discussion
- [ ] No, I am not sure if one is required
