### PR TITLE
Upgrade dependency review to action to v5

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,8 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
+
       - name: "Dependency Review"
-        uses: actions/dependency-review-action@v2
+        uses: actions/dependency-review-action@v5
         with:
           allow-ghsas: GHSA-c429-5p7v-vgjp,GHSA-7fh5-64p2-3v2j


### PR DESCRIPTION
Test to see if the vulnerabilities we're seeing downstream is also present upstream and caused by this action package upgrade